### PR TITLE
fix(rendering_stats): add missing await on get_unity_instance_from_context

### DIFF
--- a/Server/src/services/tools/rendering_stats.py
+++ b/Server/src/services/tools/rendering_stats.py
@@ -54,7 +54,7 @@ async def rendering_stats(
     include_csv: Annotated[bool | None, "For get_session_report: include CSV data."] = True,
     filename: Annotated[str | None, "For load_session/analyze_session: session JSON filename."] = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params: dict[str, Any] = {"action": action}
     if frames is not None:


### PR DESCRIPTION
## Summary

- `rendering_stats` tool was calling `get_unity_instance_from_context(ctx)` without `await`, causing `'coroutine' object has no attribute 'strip'` on every invocation
- Same root cause class as #5 / PR #6 (which patched 4 DOTS tools — `manage_dots*.py`)
- This extends the fix to the 5th affected tool

## Changed files

| File | Line | Before | After |
|---|---|---|---|
| `Server/src/services/tools/rendering_stats.py` | 57 | `unity_instance = get_unity_instance_from_context(ctx)` | `unity_instance = await get_unity_instance_from_context(ctx)` |

**Reference correct pattern:** `manage_components.py:72`, plus the 4 files fixed in PR #6.

## Test plan

- [x] `python3 -m py_compile Server/src/services/tools/rendering_stats.py` passes (syntax verified)
- [ ] Manual MCP smoke (`mcp__UnityMCP__rendering_stats` action=get_stats / get_stats_aggregated / get_system_stats) once branch deploys
- See PR #6 note re: `pytest-asyncio` missing from dev deps — integration test rig still gap, not introduced by this fix

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>