### PR TITLE
fix(dots): add missing await to get_unity_instance_from_context in 4 DOTS tool files

### DIFF
--- a/Server/src/services/tools/manage_dots.py
+++ b/Server/src/services/tools/manage_dots.py
@@ -89,7 +89,7 @@ async def manage_dots(
     page_size: Annotated[int, "Max entities/types to return (default 20, max 200)"] | None = None,
     limit: Annotated[int, "Max archetypes in performance_snapshot (default 20)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_dots_graphics.py
+++ b/Server/src/services/tools/manage_dots_graphics.py
@@ -44,7 +44,7 @@ async def manage_dots_graphics(
     world: Annotated[str, "Target world name"] | None = None,
     page_size: Annotated[int, "Max results to return (default 20)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_dots_physics.py
+++ b/Server/src/services/tools/manage_dots_physics.py
@@ -50,7 +50,7 @@ async def manage_dots_physics(
     world: Annotated[str, "Target world name"] | None = None,
     page_size: Annotated[int, "Max results to return (default 20)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_dots_subscene.py
+++ b/Server/src/services/tools/manage_dots_subscene.py
@@ -40,7 +40,7 @@ async def manage_dots_subscene(
     # SubScene identification
     scene_name: Annotated[str, "SubScene name or GameObject name (for load/unload/status/sections)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,


### PR DESCRIPTION
## Summary

- All four DOTS tool handlers were calling `get_unity_instance_from_context(ctx)` without `await`, causing `'coroutine' object has no attribute 'strip'` at runtime on every DOTS tool invocation
- `get_unity_instance_from_context` is declared `async def` in `tools/__init__.py`, so all call sites must `await` it
- Fixes are surgical — only the missing `await` keyword was added, no other changes

## Changed files

| File | Line | Before | After |
|---|---|---|---|
| `Server/src/services/tools/manage_dots.py` | 92 | `unity_instance = get_unity_instance_from_context(ctx)` | `unity_instance = await get_unity_instance_from_context(ctx)` |
| `Server/src/services/tools/manage_dots_subscene.py` | 43 | `unity_instance = get_unity_instance_from_context(ctx)` | `unity_instance = await get_unity_instance_from_context(ctx)` |
| `Server/src/services/tools/manage_dots_graphics.py` | 47 | `unity_instance = get_unity_instance_from_context(ctx)` | `unity_instance = await get_unity_instance_from_context(ctx)` |
| `Server/src/services/tools/manage_dots_physics.py` | 53 | `unity_instance = get_unity_instance_from_context(ctx)` | `unity_instance = await get_unity_instance_from_context(ctx)` |

**Reference correct pattern:** `manage_components.py:72` — `unity_instance = await get_unity_instance_from_context(ctx)`

## Test plan

- [x] `python -m py_compile` passes for all 4 changed files (syntax verified)
- [x] Integration tests exist at `Server/tests/integration/test_manage_dots*.py` for all 4 tools
- [ ] Integration tests could not be run locally — `pytest-asyncio` is missing from dev dependencies (tests use `@pytest.mark.asyncio` but `pyproject.toml` does not list `pytest-asyncio`). This is a pre-existing infrastructure gap unrelated to this fix.
- Recommend follow-up: add `pytest-asyncio` to `[project.optional-dependencies]` dev group so CI can run the DOTS integration tests

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)