### PR TITLE
feat(transport): classify per-exception errors in MCP tool response path

### DIFF
--- a/Server/src/transport/unity_transport.py
+++ b/Server/src/transport/unity_transport.py
@@ -1,6 +1,7 @@
 """Transport helpers for routing commands to Unity."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Awaitable, Callable, TypeVar
 
@@ -84,11 +85,38 @@ async def send_with_unity_instance(
                 retry_on_reload=retry_on_reload,
             )
             return normalize_unity_response(raw)
+        except asyncio.TimeoutError:
+            return normalize_unity_response(MCPResponse(
+                success=False,
+                error="unity_request_timeout",
+                message=(
+                    "Unity did not respond in time. Common causes: "
+                    "(1) Unity is mid-domain-reload — wait, check "
+                    "Library/ScriptAssemblies/*.dll mtime, "
+                    "(2) Unity main thread is busy with a long operation "
+                    "(script compile, asset import, scene bake), "
+                    "(3) the bridge socket died — check Unity console and "
+                    "Window > MCP for Unity panel. "
+                    "Inspect Unity Editor BEFORE retrying."
+                ),
+                hint="diagnose_then_retry",
+            ).model_dump())
+        except (ConnectionRefusedError, ConnectionResetError):
+            return normalize_unity_response(MCPResponse(
+                success=False,
+                error="unity_unreachable",
+                message=(
+                    "Unity is not reachable. The MCP bridge is either not "
+                    "running or has crashed. Open Unity Editor → Window > "
+                    "MCP for Unity > Start Session. Do NOT kill or restart "
+                    "the Unity Editor process to recover this — the bridge "
+                    "can be restarted from inside the running Editor."
+                ),
+                hint="restart_bridge",
+            ).model_dump())
         except Exception as exc:
-            # NOTE: asyncio.TimeoutError has an empty str() by default, which is confusing for clients.
+            # Truly unknown — preserve previous wrapping for backward-compat.
             err = str(exc) or f"{type(exc).__name__}"
-            # Fail fast with a retry hint instead of hanging for COMMAND_TIMEOUT.
-            # The client can decide whether retrying is appropriate for the command.
             return normalize_unity_response(
                 MCPResponse(success=False, error=err,
                             hint="retry").model_dump()

--- a/Server/tests/test_unity_transport_classification.py
+++ b/Server/tests/test_unity_transport_classification.py
@@ -1,0 +1,120 @@
+"""
+Tests for per-exception classification in unity_transport.send_with_unity_instance.
+
+Each test mocks PluginHub.send_command_for_instance to raise a specific
+exception class and asserts the classified MCPResponse fields come back
+with the expected error, hint, and (where applicable) message.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from transport.unity_transport import send_with_unity_instance
+
+
+async def _noop_send_fn(*args, **kwargs):  # pragma: no cover - unused
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _force_http_transport(monkeypatch):
+    """All classification tests run on the HTTP branch."""
+    from core.config import config as global_config
+    monkeypatch.setattr(global_config, "transport_mode", "http")
+    monkeypatch.setattr(global_config, "http_remote_hosted", False)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_timeout_error_is_classified_as_unity_request_timeout():
+    with patch(
+        "transport.unity_transport.PluginHub.send_command_for_instance",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        mock_send.side_effect = asyncio.TimeoutError()
+
+        response = await send_with_unity_instance(
+            _noop_send_fn, None, "ping", {},
+        )
+
+    assert response["success"] is False
+    assert response["error"] == "unity_request_timeout"
+    assert response["hint"] == "diagnose_then_retry"
+    assert response["message"] is not None
+    assert "domain-reload" in response["message"]
+    assert "Inspect Unity Editor BEFORE retrying" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_connection_refused_is_classified_as_unity_unreachable():
+    with patch(
+        "transport.unity_transport.PluginHub.send_command_for_instance",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        mock_send.side_effect = ConnectionRefusedError("no route")
+
+        response = await send_with_unity_instance(
+            _noop_send_fn, None, "ping", {},
+        )
+
+    assert response["success"] is False
+    assert response["error"] == "unity_unreachable"
+    assert response["hint"] == "restart_bridge"
+    assert response["message"] is not None
+    assert "Do NOT kill or restart the Unity Editor process" in response["message"]
+
+
+@pytest.mark.asyncio
+async def test_connection_reset_is_classified_as_unity_unreachable():
+    with patch(
+        "transport.unity_transport.PluginHub.send_command_for_instance",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        mock_send.side_effect = ConnectionResetError("peer closed")
+
+        response = await send_with_unity_instance(
+            _noop_send_fn, None, "ping", {},
+        )
+
+    assert response["success"] is False
+    assert response["error"] == "unity_unreachable"
+    assert response["hint"] == "restart_bridge"
+
+
+@pytest.mark.asyncio
+async def test_generic_runtime_error_preserves_backward_compat_wrapping():
+    with patch(
+        "transport.unity_transport.PluginHub.send_command_for_instance",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        mock_send.side_effect = RuntimeError("custom message")
+
+        response = await send_with_unity_instance(
+            _noop_send_fn, None, "ping", {},
+        )
+
+    assert response["success"] is False
+    assert response["error"] == "custom message"
+    assert response["hint"] == "retry"
+
+
+@pytest.mark.asyncio
+async def test_empty_str_exception_falls_back_to_type_name():
+    class _SilentError(Exception):
+        def __str__(self) -> str:
+            return ""
+
+    with patch(
+        "transport.unity_transport.PluginHub.send_command_for_instance",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        mock_send.side_effect = _SilentError()
+
+        response = await send_with_unity_instance(
+            _noop_send_fn, None, "ping", {},
+        )
+
+    assert response["success"] is False
+    assert response["error"] == "_SilentError"
+    assert response["hint"] == "retry"


### PR DESCRIPTION
## Problem

`Server/src/transport/unity_transport.py:87-95` wraps every exception from the MCP tool transport path into a single generic `MCPResponse(success=False, error=str(exc), hint="retry")`. For empty-`str()` exceptions (e.g. `asyncio.TimeoutError`), it substitutes the type name. Downstream MCP clients (Claude Code sessions, etc.) see useless messages like `error="TimeoutError"` or `error="[WinError 10061] No connection could be made..."` with no actionable guidance.

CLI-side connection handling in `Server/src/cli/utils/connection.py:110-126` already classifies `httpx.ConnectError` / `TimeoutException` / `HTTPStatusError` distinctly. This PR brings the same discipline to the MCP tool path.

## Fix

Replace the single `except Exception` with per-exception handlers in order:

1. **`asyncio.TimeoutError`** → `error="unity_request_timeout"`, `hint="diagnose_then_retry"`, with a message listing the 3 most common diagnostic paths (mid-domain-reload, main-thread-busy, bridge-dead).
2. **`ConnectionRefusedError` / `ConnectionResetError`** → `error="unity_unreachable"`, `hint="restart_bridge"`, with a message that explicitly tells the caller NOT to kill the Unity Editor process (the bridge restarts from inside the Editor).
3. **Generic `Exception`** (fallthrough) → preserves the previous `error=str(exc) or type(exc).__name__`, `hint="retry"` for backward compat with unknown exception types.

The `error` field changes for known exception types — downstream parsers keying on string-equality of `error` may need updates. The `hint` field gains new values (`diagnose_then_retry`, `restart_bridge`). The `message` field is new on the classified responses (was absent in the generic catch-all).

## Test plan

- 5 new pytest cases covering all 3 classified paths + fallthrough + empty-str() edge case (see `Server/tests/test_unity_transport_classification.py`).
- No regression to existing tests in `test_transport_characterization.py` (verified locally: 55 pass).

## Notes

- A companion PR ships C# eviction-notice frame + Python `EvictedByOtherClientError` for the stdio multi-client stomp case. Once that lands, this code may grow an additional `except EvictedByOtherClientError` handler between the TimeoutError and ConnectionRefusedError handlers — out of scope here to keep the two PRs independent.
- Source review at consumer: `plans/reports/review-260527-unity-mcp-error-clarity.md` in DOTS-AI workspace (Gap 2).