### PR TITLE
feat(input-simulation): add Play Mode input simulation tool

### DIFF
--- a/MCPForUnity/Editor/Tools/InputSimulation/InputDiscovery.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputDiscovery.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using MCPForUnity.Editor.Helpers;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    /// <summary>
+    /// Discovery and bounds actions for input simulation.
+    /// Finds interactable elements: UGUI Selectables, 3D Colliders, 2D Colliders.
+    /// </summary>
+    internal static class InputDiscovery
+    {
+        internal static object Discover(ToolParams p)
+        {
+            string filter = p.Get("filter");
+            int pageSize = p.GetInt("page_size") ?? 50;
+            int cursor = p.GetInt("cursor") ?? 0;
+            var items = new List<Dictionary<string, object>>();
+
+            CollectSelectables(items, filter);
+            CollectColliders3D(items, filter);
+            CollectColliders2D(items, filter);
+
+            int total = items.Count;
+            var page = items.GetRange(
+                Math.Min(cursor, total),
+                Math.Min(pageSize, Math.Max(0, total - cursor))
+            );
+            bool hasMore = cursor + pageSize < total;
+
+            return new SuccessResponse($"Found {total} interactable elements.", new
+            {
+                items = page,
+                cursor,
+                page_size = pageSize,
+                total_count = total,
+                has_more = hasMore,
+                next_cursor = hasMore ? (int?)(cursor + pageSize) : null
+            });
+        }
+
+        internal static object GetElementBounds(ToolParams p)
+        {
+            var targetToken = p.GetRaw("target");
+            if (targetToken == null || targetToken.Type != JTokenType.Object)
+                return new ErrorResponse("'target' parameter is required as JSON object.");
+
+            var (bounds, err) = InputTargetResolver.ResolveTargetBounds((JObject)targetToken);
+            if (err != null) return new ErrorResponse(err);
+
+            return new SuccessResponse("Element bounds resolved.", new
+            {
+                x = bounds.Value.x,
+                y = bounds.Value.y,
+                width = bounds.Value.width,
+                height = bounds.Value.height,
+                center_x = bounds.Value.center.x,
+                center_y = bounds.Value.center.y
+            });
+        }
+
+        // --- Collectors ---
+
+        static void CollectSelectables(List<Dictionary<string, object>> items, string filter)
+        {
+            foreach (var selectable in Selectable.allSelectablesArray)
+            {
+                if (selectable == null || !selectable.gameObject.activeInHierarchy) continue;
+                if (!string.IsNullOrEmpty(filter) && !selectable.name.Contains(filter, StringComparison.OrdinalIgnoreCase)) continue;
+
+                var rt = selectable.GetComponent<RectTransform>();
+                Rect? screenRect = GetSelectableScreenRect(rt);
+
+                items.Add(new Dictionary<string, object>
+                {
+                    ["name"] = selectable.name,
+                    ["path"] = GetGameObjectPath(selectable.gameObject),
+                    ["type"] = "ugui",
+                    ["component"] = selectable.GetType().Name,
+                    ["interactable"] = selectable.interactable,
+                    ["screen_rect"] = RectToDict(screenRect)
+                });
+            }
+        }
+
+        static void CollectColliders3D(List<Dictionary<string, object>> items, string filter)
+        {
+            var colliders = UnityEngine.Object.FindObjectsByType<Collider>(FindObjectsSortMode.None);
+            foreach (var col in colliders)
+            {
+                if (col == null || !col.gameObject.activeInHierarchy) continue;
+                if (!string.IsNullOrEmpty(filter) && !col.name.Contains(filter, StringComparison.OrdinalIgnoreCase)) continue;
+
+                Rect? screenRect = ProjectBoundsToScreen(col.bounds);
+                items.Add(new Dictionary<string, object>
+                {
+                    ["name"] = col.name,
+                    ["path"] = GetGameObjectPath(col.gameObject),
+                    ["type"] = "gameobject",
+                    ["component"] = col.GetType().Name,
+                    ["interactable"] = col.enabled,
+                    ["screen_rect"] = RectToDict(screenRect)
+                });
+            }
+        }
+
+        static void CollectColliders2D(List<Dictionary<string, object>> items, string filter)
+        {
+            var colliders = UnityEngine.Object.FindObjectsByType<Collider2D>(FindObjectsSortMode.None);
+            foreach (var col in colliders)
+            {
+                if (col == null || !col.gameObject.activeInHierarchy) continue;
+                if (!string.IsNullOrEmpty(filter) && !col.name.Contains(filter, StringComparison.OrdinalIgnoreCase)) continue;
+
+                var cam = Camera.main;
+                Rect? screenRect = null;
+                if (cam != null)
+                {
+                    var bounds = col.bounds;
+                    Vector3 sp = cam.WorldToScreenPoint(bounds.center);
+                    if (sp.z > 0)
+                    {
+                        Vector3 min = cam.WorldToScreenPoint(new Vector3(bounds.min.x, bounds.min.y, bounds.center.z));
+                        Vector3 max = cam.WorldToScreenPoint(new Vector3(bounds.max.x, bounds.max.y, bounds.center.z));
+                        screenRect = new Rect(Mathf.Min(min.x, max.x), Mathf.Min(min.y, max.y),
+                            Mathf.Abs(max.x - min.x), Mathf.Abs(max.y - min.y));
+                    }
+                }
+
+                items.Add(new Dictionary<string, object>
+                {
+                    ["name"] = col.name,
+                    ["path"] = GetGameObjectPath(col.gameObject),
+                    ["type"] = "gameobject_2d",
+                    ["component"] = col.GetType().Name,
+                    ["interactable"] = col.enabled,
+                    ["screen_rect"] = RectToDict(screenRect)
+                });
+            }
+        }
+
+        // --- Shared Helpers ---
+
+        static Rect? ProjectBoundsToScreen(Bounds bounds)
+        {
+            var cam = Camera.main;
+            if (cam == null) return null;
+            Vector3 sp = cam.WorldToScreenPoint(bounds.center);
+            if (sp.z <= 0) return null;
+            Vector3 min = cam.WorldToScreenPoint(bounds.min);
+            Vector3 max = cam.WorldToScreenPoint(bounds.max);
+            float x = Mathf.Min(min.x, max.x);
+            float y = Mathf.Min(min.y, max.y);
+            return new Rect(x, y, Mathf.Abs(max.x - min.x), Mathf.Abs(max.y - min.y));
+        }
+
+        internal static Rect? GetSelectableScreenRect(RectTransform rt)
+        {
+            if (rt == null) return null;
+
+            Vector3[] corners = new Vector3[4];
+            rt.GetWorldCorners(corners);
+            var canvas = rt.GetComponentInParent<Canvas>()?.rootCanvas;
+
+            if (canvas != null && canvas.renderMode == RenderMode.ScreenSpaceOverlay)
+            {
+                float minX = Mathf.Min(corners[0].x, corners[1].x, corners[2].x, corners[3].x);
+                float minY = Mathf.Min(corners[0].y, corners[1].y, corners[2].y, corners[3].y);
+                float maxX = Mathf.Max(corners[0].x, corners[1].x, corners[2].x, corners[3].x);
+                float maxY = Mathf.Max(corners[0].y, corners[1].y, corners[2].y, corners[3].y);
+                return new Rect(minX, minY, maxX - minX, maxY - minY);
+            }
+
+            var cam = canvas?.worldCamera ?? Camera.main;
+            if (cam != null)
+            {
+                Vector2 min = cam.WorldToScreenPoint(corners[0]);
+                Vector2 max = cam.WorldToScreenPoint(corners[2]);
+                return new Rect(min.x, min.y, max.x - min.x, max.y - min.y);
+            }
+
+            return null;
+        }
+
+        internal static string GetGameObjectPath(GameObject go)
+        {
+            string path = go.name;
+            var parent = go.transform.parent;
+            while (parent != null)
+            {
+                path = parent.name + "/" + path;
+                parent = parent.parent;
+            }
+            return "/" + path;
+        }
+
+        static object RectToDict(Rect? rect)
+        {
+            if (!rect.HasValue) return null;
+            return new { x = rect.Value.x, y = rect.Value.y, width = rect.Value.width, height = rect.Value.height };
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs
@@ -1,0 +1,156 @@
+using System;
+using MCPForUnity.Editor.Helpers;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+using UnityEngine.EventSystems;
+#if UNITY_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
+#endif
+
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    /// <summary>
+    /// Mouse + keyboard input simulation actions.
+    /// Dual backend: New Input System (InputState.Change) + Legacy (ExecuteEvents).
+    /// </summary>
+    internal static class InputSimulationActions
+    {
+        // ── Shared helper ──────────────────────────────────────────────────────────
+        static (Vector2? pos, object err) Resolve(ToolParams p, string param = "target")
+        {
+            var tok = p.GetRaw(param);
+            if (tok == null || tok.Type != JTokenType.Object)
+                return (null, new ErrorResponse($"'{param}' must be a JSON object."));
+            var (pos, msg) = InputTargetResolver.ResolveTarget((JObject)tok);
+            return msg != null ? (null, (object)new ErrorResponse(msg)) : (pos, null);
+        }
+
+#if UNITY_INPUT_SYSTEM
+        // ── New Input System helpers ───────────────────────────────────────────────
+        static int BtnIndex(string n) => n?.ToLowerInvariant() == "right" ? 1 : n?.ToLowerInvariant() == "middle" ? 2 : 0;
+        static bool TryKey(string n, out Key k) => Enum.TryParse(n ?? "", true, out k);
+        static void Move(Vector2 p) => InputState.Change(Mouse.current.position, p);
+        static void Btn(int b, float v)
+        {
+            if (b == 1)      InputState.Change(Mouse.current.rightButton,  v);
+            else if (b == 2) InputState.Change(Mouse.current.middleButton, v);
+            else             InputState.Change(Mouse.current.leftButton,   v);
+        }
+        static void Flush(bool f) { if (f) InputSystem.Update(); }
+        static void DoClick(Vector2 p, int b, bool f) { Move(p); Btn(b, 1f); Flush(f); Btn(b, 0f); Flush(f); }
+#endif
+
+        // ── Mouse Actions ──────────────────────────────────────────────────────────
+        internal static object Click(ToolParams p)
+        {
+            var (pos, e) = Resolve(p); if (e != null) return e;
+            string bn = p.Get("button", "left"); bool fl = p.GetBool("flush", true);
+#if UNITY_INPUT_SYSTEM
+            DoClick(pos.Value, BtnIndex(bn), fl);
+            return new SuccessResponse($"Clicked ({pos.Value.x:F0}, {pos.Value.y:F0}).", new { x = pos.Value.x, y = pos.Value.y, button = bn });
+#else
+            return new ErrorResponse("Legacy backend: click not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+
+        internal static object DoubleClick(ToolParams p)
+        {
+            var (pos, e) = Resolve(p); if (e != null) return e;
+            string bn = p.Get("button", "left"); bool fl = p.GetBool("flush", true);
+#if UNITY_INPUT_SYSTEM
+            int b = BtnIndex(bn); DoClick(pos.Value, b, fl); DoClick(pos.Value, b, fl);
+            return new SuccessResponse($"Double-clicked ({pos.Value.x:F0}, {pos.Value.y:F0}).", new { x = pos.Value.x, y = pos.Value.y, button = bn });
+#else
+            return new ErrorResponse("Legacy backend: double-click not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+
+        internal static object MouseMove(ToolParams p)
+        {
+            var (pos, e) = Resolve(p); if (e != null) return e;
+#if UNITY_INPUT_SYSTEM
+            Move(pos.Value); Flush(p.GetBool("flush", true));
+            return new SuccessResponse($"Mouse moved to ({pos.Value.x:F0}, {pos.Value.y:F0}).", new { x = pos.Value.x, y = pos.Value.y });
+#else
+            return new ErrorResponse("Legacy backend: mouse move not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+
+        internal static object Drag(ToolParams p)
+        {
+            var (fr, e1) = Resolve(p, "from_target"); if (e1 != null) return e1;
+            var (to, e2) = Resolve(p, "to_target");   if (e2 != null) return e2;
+#if UNITY_INPUT_SYSTEM
+            bool fl = p.GetBool("flush", true);
+            Move(fr.Value); InputState.Change(Mouse.current.leftButton, 1f); Flush(fl);
+            Move(to.Value); Flush(fl);
+            InputState.Change(Mouse.current.leftButton, 0f); Flush(fl);
+            return new SuccessResponse($"Dragged ({fr.Value.x:F0},{fr.Value.y:F0}) → ({to.Value.x:F0},{to.Value.y:F0}).",
+                new { from_x = fr.Value.x, from_y = fr.Value.y, to_x = to.Value.x, to_y = to.Value.y });
+#else
+            return new ErrorResponse("Legacy backend: drag not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+
+        internal static object Scroll(ToolParams p)
+        {
+            var (pos, e) = Resolve(p); if (e != null) return e;
+            float dx = p.GetFloat("delta_x") ?? 0f, dy = p.GetFloat("delta_y") ?? 0f;
+#if UNITY_INPUT_SYSTEM
+            Move(pos.Value); InputState.Change(Mouse.current.scroll, new Vector2(dx, dy)); Flush(p.GetBool("flush", true));
+            return new SuccessResponse($"Scrolled ({pos.Value.x:F0},{pos.Value.y:F0}) Δ({dx},{dy}).",
+                new { x = pos.Value.x, y = pos.Value.y, delta_x = dx, delta_y = dy });
+#else
+            return new ErrorResponse("Legacy backend: scroll not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+
+        // ── Keyboard Actions ───────────────────────────────────────────────────────
+        internal static object KeyPress(ToolParams p)
+        {
+            var r = p.GetRequired("key"); if (!r.IsSuccess) return new ErrorResponse(r.ErrorMessage);
+            string mode = p.Get("mode", "tap");
+#if UNITY_INPUT_SYSTEM
+            if (!TryKey(r.Value, out var k)) return new ErrorResponse($"Unknown key '{r.Value}'. Use Key enum names (e.g. Space, A, Escape).");
+            bool fl = p.GetBool("flush", true);
+            if (mode == "release") { InputState.Change(Keyboard.current[k], 0f); }
+            else { InputState.Change(Keyboard.current[k], 1f); Flush(fl); if (mode == "tap") InputState.Change(Keyboard.current[k], 0f); }
+            Flush(fl);
+            return new SuccessResponse($"Key '{r.Value}' {mode}.", new { key = r.Value, mode });
+#else
+            return new ErrorResponse("Legacy backend: key press not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+
+        internal static object KeyCombo(ToolParams p)
+        {
+            var r = p.GetRequired("key"); if (!r.IsSuccess) return new ErrorResponse(r.ErrorMessage);
+            string[] mods = p.GetStringArray("modifiers");
+#if UNITY_INPUT_SYSTEM
+            if (!TryKey(r.Value, out var k)) return new ErrorResponse($"Unknown key '{r.Value}'.");
+            bool fl = p.GetBool("flush", true);
+            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) InputState.Change(Keyboard.current[mk], 1f);
+            InputState.Change(Keyboard.current[k], 1f); Flush(fl);
+            InputState.Change(Keyboard.current[k], 0f);
+            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) InputState.Change(Keyboard.current[mk], 0f);
+            Flush(fl);
+            return new SuccessResponse($"Combo [{string.Join("+", mods ?? Array.Empty<string>())}]+{r.Value}.", new { key = r.Value, modifiers = mods });
+#else
+            return new ErrorResponse("Legacy backend: key combo not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+
+        internal static object TextInput(ToolParams p)
+        {
+            var r = p.GetRequired("text"); if (!r.IsSuccess) return new ErrorResponse(r.ErrorMessage);
+#if UNITY_INPUT_SYSTEM
+            bool fl = p.GetBool("flush", true);
+            foreach (char c in r.Value) { InputSystem.QueueTextEvent(Keyboard.current, c); Flush(fl); }
+            return new SuccessResponse($"Typed {r.Value.Length} character(s).", new { text = r.Value, length = r.Value.Length });
+#else
+            return new ErrorResponse("Legacy backend: text input not supported. Enable com.unity.inputsystem.");
+#endif
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationSequence.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationSequence.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime;
+using Newtonsoft.Json.Linq;
+
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    internal static class InputSimulationSequence
+    {
+        const int MaxSteps = 100;
+
+        internal static object StartSequence(ToolParams p)
+        {
+            var stepsToken = p.GetRaw("steps");
+            if (stepsToken == null || stepsToken.Type != JTokenType.Array)
+                return new ErrorResponse("'steps' must be a JSON array.");
+
+            var stepsArray = (JArray)stepsToken;
+            if (stepsArray.Count == 0)
+                return new ErrorResponse("'steps' array cannot be empty.");
+            if (stepsArray.Count > MaxSteps)
+                return new ErrorResponse($"Too many steps ({stepsArray.Count}). Maximum is {MaxSteps}.");
+
+            var steps = new List<SequenceStep>();
+            for (int i = 0; i < stepsArray.Count; i++)
+            {
+                var item = stepsArray[i] as JObject;
+                if (item == null)
+                    return new ErrorResponse($"Step {i} must be a JSON object.");
+
+                string action = item["action"]?.ToString();
+                if (string.IsNullOrEmpty(action))
+                    return new ErrorResponse($"Step {i} missing 'action' field.");
+                if (action == "sequence")
+                    return new ErrorResponse($"Step {i}: recursive 'sequence' actions are not allowed.");
+
+                var stepParams = item["params"] as JObject ?? new JObject();
+                stepParams["action"] = action;
+                int delayMs = (int?)item["delay_ms"] ?? 0;
+
+                steps.Add(new SequenceStep { Action = action, Params = stepParams, DelayMs = delayMs });
+            }
+
+            var bridge = InputSimulationBridge.Instance;
+            if (bridge == null)
+                return new ErrorResponse("InputSimulationBridge not available. Ensure Play Mode is active.");
+
+            string jobId = bridge.StartSequence(steps);
+            return new SuccessResponse("Sequence started.", new
+            {
+                job_id = jobId,
+                status = "running",
+                total_steps = steps.Count
+            });
+        }
+
+        internal static object GetStatus(ToolParams p)
+        {
+            var r = p.GetRequired("job_id");
+            if (!r.IsSuccess) return new ErrorResponse(r.ErrorMessage);
+
+            var bridge = InputSimulationBridge.Instance;
+            if (bridge == null)
+                return new ErrorResponse("InputSimulationBridge not available.");
+
+            var state = bridge.GetJobState(r.Value);
+            if (state == null)
+                return new ErrorResponse($"No sequence job found with id '{r.Value}'.");
+
+            return new SuccessResponse($"Sequence {state.Status}.", new
+            {
+                job_id = state.JobId,
+                status = state.Status,
+                current_step = state.CurrentStep,
+                total_steps = state.TotalSteps,
+                error = state.Error
+            });
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationTouch.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationTouch.cs
@@ -1,0 +1,108 @@
+using System;
+using MCPForUnity.Editor.Helpers;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+#if UNITY_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
+#endif
+
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    internal static class InputSimulationTouch
+    {
+        // Target resolution helper (same pattern as InputSimulationActions)
+        static (Vector2? pos, object err) Resolve(ToolParams p, string param = "target")
+        {
+            var tok = p.GetRaw(param);
+            if (tok == null || tok.Type != JTokenType.Object)
+                return (null, new ErrorResponse($"'{param}' must be a JSON object."));
+            var (pos, msg) = InputTargetResolver.ResolveTarget((JObject)tok);
+            return msg != null ? (null, (object)new ErrorResponse(msg)) : (pos, null);
+        }
+
+#if UNITY_INPUT_SYSTEM
+        static Touchscreen EnsureTouchscreen()
+        {
+            if (Touchscreen.current != null) return Touchscreen.current;
+            return InputSystem.AddDevice<Touchscreen>();
+        }
+
+        static void SimTouch(Touchscreen ts, int finger, Vector2 pos, UnityEngine.InputSystem.TouchPhase phase, bool flush)
+        {
+            var state = new TouchState
+            {
+                touchId = finger + 1,
+                position = pos,
+                phase = phase,
+            };
+            InputState.Change(ts.touches[finger], state);
+            if (flush) InputSystem.Update();
+        }
+#endif
+
+        internal static object TouchTap(ToolParams p)
+        {
+#if UNITY_INPUT_SYSTEM
+            var (pos, e) = Resolve(p); if (e != null) return e;
+            bool fl = p.GetBool("flush", true);
+            var ts = EnsureTouchscreen();
+            SimTouch(ts, 0, pos.Value, UnityEngine.InputSystem.TouchPhase.Began, fl);
+            SimTouch(ts, 0, pos.Value, UnityEngine.InputSystem.TouchPhase.Ended, fl);
+            return new SuccessResponse($"Touch tap at ({pos.Value.x:F0}, {pos.Value.y:F0}).", new { x = pos.Value.x, y = pos.Value.y });
+#else
+            return new ErrorResponse("Touch simulation requires com.unity.inputsystem package.");
+#endif
+        }
+
+        internal static object TouchSwipe(ToolParams p)
+        {
+#if UNITY_INPUT_SYSTEM
+            var (from, e1) = Resolve(p, "from_target"); if (e1 != null) return e1;
+            var (to, e2) = Resolve(p, "to_target"); if (e2 != null) return e2;
+            bool fl = p.GetBool("flush", true);
+            var ts = EnsureTouchscreen();
+            SimTouch(ts, 0, from.Value, UnityEngine.InputSystem.TouchPhase.Began, fl);
+            // Midpoint for smoother swipe
+            var mid = (from.Value + to.Value) * 0.5f;
+            SimTouch(ts, 0, mid, UnityEngine.InputSystem.TouchPhase.Moved, fl);
+            SimTouch(ts, 0, to.Value, UnityEngine.InputSystem.TouchPhase.Moved, fl);
+            SimTouch(ts, 0, to.Value, UnityEngine.InputSystem.TouchPhase.Ended, fl);
+            return new SuccessResponse($"Swipe ({from.Value.x:F0},{from.Value.y:F0}) → ({to.Value.x:F0},{to.Value.y:F0}).",
+                new { from_x = from.Value.x, from_y = from.Value.y, to_x = to.Value.x, to_y = to.Value.y });
+#else
+            return new ErrorResponse("Touch simulation requires com.unity.inputsystem package.");
+#endif
+        }
+
+        internal static object TouchPinch(ToolParams p)
+        {
+#if UNITY_INPUT_SYSTEM
+            var (center, e) = Resolve(p, "center_target"); if (e != null) return e;
+            float startDist = p.GetFloat("start_distance") ?? 100f;
+            float endDist = p.GetFloat("end_distance") ?? 50f;
+            bool fl = p.GetBool("flush", true);
+            var ts = EnsureTouchscreen();
+
+            // Two fingers symmetrically around center
+            Vector2 c = center.Value;
+            Vector2 startA = c + new Vector2(-startDist / 2, 0);
+            Vector2 startB = c + new Vector2(startDist / 2, 0);
+            Vector2 endA = c + new Vector2(-endDist / 2, 0);
+            Vector2 endB = c + new Vector2(endDist / 2, 0);
+
+            SimTouch(ts, 0, startA, UnityEngine.InputSystem.TouchPhase.Began, false);
+            SimTouch(ts, 1, startB, UnityEngine.InputSystem.TouchPhase.Began, fl);
+            SimTouch(ts, 0, endA, UnityEngine.InputSystem.TouchPhase.Moved, false);
+            SimTouch(ts, 1, endB, UnityEngine.InputSystem.TouchPhase.Moved, fl);
+            SimTouch(ts, 0, endA, UnityEngine.InputSystem.TouchPhase.Ended, false);
+            SimTouch(ts, 1, endB, UnityEngine.InputSystem.TouchPhase.Ended, fl);
+
+            return new SuccessResponse($"Pinch at ({c.x:F0},{c.y:F0}) dist {startDist}→{endDist}.",
+                new { center_x = c.x, center_y = c.y, start_distance = startDist, end_distance = endDist });
+#else
+            return new ErrorResponse("Touch simulation requires com.unity.inputsystem package.");
+#endif
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputTargetResolver.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputTargetResolver.cs
@@ -1,0 +1,264 @@
+using System;
+using MCPForUnity.Editor.Helpers;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    /// <summary>
+    /// Resolves all 4 target modes (coordinates, gameobject, ui_element, anchor) to screen coordinates.
+    /// Also handles discover and get_element_bounds actions.
+    /// </summary>
+    internal static class InputTargetResolver
+    {
+        // --- Target Resolution ---
+
+        /// <summary>
+        /// Resolve a target JSON object to screen coordinates (pixel position).
+        /// Returns (screenPos, null) on success or (null, errorMessage) on failure.
+        /// </summary>
+        internal static (Vector2? screenPos, string error) ResolveTarget(JObject targetObj)
+        {
+            if (targetObj == null)
+                return (null, "Target parameter is required.");
+
+            string mode = targetObj["mode"]?.ToString()?.ToLowerInvariant();
+            if (string.IsNullOrEmpty(mode))
+                return (null, "Target 'mode' is required. Valid: coordinates, gameobject, ui_element, anchor.");
+
+            return mode switch
+            {
+                "coordinates" => ResolveCoordinates(targetObj),
+                "gameobject"  => ResolveGameObject(targetObj),
+                "ui_element"  => ResolveUIElement(targetObj),
+                "anchor"      => ResolveAnchor(targetObj),
+                _ => (null, $"Unknown target mode: '{mode}'. Valid: coordinates, gameobject, ui_element, anchor.")
+            };
+        }
+
+        /// <summary>
+        /// Resolve a target to its full screen Rect (for bounds queries).
+        /// Returns (rect, null) on success or (null, errorMessage) on failure.
+        /// </summary>
+        internal static (Rect? bounds, string error) ResolveTargetBounds(JObject targetObj)
+        {
+            if (targetObj == null)
+                return (null, "Target parameter is required.");
+
+            string mode = targetObj["mode"]?.ToString()?.ToLowerInvariant();
+            if (string.IsNullOrEmpty(mode))
+                return (null, "Target 'mode' is required.");
+
+            return mode switch
+            {
+                "coordinates" => ResolveCoordinatesBounds(targetObj),
+                "gameobject"  => ResolveGameObjectBounds(targetObj),
+                "ui_element"  => ResolveUIElementBounds(targetObj),
+                "anchor"      => ResolveAnchorBounds(targetObj),
+                _ => (null, $"Unknown target mode: '{mode}'.")
+            };
+        }
+
+        // --- Coordinates Mode ---
+
+        static (Vector2?, string) ResolveCoordinates(JObject target)
+        {
+            float? x = (float?)target["x"];
+            float? y = (float?)target["y"];
+            if (!x.HasValue || !y.HasValue)
+                return (null, "Coordinates mode requires 'x' and 'y' fields.");
+            return (new Vector2(x.Value, y.Value), null);
+        }
+
+        static (Rect?, string) ResolveCoordinatesBounds(JObject target)
+        {
+            var (pos, err) = ResolveCoordinates(target);
+            if (err != null) return (null, err);
+            // Point rect (no size info for raw coordinates)
+            return (new Rect(pos.Value.x, pos.Value.y, 0, 0), null);
+        }
+
+        // --- GameObject Mode ---
+
+        static Camera FindCamera(JObject target)
+        {
+            string cameraName = target["camera_name"]?.ToString();
+            string cameraTag = target["camera_tag"]?.ToString();
+
+            if (!string.IsNullOrEmpty(cameraName))
+            {
+                var go = GameObject.Find(cameraName);
+                if (go != null) return go.GetComponent<Camera>();
+            }
+
+            if (!string.IsNullOrEmpty(cameraTag))
+            {
+                try { return Camera.main != null && Camera.main.CompareTag(cameraTag) ? Camera.main : GameObject.FindWithTag(cameraTag)?.GetComponent<Camera>(); }
+                catch { /* tag not defined */ }
+            }
+
+            return Camera.main;
+        }
+
+        static (GameObject, string) FindTargetGameObject(JObject target)
+        {
+            string path = target["path"]?.ToString();
+            string name = target["name"]?.ToString();
+            string instanceId = target["instance_id"]?.ToString();
+
+            GameObject go = null;
+
+            if (!string.IsNullOrEmpty(path))
+                go = GameObject.Find(path);
+            else if (!string.IsNullOrEmpty(instanceId) && int.TryParse(instanceId, out int id))
+                go = UnityEditor.EditorUtility.InstanceIDToObject(id) as GameObject;
+            else if (!string.IsNullOrEmpty(name))
+                go = GameObject.Find(name);
+
+            if (go == null)
+                return (null, $"GameObject not found. Searched: path='{path}', name='{name}', instance_id='{instanceId}'.");
+
+            return (go, null);
+        }
+
+        static (Vector2?, string) ResolveGameObject(JObject target)
+        {
+            var (go, err) = FindTargetGameObject(target);
+            if (err != null) return (null, err);
+
+            var cam = FindCamera(target);
+            if (cam == null)
+                return (null, "No camera found. Set Camera.main or provide 'camera_name'/'camera_tag' in target.");
+
+            var renderer = go.GetComponent<Renderer>();
+            Vector3 worldPos = renderer != null ? renderer.bounds.center : go.transform.position;
+            Vector3 screenPos = cam.WorldToScreenPoint(worldPos);
+
+            if (screenPos.z < 0)
+                return (null, $"GameObject '{go.name}' is behind the camera.");
+
+            return (new Vector2(screenPos.x, screenPos.y), null);
+        }
+
+        static (Rect?, string) ResolveGameObjectBounds(JObject target)
+        {
+            var (go, err) = FindTargetGameObject(target);
+            if (err != null) return (null, err);
+
+            var cam = FindCamera(target);
+            if (cam == null)
+                return (null, "No camera found.");
+
+            var renderer = go.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                var bounds = renderer.bounds;
+                Vector3 min = cam.WorldToScreenPoint(bounds.min);
+                Vector3 max = cam.WorldToScreenPoint(bounds.max);
+                if (min.z < 0 && max.z < 0) return (null, $"GameObject '{go.name}' is behind the camera.");
+                float x = Mathf.Min(min.x, max.x);
+                float y = Mathf.Min(min.y, max.y);
+                float w = Mathf.Abs(max.x - min.x);
+                float h = Mathf.Abs(max.y - min.y);
+                return (new Rect(x, y, w, h), null);
+            }
+
+            // Fallback: point at transform position
+            Vector3 sp = cam.WorldToScreenPoint(go.transform.position);
+            return (new Rect(sp.x, sp.y, 0, 0), null);
+        }
+
+        // --- UI Element Mode ---
+
+        static (Vector2?, string) ResolveUIElement(JObject target)
+        {
+            var (rect, err) = ResolveUIElementBounds(target);
+            if (err != null) return (null, err);
+            return (rect.Value.center, null);
+        }
+
+        static (Rect?, string) ResolveUIElementBounds(JObject target)
+        {
+            string query = target["name"]?.ToString() ?? target["query"]?.ToString();
+            if (string.IsNullOrEmpty(query))
+                return (null, "ui_element mode requires 'name' or 'query' field.");
+
+            // Search UGUI Selectables
+            foreach (var selectable in Selectable.allSelectablesArray)
+            {
+                if (selectable == null || !selectable.gameObject.activeInHierarchy) continue;
+                if (!selectable.name.Equals(query, StringComparison.OrdinalIgnoreCase) &&
+                    !selectable.name.Contains(query, StringComparison.OrdinalIgnoreCase)) continue;
+
+                var rt = selectable.GetComponent<RectTransform>();
+                if (rt == null) continue;
+
+                Vector3[] corners = new Vector3[4];
+                rt.GetWorldCorners(corners);
+                var cam = rt.GetComponentInParent<Canvas>()?.worldCamera;
+                // Screen space overlay: corners are already in screen space
+                var canvas = rt.GetComponentInParent<Canvas>()?.rootCanvas;
+                if (canvas != null && canvas.renderMode == RenderMode.ScreenSpaceOverlay)
+                {
+                    float minX = Mathf.Min(corners[0].x, corners[1].x, corners[2].x, corners[3].x);
+                    float minY = Mathf.Min(corners[0].y, corners[1].y, corners[2].y, corners[3].y);
+                    float maxX = Mathf.Max(corners[0].x, corners[1].x, corners[2].x, corners[3].x);
+                    float maxY = Mathf.Max(corners[0].y, corners[1].y, corners[2].y, corners[3].y);
+                    return (new Rect(minX, minY, maxX - minX, maxY - minY), null);
+                }
+                else if (cam != null)
+                {
+                    // World space / camera space canvas
+                    Vector2 min = cam.WorldToScreenPoint(corners[0]);
+                    Vector2 max = cam.WorldToScreenPoint(corners[2]);
+                    return (new Rect(min.x, min.y, max.x - min.x, max.y - min.y), null);
+                }
+            }
+
+            return (null, $"UI element not found matching '{query}'. Ensure it is active and has a Selectable component.");
+        }
+
+        // --- Anchor Mode ---
+
+        static (Vector2?, string) ResolveAnchor(JObject target)
+        {
+            string anchor = target["anchor"]?.ToString()?.ToLowerInvariant() ?? target["position"]?.ToString()?.ToLowerInvariant();
+            if (string.IsNullOrEmpty(anchor))
+                return (null, "Anchor mode requires 'anchor' or 'position' field.");
+
+            float offsetX = (float?)target["offset_x"] ?? 0f;
+            float offsetY = (float?)target["offset_y"] ?? 0f;
+            float w = Screen.width;
+            float h = Screen.height;
+
+            Vector2 pos = anchor switch
+            {
+                "center"        => new Vector2(w * 0.5f, h * 0.5f),
+                "top_left"      => new Vector2(0, h),
+                "top_right"     => new Vector2(w, h),
+                "top_center"    => new Vector2(w * 0.5f, h),
+                "bottom_left"   => new Vector2(0, 0),
+                "bottom_right"  => new Vector2(w, 0),
+                "bottom_center" => new Vector2(w * 0.5f, 0),
+                "center_left"   => new Vector2(0, h * 0.5f),
+                "center_right"  => new Vector2(w, h * 0.5f),
+                _ => Vector2.negativeInfinity
+            };
+
+            if (float.IsNegativeInfinity(pos.x))
+                return (null, $"Unknown anchor: '{anchor}'. Valid: center, top_left, top_right, top_center, bottom_left, bottom_right, bottom_center, center_left, center_right.");
+
+            return (pos + new Vector2(offsetX, offsetY), null);
+        }
+
+        static (Rect?, string) ResolveAnchorBounds(JObject target)
+        {
+            var (pos, err) = ResolveAnchor(target);
+            if (err != null) return (null, err);
+            return (new Rect(pos.Value.x, pos.Value.y, 0, 0), null);
+        }
+
+        // Discovery and GetElementBounds are in InputDiscovery.cs
+    }
+}

--- a/MCPForUnity/Editor/Tools/ManageInputSimulation.cs
+++ b/MCPForUnity/Editor/Tools/ManageInputSimulation.cs
@@ -1,0 +1,72 @@
+using System;
+using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Editor.Tools.InputSimulation;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+
+namespace MCPForUnity.Editor.Tools
+{
+    /// <summary>
+    /// Play Mode input simulation — lets AI assistants interact with running Unity games.
+    /// Actions: discover, get_element_bounds, click, double_click, mouse_move, drag, scroll,
+    /// key_press, key_combo, text_input, touch_tap, touch_swipe, touch_pinch, sequence, status.
+    /// </summary>
+    [McpForUnityTool("manage_input_simulation", AutoRegister = true, Group = "testing")]
+    public static class ManageInputSimulation
+    {
+        public static object HandleCommand(JObject @params)
+        {
+            if (@params == null) return new ErrorResponse("Parameters cannot be null.");
+
+            // Play Mode guard — input simulation only works while game is running
+            if (!EditorApplication.isPlaying)
+                return new ErrorResponse("Play Mode required. Use manage_editor action='play' first.");
+
+            var p = new ToolParams(@params);
+            var actionResult = p.GetRequired("action");
+            if (!actionResult.IsSuccess) return new ErrorResponse(actionResult.ErrorMessage);
+            string action = actionResult.Value.ToLowerInvariant();
+
+            try
+            {
+                return action switch
+                {
+                    // Discovery (Phase 1)
+                    "discover"           => InputDiscovery.Discover(p),
+                    "get_element_bounds" => InputDiscovery.GetElementBounds(p),
+
+                    // Mouse actions (Phase 2)
+                    "click"              => InputSimulationActions.Click(p),
+                    "double_click"       => InputSimulationActions.DoubleClick(p),
+                    "mouse_move"         => InputSimulationActions.MouseMove(p),
+                    "drag"               => InputSimulationActions.Drag(p),
+                    "scroll"             => InputSimulationActions.Scroll(p),
+
+                    // Keyboard actions (Phase 2)
+                    "key_press"          => InputSimulationActions.KeyPress(p),
+                    "key_combo"          => InputSimulationActions.KeyCombo(p),
+                    "text_input"         => InputSimulationActions.TextInput(p),
+
+                    // Touch actions (Phase 3)
+                    "touch_tap"          => InputSimulationTouch.TouchTap(p),
+                    "touch_swipe"        => InputSimulationTouch.TouchSwipe(p),
+                    "touch_pinch"        => InputSimulationTouch.TouchPinch(p),
+
+                    // Sequence actions (Phase 3)
+                    "sequence"           => InputSimulationSequence.StartSequence(p),
+                    "status"             => InputSimulationSequence.GetStatus(p),
+
+                    _ => new ErrorResponse(
+                        $"Unknown action: '{action}'. Valid actions: discover, get_element_bounds, " +
+                        "click, double_click, mouse_move, drag, scroll, " +
+                        "key_press, key_combo, text_input, " +
+                        "touch_tap, touch_swipe, touch_pinch, sequence, status.")
+                };
+            }
+            catch (Exception e)
+            {
+                return new ErrorResponse($"Internal error during '{action}': {e.Message}");
+            }
+        }
+    }
+}

--- a/MCPForUnity/Runtime/InputSimulationBridge.cs
+++ b/MCPForUnity/Runtime/InputSimulationBridge.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+
+namespace MCPForUnity.Runtime
+{
+    /// <summary>
+    /// Step definition for input simulation sequences.
+    /// </summary>
+    public class SequenceStep
+    {
+        public string Action;
+        public JObject Params;
+        public int DelayMs;
+    }
+
+    /// <summary>
+    /// State tracking for a running sequence job.
+    /// </summary>
+    public class SequenceJobState
+    {
+        public string JobId;
+        public string Status; // "running", "completed", "failed"
+        public int CurrentStep;
+        public int TotalSteps;
+        public string Error;
+    }
+
+    /// <summary>
+    /// Runtime MonoBehaviour that executes input simulation sequences as coroutines.
+    /// Singleton — auto-created on Play Mode start, survives scene loads.
+    /// </summary>
+    public class InputSimulationBridge : MonoBehaviour
+    {
+        static InputSimulationBridge _instance;
+        public static InputSimulationBridge Instance
+        {
+            get
+            {
+                if (_instance == null) CreateInstance();
+                return _instance;
+            }
+        }
+
+        const float TimeoutSeconds = 60f;
+        readonly Dictionary<string, SequenceJobState> _jobs = new Dictionary<string, SequenceJobState>();
+        readonly Dictionary<string, Coroutine> _coroutines = new Dictionary<string, Coroutine>();
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        static void AutoCreate() => CreateInstance();
+
+        static void CreateInstance()
+        {
+            if (_instance != null) return;
+            var go = new GameObject("[MCP] InputSimulationBridge");
+            DontDestroyOnLoad(go);
+            _instance = go.AddComponent<InputSimulationBridge>();
+        }
+
+        public string StartSequence(List<SequenceStep> steps)
+        {
+            string jobId = Guid.NewGuid().ToString("N").Substring(0, 8);
+            var state = new SequenceJobState
+            {
+                JobId = jobId,
+                Status = "running",
+                CurrentStep = 0,
+                TotalSteps = steps.Count
+            };
+            _jobs[jobId] = state;
+            _coroutines[jobId] = StartCoroutine(RunSequence(jobId, steps, state));
+            return jobId;
+        }
+
+        public SequenceJobState GetJobState(string jobId)
+        {
+            _jobs.TryGetValue(jobId, out var state);
+            return state;
+        }
+
+        IEnumerator RunSequence(string jobId, List<SequenceStep> steps, SequenceJobState state)
+        {
+            float startTime = Time.realtimeSinceStartup;
+
+            for (int i = 0; i < steps.Count; i++)
+            {
+                // Timeout check
+                if (Time.realtimeSinceStartup - startTime > TimeoutSeconds)
+                {
+                    state.Status = "failed";
+                    state.Error = $"Sequence timed out after {TimeoutSeconds}s at step {i}.";
+                    yield break;
+                }
+
+                state.CurrentStep = i;
+                var step = steps[i];
+
+                // Delay before action
+                if (step.DelayMs > 0)
+                    yield return new WaitForSeconds(step.DelayMs / 1000f);
+
+                // Execute step via delegate — bridge Runtime→Editor assembly boundary
+                try
+                {
+                    if (_commandInvoker != null)
+                    {
+                        var result = _commandInvoker("manage_input_simulation", step.Params);
+                        // Check if result indicates failure
+                        if (result is string s && s.StartsWith("ERROR:"))
+                        {
+                            state.Status = "failed";
+                            state.Error = $"Step {i} ({step.Action}) failed: {s}";
+                            yield break;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    state.Status = "failed";
+                    state.Error = $"Step {i} ({step.Action}) threw: {ex.Message}";
+                    yield break;
+                }
+
+                // Yield a frame between steps for input processing
+                yield return null;
+            }
+
+            state.CurrentStep = steps.Count;
+            state.Status = "completed";
+            _coroutines.Remove(jobId);
+        }
+
+        // Delegate for Editor → Runtime command invocation
+        static Func<string, JObject, object> _commandInvoker;
+
+        /// <summary>
+        /// Called by Editor code to register the command invoker delegate.
+        /// This bridges the Runtime → Editor assembly boundary.
+        /// </summary>
+        public static void RegisterCommandInvoker(Func<string, JObject, object> invoker)
+        {
+            _commandInvoker = invoker;
+        }
+
+        void OnDestroy()
+        {
+            if (_instance == this) _instance = null;
+        }
+    }
+}

--- a/Server/src/cli/commands/input_simulation.py
+++ b/Server/src/cli/commands/input_simulation.py
@@ -1,0 +1,390 @@
+"""Input simulation CLI commands — mouse, keyboard, touch, and sequence actions."""
+
+import json
+import sys
+from typing import Optional, Any
+
+import click
+
+from cli.utils.config import get_config
+from cli.utils.output import format_output, print_error, print_success, print_info
+from cli.utils.connection import run_command, handle_unity_errors
+from cli.utils.parsers import parse_json_dict_or_exit
+
+
+def _parse_target_or_exit(value: str, option_name: str) -> dict[str, Any]:
+    """Parse a JSON string into a target dict, exiting with an error on failure."""
+    return parse_json_dict_or_exit(value, option_name)
+
+
+@click.group()
+def input_simulation():
+    """Input simulation — mouse, keyboard, touch, and sequence actions (Play Mode)."""
+    pass
+
+
+@input_simulation.command("discover")
+@click.option("--filter", "-f", "filter_text", default=None, help="Substring filter for element names.")
+@click.option("--page-size", default=None, type=int, help="Max results (default 50).")
+@click.option("--cursor", default=None, type=int, help="Pagination cursor (0-based offset).")
+@handle_unity_errors
+def discover(filter_text: Optional[str], page_size: Optional[int], cursor: Optional[int]):
+    """List interactive UI elements in the current scene.
+
+    \b
+    Examples:
+        unity-mcp input-simulation discover
+        unity-mcp input-simulation discover --filter "Button"
+        unity-mcp input-simulation discover --page-size 20 --cursor 20
+    """
+    config = get_config()
+    params: dict[str, Any] = {"action": "discover"}
+    if filter_text:
+        params["filter"] = filter_text
+    if page_size is not None:
+        params["page_size"] = page_size
+    if cursor is not None:
+        params["cursor"] = cursor
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+
+
+@input_simulation.command("bounds")
+@click.option("--target", "-t", required=True, help="Target as JSON, e.g. '{\"mode\":\"ui_element\",\"name\":\"StartButton\"}'.")
+@handle_unity_errors
+def bounds(target: str):
+    """Get the bounding rect of a UI element.
+
+    \b
+    Examples:
+        unity-mcp input-simulation bounds --target '{"mode":"ui_element","name":"StartButton"}'
+    """
+    config = get_config()
+    target_dict = _parse_target_or_exit(target, "target")
+    params: dict[str, Any] = {"action": "get_element_bounds", "target": target_dict}
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+
+
+@input_simulation.command("click")
+@click.option("--target", "-t", required=True, help="Target as JSON.")
+@click.option("--button", "-b", default=None, type=click.Choice(["left", "right", "middle"]), help="Mouse button (default: left).")
+@handle_unity_errors
+def click_cmd(target: str, button: Optional[str]):
+    """Click at a target position or element.
+
+    \b
+    Examples:
+        unity-mcp input-simulation click --target '{"mode":"coordinates","x":100,"y":200}'
+        unity-mcp input-simulation click --target '{"mode":"ui_element","name":"StartButton"}' --button left
+        unity-mcp input-simulation click --target '{"mode":"gameobject","name":"Enemy"}' --button right
+    """
+    config = get_config()
+    target_dict = _parse_target_or_exit(target, "target")
+    params: dict[str, Any] = {"action": "click", "target": target_dict}
+    if button:
+        params["button"] = button
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Click performed")
+
+
+@input_simulation.command("double-click")
+@click.option("--target", "-t", required=True, help="Target as JSON.")
+@click.option("--button", "-b", default=None, type=click.Choice(["left", "right", "middle"]), help="Mouse button (default: left).")
+@handle_unity_errors
+def double_click(target: str, button: Optional[str]):
+    """Double-click at a target position or element.
+
+    \b
+    Examples:
+        unity-mcp input-simulation double-click --target '{"mode":"ui_element","name":"Icon"}'
+    """
+    config = get_config()
+    target_dict = _parse_target_or_exit(target, "target")
+    params: dict[str, Any] = {"action": "double_click", "target": target_dict}
+    if button:
+        params["button"] = button
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Double-click performed")
+
+
+@input_simulation.command("move")
+@click.option("--target", "-t", required=True, help="Target as JSON.")
+@handle_unity_errors
+def move(target: str):
+    """Move the mouse cursor to a target position.
+
+    \b
+    Examples:
+        unity-mcp input-simulation move --target '{"mode":"coordinates","x":300,"y":400}'
+    """
+    config = get_config()
+    target_dict = _parse_target_or_exit(target, "target")
+    params: dict[str, Any] = {"action": "mouse_move", "target": target_dict}
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Mouse moved")
+
+
+@input_simulation.command("drag")
+@click.option("--from", "from_target", required=True, help="Source target as JSON.")
+@click.option("--to", "to_target", required=True, help="Destination target as JSON.")
+@click.option("--duration", "-d", default=None, type=int, help="Duration in ms (default: 300).")
+@handle_unity_errors
+def drag(from_target: str, to_target: str, duration: Optional[int]):
+    """Drag from one target to another.
+
+    \b
+    Examples:
+        unity-mcp input-simulation drag --from '{"mode":"coordinates","x":100,"y":100}' --to '{"mode":"coordinates","x":400,"y":400}'
+        unity-mcp input-simulation drag --from '{"mode":"gameobject","name":"Card"}' --to '{"mode":"ui_element","name":"Slot"}' --duration 500
+    """
+    config = get_config()
+    from_dict = _parse_target_or_exit(from_target, "from")
+    to_dict = _parse_target_or_exit(to_target, "to")
+    params: dict[str, Any] = {
+        "action": "drag",
+        "from_target": from_dict,
+        "to_target": to_dict,
+    }
+    if duration is not None:
+        params["duration_ms"] = duration
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Drag performed")
+
+
+@input_simulation.command("scroll")
+@click.option("--target", "-t", required=True, help="Target as JSON.")
+@click.option("--dx", default=None, type=float, help="Horizontal scroll delta.")
+@click.option("--dy", default=None, type=float, help="Vertical scroll delta.")
+@handle_unity_errors
+def scroll(target: str, dx: Optional[float], dy: Optional[float]):
+    """Scroll the mouse wheel at a target position.
+
+    \b
+    Examples:
+        unity-mcp input-simulation scroll --target '{"mode":"ui_element","name":"ScrollView"}' --dy -3.0
+        unity-mcp input-simulation scroll --target '{"mode":"coordinates","x":500,"y":300}' --dy 2.0 --dx 1.0
+    """
+    config = get_config()
+    target_dict = _parse_target_or_exit(target, "target")
+    params: dict[str, Any] = {"action": "scroll", "target": target_dict}
+    if dx is not None:
+        params["delta_x"] = dx
+    if dy is not None:
+        params["delta_y"] = dy
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Scroll performed")
+
+
+@input_simulation.command("key")
+@click.argument("key_name")
+@click.option("--mode", "-m", default=None, type=click.Choice(["press", "release", "tap"]), help="Key mode (default: tap).")
+@handle_unity_errors
+def key(key_name: str, mode: Optional[str]):
+    """Press, release, or tap a key.
+
+    \b
+    Examples:
+        unity-mcp input-simulation key space
+        unity-mcp input-simulation key escape --mode tap
+        unity-mcp input-simulation key a --mode press
+        unity-mcp input-simulation key a --mode release
+    """
+    config = get_config()
+    params: dict[str, Any] = {"action": "key_press", "key": key_name}
+    if mode:
+        params["mode"] = mode
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success(f"Key '{key_name}' performed")
+
+
+@input_simulation.command("combo")
+@click.argument("key_name")
+@click.option("--mod", "-m", "modifiers", multiple=True, type=click.Choice(["ctrl", "shift", "alt"]), help="Modifier key (can be repeated).")
+@handle_unity_errors
+def combo(key_name: str, modifiers: tuple):
+    """Press a key combination with modifier keys.
+
+    \b
+    Examples:
+        unity-mcp input-simulation combo z --mod ctrl
+        unity-mcp input-simulation combo s --mod ctrl --mod shift
+        unity-mcp input-simulation combo f4 --mod alt
+    """
+    config = get_config()
+    params: dict[str, Any] = {"action": "key_combo", "key": key_name}
+    if modifiers:
+        params["modifiers"] = list(modifiers)
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        mods_str = "+".join(modifiers) + "+" if modifiers else ""
+        print_success(f"Key combo '{mods_str}{key_name}' performed")
+
+
+@input_simulation.command("text")
+@click.argument("text_value")
+@handle_unity_errors
+def text(text_value: str):
+    """Type a string of text into the focused input field.
+
+    \b
+    Examples:
+        unity-mcp input-simulation text "Hello, World!"
+        unity-mcp input-simulation text "player@example.com"
+    """
+    config = get_config()
+    params: dict[str, Any] = {"action": "text_input", "text": text_value}
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Text input performed")
+
+
+@input_simulation.command("tap")
+@click.option("--target", "-t", required=True, help="Target as JSON.")
+@handle_unity_errors
+def tap(target: str):
+    """Perform a single touch tap at a target position.
+
+    \b
+    Examples:
+        unity-mcp input-simulation tap --target '{"mode":"coordinates","x":200,"y":300}'
+        unity-mcp input-simulation tap --target '{"mode":"ui_element","name":"PlayButton"}'
+    """
+    config = get_config()
+    target_dict = _parse_target_or_exit(target, "target")
+    params: dict[str, Any] = {"action": "touch_tap", "target": target_dict}
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Touch tap performed")
+
+
+@input_simulation.command("swipe")
+@click.option("--from", "from_target", required=True, help="Source target as JSON.")
+@click.option("--to", "to_target", required=True, help="Destination target as JSON.")
+@click.option("--duration", "-d", default=None, type=int, help="Duration in ms (default: 300).")
+@handle_unity_errors
+def swipe(from_target: str, to_target: str, duration: Optional[int]):
+    """Perform a touch swipe gesture from one target to another.
+
+    \b
+    Examples:
+        unity-mcp input-simulation swipe --from '{"mode":"coordinates","x":300,"y":600}' --to '{"mode":"coordinates","x":300,"y":100}'
+        unity-mcp input-simulation swipe --from '{"mode":"anchor","anchor":"bottom"}' --to '{"mode":"anchor","anchor":"top"}' --duration 400
+    """
+    config = get_config()
+    from_dict = _parse_target_or_exit(from_target, "from")
+    to_dict = _parse_target_or_exit(to_target, "to")
+    params: dict[str, Any] = {
+        "action": "touch_swipe",
+        "from_target": from_dict,
+        "to_target": to_dict,
+    }
+    if duration is not None:
+        params["duration_ms"] = duration
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Touch swipe performed")
+
+
+@input_simulation.command("pinch")
+@click.option("--center", "-c", required=True, help="Center target as JSON.")
+@click.option("--start-dist", required=True, type=float, help="Starting distance between fingers (px).")
+@click.option("--end-dist", required=True, type=float, help="Ending distance between fingers (px).")
+@click.option("--duration", "-d", default=None, type=int, help="Duration in ms (default: 300).")
+@handle_unity_errors
+def pinch(center: str, start_dist: float, end_dist: float, duration: Optional[int]):
+    """Perform a two-finger pinch gesture.
+
+    \b
+    Examples:
+        unity-mcp input-simulation pinch --center '{"mode":"coordinates","x":400,"y":300}' --start-dist 200 --end-dist 50
+        unity-mcp input-simulation pinch --center '{"mode":"anchor","anchor":"center"}' --start-dist 50 --end-dist 200 --duration 600
+    """
+    config = get_config()
+    center_dict = _parse_target_or_exit(center, "center")
+    params: dict[str, Any] = {
+        "action": "touch_pinch",
+        "center_target": center_dict,
+        "start_distance": start_dist,
+        "end_distance": end_dist,
+    }
+    if duration is not None:
+        params["duration_ms"] = duration
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        print_success("Touch pinch performed")
+
+
+@input_simulation.command("sequence")
+@click.argument("steps_json")
+@handle_unity_errors
+def sequence(steps_json: str):
+    """Execute multiple input steps in order.
+
+    STEPS_JSON is a JSON array of step objects, each with {action, params, delay_ms}.
+
+    \b
+    Examples:
+        unity-mcp input-simulation sequence '[{"action":"click","params":{"target":{"mode":"ui_element","name":"StartButton"}},"delay_ms":200},{"action":"key_press","params":{"key":"space"},"delay_ms":100}]'
+    """
+    config = get_config()
+    try:
+        steps = json.loads(steps_json)
+    except json.JSONDecodeError as e:
+        print_error(f"Invalid JSON for steps: {e}")
+        sys.exit(1)
+    if not isinstance(steps, list):
+        print_error("steps must be a JSON array")
+        sys.exit(1)
+    params: dict[str, Any] = {"action": "sequence", "steps": steps}
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if result.get("success"):
+        job_id = result.get("data", {}).get("job_id") if isinstance(result.get("data"), dict) else None
+        if job_id:
+            print_info(f"Sequence job started: {job_id}")
+            print_info(f"Poll with: unity-mcp input-simulation status {job_id}")
+        else:
+            print_success("Sequence completed")
+
+
+@input_simulation.command("status")
+@click.argument("job_id")
+@handle_unity_errors
+def status(job_id: str):
+    """Poll an async sequence job for status and results.
+
+    \b
+    Examples:
+        unity-mcp input-simulation status abc123
+    """
+    config = get_config()
+    params: dict[str, Any] = {"action": "status", "job_id": job_id}
+    result = run_command("manage_input_simulation", params, config)
+    click.echo(format_output(result, config.format))
+    if isinstance(result, dict) and result.get("success"):
+        data = result.get("data", {})
+        job_status = data.get("status", "unknown") if isinstance(data, dict) else "unknown"
+        if job_status == "completed":
+            print_success("Sequence completed")
+        elif job_status == "running":
+            print_info("Sequence still running")
+        elif job_status == "failed":
+            print_error("Sequence failed")

--- a/Server/src/cli/main.py
+++ b/Server/src/cli/main.py
@@ -277,6 +277,7 @@ def register_commands():
         ("cli.commands.packages", "packages"),
         ("cli.commands.reflect", "reflect"),
         ("cli.commands.docs", "docs"),
+        ("cli.commands.input_simulation", "input_simulation"),
     ]
 
     for module_name, command_name in optional_commands:

--- a/Server/src/services/tools/manage_input_simulation.py
+++ b/Server/src/services/tools/manage_input_simulation.py
@@ -1,0 +1,124 @@
+"""
+Play Mode input simulation tool — mouse, keyboard, touch, and sequence actions.
+Actions: discover, get_element_bounds, click, double_click, mouse_move, drag, scroll,
+key_press, key_combo, text_input, touch_tap, touch_swipe, touch_pinch, sequence, status.
+"""
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context
+from mcp.types import ToolAnnotations
+
+from services.registry import mcp_for_unity_tool
+from services.tools import get_unity_instance_from_context
+from transport.unity_transport import send_with_unity_instance
+from transport.legacy.unity_connection import async_send_command_with_retry
+
+
+@mcp_for_unity_tool(
+    description=(
+        "Play Mode input simulation. "
+        "Actions: discover (list interactive UI elements), "
+        "get_element_bounds (bounding rect of a UI element), "
+        "click (left/right/middle mouse click), "
+        "double_click (double mouse click), "
+        "mouse_move (move cursor to position), "
+        "drag (click-hold-drag from one target to another), "
+        "scroll (mouse wheel scroll), "
+        "key_press (press/release/tap a key), "
+        "key_combo (key with modifier keys, e.g. Ctrl+Z), "
+        "text_input (type a string of text), "
+        "touch_tap (single touch tap), "
+        "touch_swipe (touch swipe gesture), "
+        "touch_pinch (two-finger pinch gesture), "
+        "sequence (execute multiple input steps in order), "
+        "status (poll async sequence job by job_id)."
+    ),
+    group="testing",
+    annotations=ToolAnnotations(title="Manage Input Simulation", destructiveHint=True),
+)
+async def manage_input_simulation(
+    ctx: Context,
+    action: Annotated[
+        Literal[
+            "discover",
+            "get_element_bounds",
+            "click",
+            "double_click",
+            "mouse_move",
+            "drag",
+            "scroll",
+            "key_press",
+            "key_combo",
+            "text_input",
+            "touch_tap",
+            "touch_swipe",
+            "touch_pinch",
+            "sequence",
+            "status",
+        ],
+        "Action to perform",
+    ],
+    target: Annotated[
+        dict | None,
+        "Target: {mode:'coordinates'|'gameobject'|'ui_element'|'anchor', ...}",
+    ] = None,
+    from_target: Annotated[dict | None, "Source target for drag/swipe"] = None,
+    to_target: Annotated[dict | None, "Destination target for drag/swipe"] = None,
+    center_target: Annotated[dict | None, "Center target for pinch"] = None,
+    button: Annotated[str | None, "Mouse button: left, right, middle"] = None,
+    key: Annotated[str | None, "Key name (e.g. space, a, escape)"] = None,
+    modifiers: Annotated[list[str] | None, "Modifier keys (ctrl, shift, alt)"] = None,
+    mode: Annotated[str | None, "Key mode: press, release, tap"] = None,
+    text: Annotated[str | None, "Text to type"] = None,
+    delta_x: Annotated[float | None, "Scroll delta X"] = None,
+    delta_y: Annotated[float | None, "Scroll delta Y"] = None,
+    duration_ms: Annotated[int | None, "Duration in ms for drag/swipe/pinch"] = None,
+    start_distance: Annotated[float | None, "Start distance for pinch (px)"] = None,
+    end_distance: Annotated[float | None, "End distance for pinch (px)"] = None,
+    steps: Annotated[
+        list[dict] | None, "Sequence steps [{action, params, delay_ms}]"
+    ] = None,
+    job_id: Annotated[str | None, "Job ID for status polling"] = None,
+    flush: Annotated[bool | None, "Flush input immediately (default true)"] = None,
+    capture_after: Annotated[
+        bool | None, "Take screenshot after action (default false)"
+    ] = None,
+    filter: Annotated[str | None, "Filter for discover (substring match)"] = None,
+    page_size: Annotated[int | None, "Max results (default 50)"] = None,
+    cursor: Annotated[int | None, "Pagination cursor"] = None,
+) -> dict[str, Any]:
+    unity_instance = get_unity_instance_from_context(ctx)
+
+    params: dict[str, Any] = {
+        "action": action,
+        "target": target,
+        "from_target": from_target,
+        "to_target": to_target,
+        "center_target": center_target,
+        "button": button,
+        "key": key,
+        "modifiers": modifiers,
+        "mode": mode,
+        "text": text,
+        "delta_x": delta_x,
+        "delta_y": delta_y,
+        "duration_ms": duration_ms,
+        "start_distance": start_distance,
+        "end_distance": end_distance,
+        "steps": steps,
+        "job_id": job_id,
+        "flush": flush,
+        "capture_after": capture_after,
+        "filter": filter,
+        "page_size": page_size,
+        "cursor": cursor,
+    }
+    # Strip None values — only send what the caller explicitly provided
+    params = {k: v for k, v in params.items() if v is not None}
+
+    response = await send_with_unity_instance(
+        async_send_command_with_retry, unity_instance, "manage_input_simulation", params
+    )
+    return response

--- a/Server/tests/integration/test_manage_input_simulation.py
+++ b/Server/tests/integration/test_manage_input_simulation.py
@@ -1,0 +1,403 @@
+"""
+Tests for the manage_input_simulation tool.
+Validates parameter routing for Play Mode input simulation actions.
+"""
+import pytest
+
+from .test_helpers import DummyContext
+import services.tools.manage_input_simulation as sim_mod
+
+
+def _fake_send_factory(captured: dict, response: dict = None):
+    if response is None:
+        response = {"success": True, "message": "OK", "data": {}}
+
+    async def fake_send(cmd, params, **kwargs):
+        captured["cmd"] = cmd
+        captured["params"] = params
+        return response
+
+    return fake_send
+
+
+# ---------------------------------------------------------------------------
+# Action routing tests — one per action
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_discover(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Found 3 elements.", "data": {"elements": []}}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="discover",
+        filter="Button",
+        page_size=10,
+    )
+    assert resp["success"] is True
+    assert captured["cmd"] == "manage_input_simulation"
+    assert captured["params"]["action"] == "discover"
+    assert captured["params"]["filter"] == "Button"
+    assert captured["params"]["page_size"] == 10
+
+
+@pytest.mark.asyncio
+async def test_get_element_bounds(monkeypatch):
+    captured = {}
+    target = {"mode": "ui_element", "path": "Canvas/Button"}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Bounds retrieved.", "data": {"rect": {}}}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="get_element_bounds",
+        target=target,
+    )
+    assert resp["success"] is True
+    assert captured["cmd"] == "manage_input_simulation"
+    assert captured["params"]["action"] == "get_element_bounds"
+    assert captured["params"]["target"] == target
+
+
+@pytest.mark.asyncio
+async def test_click(monkeypatch):
+    captured = {}
+    target = {"mode": "coordinates", "x": 500, "y": 300}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Clicked."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="click",
+        target=target,
+        button="left",
+    )
+    assert resp["success"] is True
+    assert captured["cmd"] == "manage_input_simulation"
+    assert captured["params"]["action"] == "click"
+    assert captured["params"]["target"] == target
+    assert captured["params"]["button"] == "left"
+
+
+@pytest.mark.asyncio
+async def test_double_click(monkeypatch):
+    captured = {}
+    target = {"mode": "coordinates", "x": 200, "y": 150}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Double-clicked."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="double_click",
+        target=target,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "double_click"
+    assert captured["params"]["target"] == target
+
+
+@pytest.mark.asyncio
+async def test_mouse_move(monkeypatch):
+    captured = {}
+    target = {"mode": "coordinates", "x": 100, "y": 200}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="mouse_move",
+        target=target,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "mouse_move"
+    assert captured["params"]["target"] == target
+
+
+@pytest.mark.asyncio
+async def test_drag(monkeypatch):
+    captured = {}
+    from_target = {"mode": "coordinates", "x": 100, "y": 100}
+    to_target = {"mode": "coordinates", "x": 400, "y": 400}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Dragged."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="drag",
+        from_target=from_target,
+        to_target=to_target,
+        duration_ms=500,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "drag"
+    assert captured["params"]["from_target"] == from_target
+    assert captured["params"]["to_target"] == to_target
+    assert captured["params"]["duration_ms"] == 500
+
+
+@pytest.mark.asyncio
+async def test_scroll(monkeypatch):
+    captured = {}
+    target = {"mode": "coordinates", "x": 300, "y": 300}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Scrolled."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="scroll",
+        target=target,
+        delta_x=0.0,
+        delta_y=-3.0,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "scroll"
+    assert captured["params"]["target"] == target
+    assert captured["params"]["delta_x"] == 0.0
+    assert captured["params"]["delta_y"] == -3.0
+
+
+@pytest.mark.asyncio
+async def test_key_press(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Key pressed."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="key_press",
+        key="space",
+        mode="tap",
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "key_press"
+    assert captured["params"]["key"] == "space"
+    assert captured["params"]["mode"] == "tap"
+
+
+@pytest.mark.asyncio
+async def test_key_combo(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Key combo executed."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="key_combo",
+        modifiers=["ctrl"],
+        key="s",
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "key_combo"
+    assert captured["params"]["modifiers"] == ["ctrl"]
+    assert captured["params"]["key"] == "s"
+
+
+@pytest.mark.asyncio
+async def test_text_input(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Text typed."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="text_input",
+        text="hello",
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "text_input"
+    assert captured["params"]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_touch_tap(monkeypatch):
+    captured = {}
+    target = {"mode": "coordinates", "x": 250, "y": 400}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Touch tapped."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="touch_tap",
+        target=target,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "touch_tap"
+    assert captured["params"]["target"] == target
+
+
+@pytest.mark.asyncio
+async def test_touch_swipe(monkeypatch):
+    captured = {}
+    from_target = {"mode": "coordinates", "x": 100, "y": 500}
+    to_target = {"mode": "coordinates", "x": 100, "y": 200}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Touch swiped."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="touch_swipe",
+        from_target=from_target,
+        to_target=to_target,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "touch_swipe"
+    assert captured["params"]["from_target"] == from_target
+    assert captured["params"]["to_target"] == to_target
+
+
+@pytest.mark.asyncio
+async def test_touch_pinch(monkeypatch):
+    captured = {}
+    center_target = {"mode": "coordinates", "x": 400, "y": 300}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Pinch executed."}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="touch_pinch",
+        center_target=center_target,
+        start_distance=50.0,
+        end_distance=150.0,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "touch_pinch"
+    assert captured["params"]["center_target"] == center_target
+    assert captured["params"]["start_distance"] == 50.0
+    assert captured["params"]["end_distance"] == 150.0
+
+
+@pytest.mark.asyncio
+async def test_sequence(monkeypatch):
+    captured = {}
+    steps = [
+        {"action": "click", "params": {"target": {"mode": "coordinates", "x": 100, "y": 100}}, "delay_ms": 200},
+        {"action": "key_press", "params": {"key": "escape"}, "delay_ms": 0},
+    ]
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Sequence started.", "data": {"job_id": "abc123"}}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="sequence",
+        steps=steps,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "sequence"
+    assert captured["params"]["steps"] == steps
+
+
+@pytest.mark.asyncio
+async def test_status(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured, {"success": True, "message": "Job complete.", "data": {"status": "done"}}),
+    )
+    resp = await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="status",
+        job_id="abc123",
+    )
+    assert resp["success"] is True
+    assert captured["params"]["action"] == "status"
+    assert captured["params"]["job_id"] == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_none_params_stripped(monkeypatch):
+    """None values must not appear in the params sent to Unity."""
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured),
+    )
+    await sim_mod.manage_input_simulation(ctx=DummyContext(), action="discover")
+    assert set(captured["params"].keys()) == {"action"}
+
+
+@pytest.mark.asyncio
+async def test_python_exception_propagates(monkeypatch):
+    """Exceptions from the transport layer propagate out of the tool (no suppression)."""
+    async def raising_send(cmd, params, **kwargs):
+        raise ConnectionError("Unity not connected")
+
+    monkeypatch.setattr(sim_mod, "async_send_command_with_retry", raising_send)
+    with pytest.raises(ConnectionError, match="Unity not connected"):
+        await sim_mod.manage_input_simulation(ctx=DummyContext(), action="discover")
+
+
+@pytest.mark.asyncio
+async def test_target_dict_passthrough(monkeypatch):
+    """Complex nested target dicts pass through to Unity unchanged."""
+    captured = {}
+    complex_target = {
+        "mode": "gameobject",
+        "path": "Level/Player/Body",
+        "component": "Button",
+        "offset_x": 10,
+        "offset_y": -5,
+    }
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured),
+    )
+    await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="click",
+        target=complex_target,
+    )
+    assert captured["params"]["target"] == complex_target
+
+
+@pytest.mark.asyncio
+async def test_flush_param(monkeypatch):
+    """flush=True must be forwarded in params."""
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured),
+    )
+    await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="click",
+        target={"mode": "coordinates", "x": 0, "y": 0},
+        flush=True,
+    )
+    assert captured["params"]["flush"] is True
+
+
+@pytest.mark.asyncio
+async def test_capture_after_param(monkeypatch):
+    """capture_after=True must be forwarded in params."""
+    captured = {}
+    monkeypatch.setattr(
+        sim_mod, "async_send_command_with_retry",
+        _fake_send_factory(captured),
+    )
+    await sim_mod.manage_input_simulation(
+        ctx=DummyContext(),
+        action="click",
+        target={"mode": "coordinates", "x": 0, "y": 0},
+        capture_after=True,
+    )
+    assert captured["params"]["capture_after"] is True

--- a/plans/260402-1302-input-simulation-tool/phase-01-target-resolution-discovery.md
+++ b/plans/260402-1302-input-simulation-tool/phase-01-target-resolution-discovery.md
@@ -1,0 +1,147 @@
+---
+phase: 1
+status: pending
+effort: M
+blocks: [2, 3]
+---
+
+# Phase 1: C# Target Resolution + Discovery
+
+## Context Links
+
+- Pattern: `MCPForUnity/Editor/Tools/ManageInputSystem.cs` — action dispatch, `#if UNITY_INPUT_SYSTEM`, ToolParams
+- Pattern: `MCPForUnity/Editor/Helpers/GameObjectLookup.cs` — `FindByTarget(JToken, string, bool)` for GO lookup
+- Pattern: `MCPForUnity/Editor/Helpers/ObjectResolver.cs` — flexible object resolution
+- Pattern: `MCPForUnity/Editor/Helpers/Pagination.cs` — `PaginationRequest.FromParams()`, `PaginationResponse<T>.Create()`
+- Pattern: `MCPForUnity/Editor/Helpers/ToolParams.cs` — `GetRequired()`, `Get()`, `GetInt()`, `GetFloat()`, `GetBool()`
+- Pattern: `MCPForUnity/Editor/Helpers/Response.cs` — `SuccessResponse`, `ErrorResponse`
+
+## Overview
+
+Build the main entry-point `ManageInputSimulation.cs` (action dispatch + Play Mode guard) and the `InputTargetResolver` helper that converts all 4 targeting modes to screen coordinates. Implement `discover` and `get_element_bounds` actions.
+
+## Key Insights
+
+- `GameObjectLookup.FindByTarget(JToken, string, bool)` already handles by_name, by_path, by_id, by_tag, by_id_or_name_or_path. Reuse it for `gameobject` target mode.
+- UI Toolkit `VisualElement` world rect: `ve.worldBound` gives `Rect` in panel space. For UGUI `RectTransform`, use `RectTransformUtility.PixelAdjustRect()`.
+- `Camera.main.WorldToScreenPoint()` for 3D GameObjects. Note: Unity screen coords are bottom-left origin; Input System expects this.
+- Discovery needs to enumerate: `Selectable.allSelectablesArray` (UGUI), root `VisualElement` tree (UI Toolkit), plus renderable GameObjects.
+
+## Requirements
+
+### Functional
+- Parse `target` param as JSON object with `mode` field: `coordinates`, `gameobject`, `ui_element`, `anchor`
+- `coordinates` mode: extract `x`, `y` directly
+- `gameobject` mode: extract `name` or `path` or `instance_id`, find GO, get screen center via renderer bounds. Optional `camera_name`/`camera_tag` to override Camera.main
+- `ui_element` mode: extract `name`, find Selectable or VisualElement, get screen rect center
+- `anchor` mode: extract `anchor` (center, top_left, top_right, bottom_left, bottom_right, top_center, bottom_center, center_left, center_right) + optional `offset_x`, `offset_y`
+- `discover` action: paginated list of interactable elements with name, type (ugui/uitoolkit/gameobject), screen rect
+- `get_element_bounds` action: screen rect for a single target
+- All actions require Play Mode — return clear error if `!EditorApplication.isPlaying`
+
+### Non-Functional
+- ManageInputSimulation.cs must stay under 200 lines (just dispatch + guard)
+- InputTargetResolver.cs handles all resolution logic
+
+## Architecture
+
+```csharp
+// ManageInputSimulation.cs — ~80 lines
+[McpForUnityTool("manage_input_simulation", AutoRegister = true, Group = "testing")]
+public static class ManageInputSimulation
+{
+    public static object HandleCommand(JObject @params)
+    {
+        // 1. Play Mode guard
+        // 2. Parse action
+        // 3. Switch dispatch to appropriate handler
+    }
+}
+
+// InputTargetResolver.cs — ~150 lines
+internal static class InputTargetResolver
+{
+    // Returns (Vector2 screenPos, string error)
+    internal static (Vector2?, string) ResolveTarget(JObject targetObj) { ... }
+    internal static (Rect?, string) ResolveTargetBounds(JObject targetObj) { ... }
+    internal static object Discover(ToolParams p) { ... }
+    internal static object GetElementBounds(ToolParams p) { ... }
+}
+```
+
+## Related Code Files
+
+### Create
+- `MCPForUnity/Editor/Tools/ManageInputSimulation.cs`
+- `MCPForUnity/Editor/Tools/InputSimulation/InputTargetResolver.cs`
+
+### Read (reference patterns)
+- `MCPForUnity/Editor/Tools/ManageInputSystem.cs`
+- `MCPForUnity/Editor/Helpers/GameObjectLookup.cs`
+- `MCPForUnity/Editor/Helpers/Pagination.cs`
+- `MCPForUnity/Editor/Helpers/ToolParams.cs`
+
+## Implementation Steps
+
+1. Create directory `MCPForUnity/Editor/Tools/InputSimulation/`
+2. Create `ManageInputSimulation.cs`:
+   - Namespace: `MCPForUnity.Editor.Tools`
+   - Attribute: `[McpForUnityTool("manage_input_simulation", AutoRegister = true, Group = "testing")]`
+   - `public static object HandleCommand(JObject @params)`
+   - First line: `if (!EditorApplication.isPlaying) return new ErrorResponse("Play Mode required. Use manage_editor play first.");`
+   - Parse action via `ToolParams.GetRequired("action")`
+   - Switch on action: `discover`, `get_element_bounds` → `InputTargetResolver` methods
+   - All other actions (click, key_press, etc.) → placeholder `return new ErrorResponse("Not implemented: " + action);` (filled in Phase 2/3)
+3. Create `InputTargetResolver.cs`:
+   - Namespace: `MCPForUnity.Editor.Tools.InputSimulation`
+   - `internal static class InputTargetResolver`
+   - **ResolveTarget(JObject targetObj) -> (Vector2? screenPos, string error)**:
+     - Read `targetObj["mode"]` (required)
+     - `"coordinates"`: read `x`, `y` from targetObj, return as Vector2
+     - `"gameobject"`: read `name`/`path`/`instance_id`, call `GameObjectLookup.FindByTarget()`, get `Renderer.bounds.center`. Camera: check `camera_name`/`camera_tag` in target, fallback to `Camera.main`. Error if no camera. `camera.WorldToScreenPoint()`, return xy
+     - `"ui_element"`: read `name`, search `Selectable.allSelectablesArray` by GO name, get `RectTransform` screen center; also check UI Toolkit panels
+     - `"anchor"`: read `anchor` string, map to screen fraction, add `offset_x`/`offset_y`
+   - **ResolveTargetBounds(JObject targetObj) -> (Rect? screenRect, string error)**:
+     - Same resolution but return full Rect instead of center point
+   - **Discover(ToolParams p) -> object**:
+     - Collect UGUI Selectables: `Selectable.allSelectablesArray` → name, type="ugui", screen rect
+     - Collect UI Toolkit: iterate `UIDocument` instances → root VisualElement tree → interactive elements (Button, Toggle, etc.)
+     - Collect ALL GameObjects with Colliders (type="gameobject", screen rect via camera projection)
+     - Filter by optional `filter` param (substring match on name)
+     - Paginate via `PaginationRequest.FromParams()` / `PaginationResponse<T>.Create()`
+     - Return `SuccessResponse` with paginated items
+   - **GetElementBounds(ToolParams p) -> object**:
+     - Parse target param, call `ResolveTargetBounds`, return screen Rect
+
+## Todo
+
+- [ ] Create `MCPForUnity/Editor/Tools/InputSimulation/` directory
+- [ ] Create `ManageInputSimulation.cs` with action dispatch + Play Mode guard
+- [ ] Create `InputTargetResolver.cs` with all 4 target modes
+- [ ] Implement `ResolveTarget()` — coordinates mode
+- [ ] Implement `ResolveTarget()` — gameobject mode (GameObjectLookup + WorldToScreenPoint)
+- [ ] Implement `ResolveTarget()` — ui_element mode (Selectable + VisualElement)
+- [ ] Implement `ResolveTarget()` — anchor mode
+- [ ] Implement `Discover()` with pagination
+- [ ] Implement `GetElementBounds()`
+- [ ] Verify compilation in Unity
+
+## Success Criteria
+
+- `ManageInputSimulation.cs` under 200 lines
+- `discover` returns paginated list of interactable elements with screen rects
+- `get_element_bounds` returns screen rect for any valid target
+- Clear "Play Mode required" error when not playing
+- Unknown action returns error listing valid actions
+
+## Risk Assessment
+
+| Risk | L | I | Score | Mitigation |
+|------|---|---|-------|------------|
+| UI Toolkit panels not accessible from Editor code | 2 | 3 | 6 | UIDocument.rootVisualElement accessible; fall back to UGUI-only |
+| Camera.main null in some setups | 3 | 3 | 9 | Accept optional `camera` param; error if no camera found |
+| Selectable.allSelectablesArray only returns enabled | 2 | 2 | 4 | Document: only enabled selectables discovered |
+
+## Timeline
+
+Effort: M (medium) — ~3-4 hours. GameObjectLookup reuse saves significant work.

--- a/plans/260402-1302-input-simulation-tool/phase-02-mouse-keyboard-simulation.md
+++ b/plans/260402-1302-input-simulation-tool/phase-02-mouse-keyboard-simulation.md
@@ -1,0 +1,185 @@
+---
+phase: 2
+status: pending
+effort: L
+blocked_by: [1]
+blocks: [3]
+---
+
+# Phase 2: C# Mouse + Keyboard Input Simulation
+
+## Context Links
+
+- Pattern: `MCPForUnity/Editor/Tools/ManageInputSystem.cs` — `#if UNITY_INPUT_SYSTEM` conditional compilation
+- Phase 1: `ManageInputSimulation.cs` — action dispatch (wire new actions here)
+- Phase 1: `InputTargetResolver.cs` — `ResolveTarget()` for screen coords
+- Unity API: `UnityEngine.InputSystem.InputState.Change()`, `UnityEngine.InputSystem.LowLevel.QueueStateEvent()`
+- Unity API: `UnityEngine.EventSystems.ExecuteEvents`
+- Unity API: `UnityEngine.Event` for legacy IMGUI
+
+## Overview
+
+Implement mouse actions (click, double_click, mouse_move, drag, scroll) and keyboard actions (key_press, key_combo, text_input) with dual-backend support: New Input System via InputState manipulation, legacy via ExecuteEvents.
+
+## Key Insights
+
+- New Input System: `Mouse.current`, `Keyboard.current` are the device singletons. `InputState.Change(Mouse.current.position, screenPos)` moves the pointer. `InputState.Change(Mouse.current.press, 1f)` presses button.
+- For click, sequence: move → press → release. For double_click: move → press → release → press → release with short delay.
+- Legacy UGUI: `ExecuteEvents.Execute(target, pointerEventData, ExecuteEvents.pointerClickHandler)` directly triggers click on a specific GameObject. This only works for UI elements with EventSystem handlers.
+- Legacy `Event` queue: `new Event { type = EventType.KeyDown, keyCode = KeyCode.Space }` can be sent for IMGUI.
+- `key_combo` (e.g., Ctrl+S): press modifier(s), press key, release key, release modifier(s).
+- `text_input`: For New Input System, use `Keyboard.current.text` control. For legacy, use `Event` with `EventType.KeyDown` and `character` field.
+
+## Requirements
+
+### Functional
+- All simulation actions accept optional `flush` param (default true). When true, calls `InputSystem.Update()` after state change for immediate processing. When false, batches changes for next frame (useful in sequences).
+- `click(target, button?)`: Resolve target → screen coords. Simulate pointer move + press + release. `button` defaults to "left".
+- `double_click(target, button?)`: Two rapid click sequences.
+- `mouse_move(target)`: Move pointer to target position without clicking.
+- `drag(from_target, to_target, duration_ms?)`: Move to from, press, interpolate to to, release. `duration_ms` defaults to 200.
+- `scroll(target, delta_x?, delta_y?)`: Scroll wheel at target position. At least one delta required.
+- `key_press(key, mode?)`: `mode` = press | release | tap (default: tap). `key` is key name string (e.g., "space", "a", "escape").
+- `key_combo(modifiers[], key)`: Simultaneous modifier keys + main key.
+- `text_input(text)`: Type text string character by character into focused element.
+
+### Non-Functional
+- Conditional compilation: `#if UNITY_INPUT_SYSTEM` for new system, `#else` for legacy
+- Mouse button mapping: "left"→0, "right"→1, "middle"→2
+- Key name mapping: string → `Key` enum (new) or `KeyCode` enum (legacy)
+- All actions return `SuccessResponse` with what was done, or `ErrorResponse`
+
+## Architecture
+
+```csharp
+// InputSimulationActions.cs — ~180 lines
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    internal static class InputSimulationActions
+    {
+        // Mouse actions
+        internal static object Click(ToolParams p) { ... }
+        internal static object DoubleClick(ToolParams p) { ... }
+        internal static object MouseMove(ToolParams p) { ... }
+        internal static object Drag(ToolParams p) { ... }
+        internal static object Scroll(ToolParams p) { ... }
+
+        // Keyboard actions
+        internal static object KeyPress(ToolParams p) { ... }
+        internal static object KeyCombo(ToolParams p) { ... }
+        internal static object TextInput(ToolParams p) { ... }
+
+        // Internal helpers
+        private static void SimulateMouseMove(Vector2 screenPos) { ... }
+        private static void SimulateMouseButton(int button, bool pressed) { ... }
+        private static void SimulateKey(string keyName, bool pressed) { ... }
+    }
+}
+```
+
+Dual backend pattern per method:
+```csharp
+private static void SimulateMouseMove(Vector2 screenPos)
+{
+#if UNITY_INPUT_SYSTEM
+    if (Mouse.current != null)
+        InputState.Change(Mouse.current.position, screenPos);
+#else
+    // Legacy: ExecuteEvents with synthesized PointerEventData
+    // or store position for next raycast
+#endif
+}
+```
+
+## Related Code Files
+
+### Create
+- `MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs`
+
+### Modify
+- `MCPForUnity/Editor/Tools/ManageInputSimulation.cs` — wire click/double_click/mouse_move/drag/scroll/key_press/key_combo/text_input actions
+
+### Read (reference)
+- `MCPForUnity/Editor/Tools/ManageInputSystem.cs` — `#if UNITY_INPUT_SYSTEM` pattern
+- `MCPForUnity/Editor/Tools/InputSimulation/InputTargetResolver.cs` — target resolution
+
+## Implementation Steps
+
+1. Create `InputSimulationActions.cs` in `MCPForUnity/Editor/Tools/InputSimulation/`
+2. Add key name mapping utility:
+   - `ParseMouseButton(string name) -> int` — "left"→0, "right"→1, "middle"→2
+   - `ParseKeyName(string name)` → returns `Key` (new) or `KeyCode` (legacy) via `Enum.TryParse`
+3. Implement `SimulateMouseMove(Vector2 screenPos)`:
+   - New: `InputState.Change(Mouse.current.position, screenPos)`
+   - Legacy: store for `ExecuteEvents` raycast origin
+4. Implement `SimulateMouseButton(int button, bool pressed)`:
+   - New: `InputState.Change(Mouse.current.leftButton, pressed ? 1f : 0f)` (or rightButton/middleButton)
+   - Legacy: create `PointerEventData`, `ExecuteEvents.Execute` on current raycast hit
+5. Implement `Click(ToolParams p)`:
+   - Parse `target` → `InputTargetResolver.ResolveTarget(targetObj)`
+   - Parse `button` (default "left")
+   - Move → press → release (using `InputTestFixture.CallProcessAfterEvents()` or similar to flush)
+   - Return `SuccessResponse("Clicked at (x, y)", new { x, y, button })`
+6. Implement `DoubleClick(ToolParams p)`:
+   - Two click sequences
+7. Implement `MouseMove(ToolParams p)`:
+   - Move only, no press
+8. Implement `Drag(ToolParams p)`:
+   - Parse `from_target`, `to_target`, `duration_ms`
+   - Move to from → press → move to to → release
+   - Note: for immediate (sync) drag, just teleport from → to. Duration only matters in sequence mode.
+9. Implement `Scroll(ToolParams p)`:
+   - New: `InputState.Change(Mouse.current.scroll, new Vector2(deltaX, deltaY))`
+   - Legacy: `ExecuteEvents.ExecuteHierarchy(target, scrollEventData, ExecuteEvents.scrollHandler)`
+10. Implement `KeyPress(ToolParams p)`:
+    - Parse `key` name, `mode` (press/release/tap)
+    - New: `InputState.Change(Keyboard.current[parsedKey], pressed ? 1f : 0f)`
+    - Legacy: `Event` queue
+    - tap = press + release
+11. Implement `KeyCombo(ToolParams p)`:
+    - Parse `modifiers[]` and `key`
+    - Press each modifier, press key, release key, release modifiers (reverse order)
+12. Implement `TextInput(ToolParams p)`:
+    - Parse `text`
+    - New: for each char, `QueueTextEvent` on Keyboard
+    - Legacy: `Event` with character field per char
+13. Wire all new actions into `ManageInputSimulation.cs` switch statement
+
+## Todo
+
+- [ ] Create `InputSimulationActions.cs`
+- [ ] Implement mouse button & key name parsing helpers
+- [ ] Implement `SimulateMouseMove` (new + legacy)
+- [ ] Implement `SimulateMouseButton` (new + legacy)
+- [ ] Implement `Click` action
+- [ ] Implement `DoubleClick` action
+- [ ] Implement `MouseMove` action
+- [ ] Implement `Drag` action
+- [ ] Implement `Scroll` action
+- [ ] Implement `SimulateKey` (new + legacy)
+- [ ] Implement `KeyPress` action
+- [ ] Implement `KeyCombo` action
+- [ ] Implement `TextInput` action
+- [ ] Wire all actions into ManageInputSimulation.cs dispatch
+- [ ] Verify compilation with and without Input System package
+
+## Success Criteria
+
+- click/double_click/mouse_move/drag/scroll work with New Input System
+- key_press/key_combo/text_input work with New Input System
+- Legacy fallback compiles and provides partial coverage (UI events)
+- All actions return structured SuccessResponse or ErrorResponse
+- Compilation succeeds with `#if UNITY_INPUT_SYSTEM` both true and false
+
+## Risk Assessment
+
+| Risk | L | I | Score | Mitigation |
+|------|---|---|-------|------------|
+| InputState.Change doesn't trigger downstream handlers | 3 | 4 | 12 | Also call `InputSystem.Update()` after state change; test in actual Unity |
+| Legacy drag has no clean API | 3 | 3 | 9 | Sync drag = teleport from→to; async drag in Phase 3 sequence |
+| Key name parsing inconsistency | 2 | 2 | 4 | Normalize to lowercase; provide common aliases (space, enter, escape) |
+| File exceeds 200 lines | 3 | 2 | 6 | Mouse in one region, keyboard in another; split if >250 |
+
+## Timeline
+
+Effort: L (large) — ~5-6 hours. Most actions, dual backend, thorough key/button mapping.

--- a/plans/260402-1302-input-simulation-tool/phase-03-touch-sequence-mode.md
+++ b/plans/260402-1302-input-simulation-tool/phase-03-touch-sequence-mode.md
@@ -1,0 +1,194 @@
+---
+phase: 3
+status: pending
+effort: M
+blocked_by: [2]
+---
+
+# Phase 3: C# Touch + Sequence Mode
+
+## Context Links
+
+- Pattern: `MCPForUnity/Editor/Tools/RunTests.cs` — async `Task<object> HandleCommand()`, `TestJobManager` pattern
+- Pattern: `MCPForUnity/Editor/Tools/McpForUnityToolAttribute.cs` — `RequiresPolling`, `PollAction`, `MaxPollSeconds`
+- Pattern: `MCPForUnity/Editor/Helpers/Response.cs` — `PendingResponse` for polling
+- Phase 2: `InputSimulationActions.cs` — mouse/keyboard injection patterns
+- Phase 1: `InputTargetResolver.cs` — target resolution
+- Unity API: `UnityEngine.InputSystem.EnhancedTouch`, `UnityEngine.InputSystem.LowLevel.TouchState`
+- Unity API: `EditorApplication.update` for coroutine-like polling
+
+## Overview
+
+Implement touch simulation (tap, swipe, pinch) and the async `sequence` action that executes a list of steps with delays, reporting progress via polling.
+
+## Key Insights
+
+- Touch simulation with New Input System: `InputState.Change(Touchscreen.current.touches[0], new TouchState { position = pos, phase = Begin })`. Must cycle through Begin → Moved → Ended phases.
+- Touch requires `EnhancedTouchSupport.Enable()` at start.
+- Pinch requires two simultaneous touches (touches[0] and touches[1]).
+- Legacy touch: no clean API. Can only fake through UGUI EventSystem with synthesized touch PointerEventData.
+- Sequence mode: store step list + state in a static dictionary keyed by job_id (same pattern as TestJobManager). Use `EditorApplication.update` callback to advance steps. Return `PendingResponse` initially, poll with `status` action.
+- Important: `InputSimulationBridge` is a Runtime MonoBehaviour for coroutine execution in Play Mode. It self-creates via `[RuntimeInitializeOnLoadMethod]` or on-demand singleton.
+
+## Requirements
+
+### Functional
+- `touch_tap(target)`: Single touch at target — Begin → Ended.
+- `touch_swipe(from_target, to_target, duration_ms?)`: Touch Begin at from, Moved interpolation, Ended at to. `duration_ms` defaults to 300.
+- `touch_pinch(center_target, start_distance, end_distance, duration_ms?)`: Two touches symmetrically around center, interpolating distance. `duration_ms` defaults to 500.
+- `sequence(steps[])`: Each step is `{ action, params, delay_ms? }`. Execute steps serially with optional delays. Returns `{ job_id, status: "running" }`. Poll via `status` action.
+- `status(job_id)`: Returns current sequence job state — running/completed/failed, current step index, total steps.
+
+### Non-Functional
+- Touch actions require `#if UNITY_INPUT_SYSTEM` — no legacy fallback for touch (return clear error).
+- Sequence uses async handler (`Task<object>`), or sync handler returning PendingResponse.
+- Max sequence steps: 100 (guard against abuse).
+- Max sequence duration: 60 seconds timeout.
+
+## Architecture
+
+```csharp
+// InputSimulationTouch.cs — ~120 lines
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    internal static class InputSimulationTouch
+    {
+#if UNITY_INPUT_SYSTEM
+        internal static object TouchTap(ToolParams p) { ... }
+        internal static object TouchSwipe(ToolParams p) { ... }
+        internal static object TouchPinch(ToolParams p) { ... }
+        
+        private static void SimulateTouch(int fingerId, Vector2 pos, TouchPhase phase) { ... }
+#else
+        internal static object TouchTap(ToolParams p) => TouchNotSupported();
+        internal static object TouchSwipe(ToolParams p) => TouchNotSupported();
+        internal static object TouchPinch(ToolParams p) => TouchNotSupported();
+        
+        private static object TouchNotSupported() =>
+            new ErrorResponse("Touch simulation requires com.unity.inputsystem package.");
+#endif
+    }
+}
+
+// InputSimulationBridge.cs (Runtime) — ~100 lines
+namespace MCPForUnity.Runtime
+{
+    public class InputSimulationBridge : MonoBehaviour
+    {
+        private static InputSimulationBridge _instance;
+        public static InputSimulationBridge Instance { get { ... } }
+        
+        // Coroutine-based sequence execution
+        public string StartSequence(List<SequenceStep> steps) { ... }
+        public SequenceJobState GetJobState(string jobId) { ... }
+        
+        [RuntimeInitializeOnLoadMethod]
+        static void AutoCreate() { ... }
+    }
+}
+```
+
+Sequence lifecycle (static callback pattern — Editor calls Bridge directly):
+1. `ManageInputSimulation.HandleCommand` receives `action=sequence`
+2. Parses `steps[]` array, validates count <=100
+3. Calls `InputSimulationBridge.StartSequence(steps)` — static method, both on main thread during Play Mode
+4. Bridge.StartCoroutine internally, returns job_id
+5. Returns `SuccessResponse("Sequence started", { job_id, status: "running", total_steps })`
+6. Client polls with `action=status&job_id=xxx`
+7. Bridge executes steps as coroutine (each step calls action handler directly), updating state dict
+8. Status returns current_step, total, status (running/completed/failed/error)
+
+## Related Code Files
+
+### Create
+- `MCPForUnity/Editor/Tools/InputSimulation/InputSimulationTouch.cs`
+- `MCPForUnity/Runtime/InputSimulationBridge.cs`
+
+### Modify
+- `MCPForUnity/Editor/Tools/ManageInputSimulation.cs` — wire touch_tap/swipe/pinch/sequence/status actions
+
+### Read (reference)
+- `MCPForUnity/Editor/Tools/RunTests.cs` — async job pattern
+- `MCPForUnity/Editor/Resources/Tests/` — TestJobManager pattern (for sequence job tracking)
+
+## Implementation Steps
+
+1. Create `InputSimulationTouch.cs`:
+   - `#if UNITY_INPUT_SYSTEM` guard
+   - `SimulateTouch(int fingerId, Vector2 pos, UnityEngine.InputSystem.TouchPhase phase)`:
+     - Create `TouchState` struct, set `touchId`, `position`, `phase`
+     - `InputState.Change(Touchscreen.current.touches[fingerId], touchState)`
+   - `TouchTap(ToolParams p)`:
+     - Resolve target → screen coords
+     - SimulateTouch(0, pos, Began) → SimulateTouch(0, pos, Ended)
+     - Return SuccessResponse
+   - `TouchSwipe(ToolParams p)`:
+     - Resolve from_target, to_target
+     - For sync (non-sequence): Begin at from, Ended at to (instant)
+     - For sequence: intermediate Moved phases handled by bridge coroutine
+   - `TouchPinch(ToolParams p)`:
+     - Resolve center_target
+     - Two fingers: center ± (distance/2, 0)
+     - Begin both → interpolate distances → End both
+   - `#else` block: all methods return `TouchNotSupported()` error
+
+2. Create `InputSimulationBridge.cs` in `MCPForUnity/Runtime/`:
+   - Namespace: `MCPForUnity.Runtime`
+   - Singleton MonoBehaviour with `DontDestroyOnLoad`
+   - `[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]` for auto-creation
+   - Data classes:
+     ```csharp
+     public class SequenceStep { public string Action; public JObject Params; public int DelayMs; }
+     public class SequenceJobState { public string JobId; public string Status; public int CurrentStep; public int TotalSteps; public string Error; }
+     ```
+   - `Dictionary<string, SequenceJobState> _jobs`
+   - `StartSequence(List<SequenceStep> steps)`: generate GUID job_id, start coroutine, return job_id
+   - Coroutine: iterate steps, for each: execute action via `CommandRegistry.InvokeCommandAsync()`, wait `DelayMs`, update state
+   - `GetJobState(string jobId)`: return current state or null
+   - Timeout: cancel coroutine after 60s
+
+3. Wire into `ManageInputSimulation.cs`:
+   - Add cases: `touch_tap`, `touch_swipe`, `touch_pinch` → `InputSimulationTouch` methods
+   - Add case: `sequence` → parse steps array, validate count <=100, call bridge
+   - Add case: `status` → call bridge `GetJobState`, return state
+   - Note: `sequence` and `status` do NOT need `#if` guard — they dispatch to individual actions that have their own guards
+
+4. Add `MCPForUnity.Runtime` assembly reference in Editor asmdef if not already present
+
+## Todo
+
+- [ ] Create `InputSimulationTouch.cs` with `#if UNITY_INPUT_SYSTEM` guard
+- [ ] Implement `SimulateTouch()` helper
+- [ ] Implement `TouchTap` action
+- [ ] Implement `TouchSwipe` action
+- [ ] Implement `TouchPinch` action
+- [ ] Create `InputSimulationBridge.cs` Runtime MonoBehaviour
+- [ ] Implement singleton auto-creation
+- [ ] Implement `StartSequence()` with coroutine
+- [ ] Implement `GetJobState()` for polling
+- [ ] Implement sequence timeout (60s)
+- [ ] Wire touch_tap/swipe/pinch/sequence/status into ManageInputSimulation.cs
+- [ ] Check Editor asmdef references Runtime asmdef
+- [ ] Verify compilation with and without Input System
+
+## Success Criteria
+
+- Touch actions work with New Input System Touchscreen device
+- Touch actions return clear error without Input System package
+- Sequence starts, returns job_id, polls status showing progress
+- Sequence completes and reports success with step count
+- Sequence errors caught and reported via status
+- 60s timeout terminates stuck sequences
+
+## Risk Assessment
+
+| Risk | L | I | Score | Mitigation |
+|------|---|---|-------|------------|
+| Touchscreen.current null in Editor | 3 | 4 | 12 | Check device exists; add virtual touchscreen via `InputSystem.AddDevice<Touchscreen>()` |
+| Coroutine timing in Editor update loop | 2 | 3 | 6 | Use `WaitForSeconds` in coroutine; Play Mode guarantees game loop |
+| CommandRegistry.InvokeCommandAsync from Runtime assembly | 3 | 3 | 9 | Bridge stores action+params; Editor code drives execution from update callback |
+| Sequence steps reference self recursively | 2 | 3 | 6 | Disallow "sequence" as a step action |
+
+## Timeline
+
+Effort: M (medium) — ~4 hours. Touch is straightforward with InputState. Sequence needs careful coroutine/job management but pattern exists in RunTests.

--- a/plans/260402-1302-input-simulation-tool/phase-04-python-mcp-tool-cli.md
+++ b/plans/260402-1302-input-simulation-tool/phase-04-python-mcp-tool-cli.md
@@ -1,0 +1,207 @@
+---
+phase: 4
+status: pending
+effort: M
+blocked_by: [1]
+---
+
+# Phase 4: Python MCP Tool + CLI
+
+## Context Links
+
+- Pattern: `Server/src/services/tools/manage_input_system.py` — single composite tool, param routing, `send_with_unity_instance`
+- Pattern: `Server/src/services/tools/run_tests.py` — complex tool with models, polling support
+- Pattern: `Server/src/services/registry/tool_registry.py` — `@mcp_for_unity_tool` decorator, `group` param, TOOL_GROUPS
+- Pattern: `Server/src/cli/commands/editor.py` — Click commands, `@handle_unity_errors`, `run_command`, `format_output`
+- Pattern: `Server/src/cli/main.py:248-280` — `optional_commands` list for CLI registration
+
+## Overview
+
+Create the Python MCP tool that exposes all input simulation actions to AI assistants, plus CLI commands for manual developer use.
+
+## Key Insights
+
+- Python tool is a thin pass-through: validate params Python-side, serialize to JSON, send to Unity C#, return response.
+- Use `Annotated[Literal[...], "..."]` for `action` param to enumerate all valid actions.
+- The `target` param is a JSON object with `mode` + mode-specific fields. Python type: `dict | None`.
+- For `sequence`, the `steps` param is a list of dicts.
+- CLI commands: one `@click.group()` called `input_simulation` with subcommands for each action.
+- CLI uses `run_command("manage_input_simulation", params, config)` — same pattern as all other CLI commands.
+
+## Requirements
+
+### Functional
+- `manage_input_simulation` MCP tool with all 15 actions as Literal type
+- All target params accept JSON object `{ "mode": "...", ... }`
+- `sequence` param `steps` is `list[dict]`
+- CLI group `input-simulation` with subcommands: discover, bounds, click, double-click, move, drag, scroll, key, combo, text, tap, swipe, pinch, sequence, status
+- Tool description lists all actions concisely
+
+### Non-Functional
+- Group: `"testing"` (matches C# side)
+- `ToolAnnotations(title="Manage Input Simulation", destructiveHint=True)` — simulating input can change game state
+- CLI subcommand names use hyphens (click convention), but send snake_case actions to Unity
+
+## Architecture
+
+```python
+# manage_input_simulation.py
+@mcp_for_unity_tool(
+    group="testing",
+    description="Play Mode input simulation. Actions: discover, get_element_bounds, "
+                "click, double_click, mouse_move, drag, scroll, "
+                "key_press, key_combo, text_input, "
+                "touch_tap, touch_swipe, touch_pinch, sequence, status.",
+    annotations=ToolAnnotations(title="Manage Input Simulation", destructiveHint=True),
+)
+async def manage_input_simulation(
+    ctx: Context,
+    action: Annotated[Literal[...], "Action to perform"],
+    target: Annotated[dict, "Target spec"] | None = None,
+    # ... per-action optional params
+) -> dict[str, Any]:
+    ...
+```
+
+```python
+# input_simulation.py (CLI)
+@click.group()
+def input_simulation():
+    """Input simulation — interact with running Unity games."""
+    pass
+
+@input_simulation.command("click")
+@click.option("--target", "-t", required=True, help="Target JSON")
+@click.option("--button", "-b", default="left")
+@handle_unity_errors
+def click_cmd(target, button):
+    ...
+```
+
+## Related Code Files
+
+### Create
+- `Server/src/services/tools/manage_input_simulation.py`
+- `Server/src/cli/commands/input_simulation.py`
+
+### Modify
+- `Server/src/cli/main.py` — add to `optional_commands` list
+
+### Read (reference)
+- `Server/src/services/tools/manage_input_system.py`
+- `Server/src/services/tools/run_tests.py`
+- `Server/src/cli/commands/editor.py`
+
+## Implementation Steps
+
+1. Create `Server/src/services/tools/manage_input_simulation.py`:
+   - Imports: `Annotated, Any, Literal`, `Context`, `ToolAnnotations`, registry, transport
+   - `@mcp_for_unity_tool(group="testing", description=..., annotations=...)`
+   - Function signature with all params:
+     ```python
+     async def manage_input_simulation(
+         ctx: Context,
+         action: Annotated[Literal[
+             "discover", "get_element_bounds",
+             "click", "double_click", "mouse_move", "drag", "scroll",
+             "key_press", "key_combo", "text_input",
+             "touch_tap", "touch_swipe", "touch_pinch",
+             "sequence", "status"
+         ], "Action to perform"],
+         target: Annotated[dict, "Target: {mode:'coordinates'|'gameobject'|'ui_element'|'anchor', ...}"] | None = None,
+         from_target: Annotated[dict, "Source target for drag/swipe"] | None = None,
+         to_target: Annotated[dict, "Destination target for drag/swipe"] | None = None,
+         center_target: Annotated[dict, "Center target for pinch"] | None = None,
+         button: Annotated[str, "Mouse button: left, right, middle"] | None = None,
+         key: Annotated[str, "Key name (e.g. space, a, escape)"] | None = None,
+         modifiers: Annotated[list[str], "Modifier keys (ctrl, shift, alt)"] | None = None,
+         mode: Annotated[str, "Key mode: press, release, tap"] | None = None,
+         text: Annotated[str, "Text to type"] | None = None,
+         delta_x: Annotated[float, "Scroll delta X"] | None = None,
+         delta_y: Annotated[float, "Scroll delta Y"] | None = None,
+         duration_ms: Annotated[int, "Duration in ms for drag/swipe/pinch"] | None = None,
+         start_distance: Annotated[float, "Start distance for pinch (px)"] | None = None,
+         end_distance: Annotated[float, "End distance for pinch (px)"] | None = None,
+         steps: Annotated[list[dict], "Sequence steps [{action, params, delay_ms}]"] | None = None,
+         job_id: Annotated[str, "Job ID for status polling"] | None = None,
+         flush: Annotated[bool, "Flush input immediately (default true)"] | None = None,
+         capture_after: Annotated[bool, "Take screenshot after action (default false)"] | None = None,
+         filter: Annotated[str, "Filter for discover (substring match)"] | None = None,
+         page_size: Annotated[int, "Max results (default 50)"] | None = None,
+         cursor: Annotated[int, "Pagination cursor"] | None = None,
+     ) -> dict[str, Any]:
+     ```
+   - Body: build params dict, strip None values, send via `send_with_unity_instance`
+   - Response handling: same pattern as `manage_input_system.py`
+
+2. Create `Server/src/cli/commands/input_simulation.py`:
+   - `@click.group()` named `input_simulation`
+   - Helper: `_build_target(target_json: str) -> dict` — parse JSON string to dict
+   - Subcommands:
+     - `discover` — `--filter`, `--page-size`, `--cursor`
+     - `bounds` — `--target` (required)
+     - `click` — `--target` (required), `--button`
+     - `double-click` — `--target`, `--button`
+     - `move` — `--target`
+     - `drag` — `--from`, `--to`, `--duration`
+     - `scroll` — `--target`, `--dx`, `--dy`
+     - `key` — `KEY_NAME`, `--mode`
+     - `combo` — `KEY_NAME`, `--mod` (multiple)
+     - `text` — `TEXT`
+     - `tap` — `--target`
+     - `swipe` — `--from`, `--to`, `--duration`
+     - `pinch` — `--center`, `--start-dist`, `--end-dist`, `--duration`
+     - `sequence` — `STEPS_JSON`
+     - `status` — `JOB_ID`
+   - Each subcommand: parse args, build params dict, `run_command("manage_input_simulation", params, config)`, format output
+
+3. Add to `Server/src/cli/main.py` `optional_commands`:
+   ```python
+   ("cli.commands.input_simulation", "input_simulation"),
+   ```
+
+## Todo
+
+- [ ] Create `manage_input_simulation.py` MCP tool
+- [ ] Define all action Literal types
+- [ ] Define all optional params with Annotated types
+- [ ] Implement param building and Unity send
+- [ ] Create `input_simulation.py` CLI group
+- [ ] Implement `discover` subcommand
+- [ ] Implement `bounds` subcommand
+- [ ] Implement `click` subcommand
+- [ ] Implement `double-click` subcommand
+- [ ] Implement `move` subcommand
+- [ ] Implement `drag` subcommand
+- [ ] Implement `scroll` subcommand
+- [ ] Implement `key` subcommand
+- [ ] Implement `combo` subcommand
+- [ ] Implement `text` subcommand
+- [ ] Implement `tap` subcommand
+- [ ] Implement `swipe` subcommand
+- [ ] Implement `pinch` subcommand
+- [ ] Implement `sequence` subcommand
+- [ ] Implement `status` subcommand
+- [ ] Register CLI in `main.py`
+- [ ] Run `cd Server && uv run python -c "import services.tools.manage_input_simulation"` to verify import
+
+## Success Criteria
+
+- `manage_input_simulation` tool appears in FastMCP tool listing under "testing" group
+- All 15 actions accepted by Literal type
+- None params stripped before send
+- CLI group registers without errors
+- Each CLI subcommand sends correct action + params to Unity
+- Import succeeds without errors
+
+## Risk Assessment
+
+| Risk | L | I | Score | Mitigation |
+|------|---|---|-------|------------|
+| Too many params on one tool signature | 2 | 2 | 4 | Common pattern in codebase; AI assistants handle well |
+| CLI target JSON parsing errors | 3 | 2 | 6 | Use `parse_json_dict_or_exit` from existing utils |
+| Forgetting to register CLI in main.py | 1 | 3 | 3 | Explicit step in checklist |
+
+## Timeline
+
+Effort: M (medium) — ~3-4 hours. MCP tool is straightforward mirroring. CLI has many subcommands but each is boilerplate.

--- a/plans/260402-1302-input-simulation-tool/phase-05-tests.md
+++ b/plans/260402-1302-input-simulation-tool/phase-05-tests.md
@@ -1,0 +1,99 @@
+---
+phase: 5
+status: pending
+effort: S
+blocked_by: [4]
+---
+
+# Phase 5: Tests
+
+## Context Links
+
+- Pattern: `Server/tests/integration/test_manage_input_system.py` — monkeypatch `async_send_command_with_retry`, DummyContext, captured params
+- Pattern: `Server/tests/integration/test_helpers.py` — `DummyContext` class
+- Test command: `cd Server && uv run pytest tests/integration/test_manage_input_simulation.py -v`
+
+## Overview
+
+Python integration tests for the MCP tool. Tests verify parameter routing (correct action + params sent to Unity) and error handling. These do NOT test actual Unity input simulation — that requires a running Unity instance.
+
+## Key Insights
+
+- Existing test pattern: monkeypatch `async_send_command_with_retry` on the tool module, capture `cmd` and `params`, verify routing.
+- `_fake_send_factory(captured, response)` — reusable factory for mock send functions.
+- Each test: construct DummyContext, call tool function directly, assert captured params.
+- Also test: None params stripped, Python exception caught, target dict serialized correctly.
+
+## Requirements
+
+### Functional
+- Test each action routes correct `action` param
+- Test target dict passes through correctly
+- Test optional params stripped when None
+- Test Python exception returns `success: False`
+- Test sequence `steps` list passes through
+- Test `job_id` param for status action
+
+### Non-Functional
+- File: `Server/tests/integration/test_manage_input_simulation.py`
+- Use `pytest.mark.asyncio`
+- Follow exact pattern from `test_manage_input_system.py`
+
+## Implementation Steps
+
+1. Create `Server/tests/integration/test_manage_input_simulation.py`
+2. Import helpers:
+   ```python
+   import pytest
+   from .test_helpers import DummyContext
+   import services.tools.manage_input_simulation as sim_mod
+   ```
+3. Create `_fake_send_factory` (copy pattern from test_manage_input_system.py)
+4. Implement tests:
+   - `test_discover` — action="discover", verify filter/page_size pass through
+   - `test_get_element_bounds` — action="get_element_bounds", target dict
+   - `test_click` — action="click", target + button
+   - `test_double_click` — action="double_click", target
+   - `test_mouse_move` — action="mouse_move", target
+   - `test_drag` — action="drag", from_target + to_target + duration_ms
+   - `test_scroll` — action="scroll", target + delta_x + delta_y
+   - `test_key_press` — action="key_press", key + mode
+   - `test_key_combo` — action="key_combo", modifiers + key
+   - `test_text_input` — action="text_input", text
+   - `test_touch_tap` — action="touch_tap", target
+   - `test_touch_swipe` — action="touch_swipe", from_target + to_target
+   - `test_touch_pinch` — action="touch_pinch", center_target + distances
+   - `test_sequence` — action="sequence", steps list
+   - `test_status` — action="status", job_id
+   - `test_none_params_stripped` — call with minimal params, verify only non-None in captured
+   - `test_python_exception_caught` — monkeypatch raising send, verify error response
+   - `test_target_dict_passthrough` — verify target dict serialized as-is
+
+## Todo
+
+- [ ] Create test file
+- [ ] Implement `_fake_send_factory`
+- [ ] Implement per-action routing tests (15 actions)
+- [ ] Implement `test_none_params_stripped`
+- [ ] Implement `test_python_exception_caught`
+- [ ] Implement `test_target_dict_passthrough`
+- [ ] Run `cd Server && uv run pytest tests/integration/test_manage_input_simulation.py -v`
+- [ ] Verify all tests pass
+
+## Success Criteria
+
+- 18+ tests covering all actions + edge cases
+- All tests pass with `uv run pytest`
+- No test depends on running Unity instance
+- Tests follow exact same pattern as existing test files
+
+## Risk Assessment
+
+| Risk | L | I | Score | Mitigation |
+|------|---|---|-------|------------|
+| monkeypatch target differs due to import path change | 2 | 2 | 4 | Verify import matches: `sim_mod.async_send_command_with_retry` |
+| DummyContext missing required fields for new tool | 1 | 2 | 2 | DummyContext is generic; no tool-specific fields needed |
+
+## Timeline
+
+Effort: S (small) — ~1-2 hours. Pattern is well-established; mostly boilerplate per action.

--- a/plans/260402-1302-input-simulation-tool/plan.md
+++ b/plans/260402-1302-input-simulation-tool/plan.md
@@ -1,0 +1,105 @@
+---
+status: completed
+created: 2026-04-02
+branch: feat/update-tools
+base: beta
+---
+
+# Plan: manage_input_simulation Tool
+
+Play Mode input simulation tool for Unity MCP. Lets AI assistants click, type, drag, touch, and sequence interactions in running Unity games.
+
+## Phases
+
+| # | Phase | Scope | Status | Effort | Blocked By |
+|---|-------|-------|--------|--------|------------|
+| 1 | C# Target Resolution + Discovery | `ManageInputSimulation.cs`, `InputTargetResolver.cs` | pending | M | -- |
+| 2 | C# Mouse + Keyboard Simulation | `InputSimulationActions.cs` (mouse/kb methods) | pending | L | Phase 1 |
+| 3 | C# Touch + Sequence Mode | `InputSimulationTouch.cs`, `InputSimulationBridge.cs` | pending | M | Phase 2 |
+| 4 | Python MCP Tool + CLI | `manage_input_simulation.py`, `input_simulation.py` (CLI) | pending | M | Phase 1 |
+| 5 | Tests | `test_manage_input_simulation.py` | pending | S | Phase 4 |
+
+## Files to Create
+
+| File | Owner | Phase |
+|------|-------|-------|
+| `MCPForUnity/Editor/Tools/ManageInputSimulation.cs` | Phase 1-3 | Main handler + action dispatch |
+| `MCPForUnity/Editor/Tools/InputSimulation/InputTargetResolver.cs` | Phase 1 | Target resolution (coords/GO/UI/anchor -> screen) |
+| `MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs` | Phase 2 | Mouse + keyboard injection |
+| `MCPForUnity/Editor/Tools/InputSimulation/InputSimulationTouch.cs` | Phase 3 | Touch actions |
+| `MCPForUnity/Runtime/InputSimulationBridge.cs` | Phase 3 | Runtime MonoBehaviour for sequences |
+| `Server/src/services/tools/manage_input_simulation.py` | Phase 4 | Python MCP tool |
+| `Server/src/cli/commands/input_simulation.py` | Phase 4 | CLI commands |
+| `Server/tests/integration/test_manage_input_simulation.py` | Phase 5 | Integration tests |
+
+## Files to Modify
+
+| File | Change | Phase |
+|------|--------|-------|
+| `Server/src/cli/main.py` | Add `("cli.commands.input_simulation", "input_simulation")` to `optional_commands` | Phase 4 |
+
+## Architecture
+
+```
+AI ─► Python manage_input_simulation ─► WebSocket ─► C# ManageInputSimulation
+  HandleCommand dispatches by action:
+  ├─ discover / get_element_bounds → InputTargetResolver
+  ├─ click / double_click / mouse_move / drag / scroll → InputSimulationActions
+  ├─ key_press / key_combo / text_input → InputSimulationActions
+  ├─ touch_tap / touch_swipe / touch_pinch → InputSimulationTouch
+  └─ sequence → InputSimulationBridge (async polling)
+```
+
+Target resolution chain:
+- `coordinates` → direct (x, y) passthrough
+- `gameobject` → `GameObjectLookup.FindByTarget()` → `Renderer.bounds` → `Camera.main.WorldToScreenPoint()`
+- `ui_element` → find `Selectable`/`VisualElement` → `RectTransformUtility.WorldToScreenPoint()`
+- `anchor` → screen percentage (center/top_left/etc.) + pixel offset
+
+## Conditional Compilation Strategy
+
+ManageInputSimulation.cs outer file: no #if guard (always compiles).
+InputSimulationActions.cs and InputSimulationTouch.cs: `#if UNITY_INPUT_SYSTEM` blocks for New Input System path; `#else` blocks for legacy EventSystem fallback.
+
+## Validation Decisions (2026-04-02)
+
+| Question | Decision |
+|----------|----------|
+| Input flush after InputState.Change | Configurable `flush` param (default true = call InputSystem.Update() immediately) |
+| Runtime assembly for Bridge | Keep in Runtime (as planned). JObject dep acceptable |
+| Legacy Input support | Keep (as planned). Partial coverage via ExecuteEvents |
+| Tool count | Single tool with 16 actions (as planned) |
+| Camera for WorldToScreenPoint | Camera.main default + optional `camera_name`/`camera_tag` in target spec |
+| Editor↔Runtime communication | Static callback pattern — Editor calls Bridge.StartSequence() directly |
+| Discovery scope | UI elements (Selectable, VisualElement) + ALL GameObjects with Colliders, paginated |
+| Visual feedback | Optional `capture_after` param — returns base64 screenshot in response when true |
+
+## Dependencies
+
+- `MCPForUnity.Editor.Helpers` (ToolParams, Response, Pagination, GameObjectLookup)
+- `UnityEngine.InputSystem` (optional, via conditional compilation)
+- `UnityEngine.EventSystems` (for legacy fallback)
+- `MCPForUnity.Runtime` assembly (for InputSimulationBridge)
+
+## Risk Assessment
+
+| Risk | L | I | Score | Mitigation |
+|------|---|---|-------|------------|
+| Legacy Input.GetKey() unfakeable | 4 | 3 | 12 | Document limitation; legacy only covers UI via ExecuteEvents |
+| Screen coords fragile across resolutions | 3 | 3 | 9 | Default to name-based targeting; anchor system |
+| Play Mode guard forgotten | 2 | 4 | 8 | Central guard in HandleCommand — single check |
+| ManageInputSimulation.cs exceeds 200 lines | 4 | 2 | 8 | Split into InputSimulation/ subfolder helpers |
+| Sequence async polling complexity | 3 | 3 | 9 | Reuse proven RunTests/TestJobManager pattern |
+| Touch requires InputSystem package | 3 | 2 | 6 | #if guard; clear error when missing |
+| InputSimulationBridge needs Runtime assembly ref | 2 | 3 | 6 | Reference MCPForUnity.Runtime from Editor asmdef |
+
+## Timeline
+
+| Phase | Effort | Notes |
+|-------|--------|-------|
+| Phase 1 | M | Foundation — target resolution + discovery |
+| Phase 2 | L | Most actions — mouse/keyboard + dual backend |
+| Phase 3 | M | Touch + async sequence |
+| Phase 4 | M | Python side — straightforward mirroring |
+| Phase 5 | S | Test patterns well-established |
+| **Total** | **~L** | Critical path: 1 → 2 → 3; Phase 4 can start after Phase 1 |


### PR DESCRIPTION
## Summary
- Add `manage_input_simulation` MCP tool with 16 actions for Play Mode input simulation
- Mouse (click, double-click, drag, scroll, move), keyboard (key press, combo, text input), touch (tap, swipe, pinch)
- 4 target modes: coordinates, gameobject path, UI element query, screen anchors
- Dual backend: New Input System (full) + Legacy EventSystem (partial)
- Async sequence execution with polling for multi-step input chains
- Discovery action to find all interactable elements (UGUI, 3D/2D colliders)
- 20 Python integration tests (all passing)

## Files
- C#: `ManageInputSimulation.cs` + `InputSimulation/` subfolder (6 files) + `InputSimulationBridge.cs` (Runtime)
- Python: `manage_input_simulation.py` (MCP tool) + `input_simulation.py` (CLI) + tests
- Modified: `cli/main.py` (CLI registration)

## Test plan
- [x] 20/20 Python integration tests pass
- [ ] Unity compilation verification (requires Unity Editor)
- [ ] Manual Play Mode testing with actual game