### PR TITLE
feat(stdio): structured eviction notice when stale client stomped

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -510,6 +510,12 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     // In stdio transport there is only ever one active Python server.
                     // A new connection means the old one is dead — close stale clients so
                     // their hung ReadFrameAsUtf8Async calls throw and exit cleanly.
+                    //
+                    // Before closing, send a structured eviction notice frame so the stomped
+                    // client can surface a clear error ("you were evicted by another MCP
+                    // client") instead of a generic "Connection closed before reading
+                    // expected bytes". The notice is best-effort with a tight timeout — a
+                    // half-dead socket must not block the accept loop.
                     TcpClient[] staleClients;
                     lock (clientsLock)
                     {
@@ -517,9 +523,28 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     }
                     if (staleClients.Length > 0)
                     {
-                        McpLog.Info($"Closing {staleClients.Length} stale client(s) after new connection");
+                        var newEp = client.Client?.RemoteEndPoint?.ToString() ?? "unknown";
+                        McpLog.Info($"Closing {staleClients.Length} stale client(s) after new connection from {newEp}");
+                        var evictionPayload = JsonConvert.SerializeObject(new
+                        {
+                            status = "evicted",
+                            reason = "stdio_single_client_stomped",
+                            error = $"Another MCP client connected from {newEp}. Stdio transport allows " +
+                                    "only one MCP client at a time; this connection has been evicted. " +
+                                    "If you need concurrent MCP clients (e.g. multiple Claude Code sessions), " +
+                                    "switch the bridge to HTTP transport mode.",
+                            evicted_at_unix_ms = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                            new_client_endpoint = newEp,
+                        });
+                        var evictionBytes = System.Text.Encoding.UTF8.GetBytes(evictionPayload);
                         foreach (var stale in staleClients)
                         {
+                            try
+                            {
+                                using var noticeCts = new CancellationTokenSource(500);
+                                await WriteFrameAsync(stale.GetStream(), evictionBytes, noticeCts.Token).ConfigureAwait(false);
+                            }
+                            catch { /* best-effort; socket may already be dead */ }
                             try { stale.Close(); } catch { }
                         }
                     }

--- a/Server/src/transport/legacy/unity_connection.py
+++ b/Server/src/transport/legacy/unity_connection.py
@@ -27,6 +27,23 @@ _connection_lock = threading.Lock()
 FRAMED_MAX = 64 * 1024 * 1024
 
 
+class EvictedByOtherClientError(ConnectionError):
+    """Raised when the Unity bridge sends an eviction notice frame —
+    another MCP client connected and took over the single stdio slot.
+
+    Carries the C#-side payload so callers can surface the structured
+    error (new client endpoint, eviction timestamp) instead of seeing
+    only a generic socket close.
+    """
+
+    def __init__(self, message: str, payload: dict | None = None):
+        super().__init__(message)
+        self.payload = payload or {}
+        self.reason = self.payload.get("reason")
+        self.new_client_endpoint = self.payload.get("new_client_endpoint")
+        self.evicted_at_unix_ms = self.payload.get("evicted_at_unix_ms")
+
+
 @dataclass
 class UnityConnection:
     """Manages the socket connection to the Unity Editor."""
@@ -198,11 +215,29 @@ class UnityConnection:
                     payload = self._read_exact(sock, payload_len)
                     logger.debug(
                         f"Received framed response ({len(payload)} bytes)")
+                    # Detect eviction-notice frames sent by StdioBridgeHost when
+                    # a new MCP client connects and stomps this one. The C# side
+                    # writes a JSON payload with status="evicted" immediately
+                    # before closing the stale socket; raising a typed exception
+                    # lets the MCP tool layer surface a clear error rather than
+                    # the generic IOException that would follow the socket close.
+                    try:
+                        decoded = json.loads(payload.decode('utf-8'))
+                    except (ValueError, UnicodeDecodeError):
+                        decoded = None
+                    if isinstance(decoded, dict) and decoded.get("status") == "evicted":
+                        message = decoded.get(
+                            "error") or "Connection evicted by another MCP client."
+                        logger.warning(
+                            "Received eviction notice from Unity bridge: %s", message)
+                        raise EvictedByOtherClientError(message, decoded)
                     return payload
             except socket.timeout as exc:
                 logger.warning("Socket timeout during framed receive")
                 raise TimeoutError("Timeout receiving Unity response") from exc
             except TimeoutError:
+                raise
+            except EvictedByOtherClientError:
                 raise
             except Exception as exc:
                 logger.error(f"Error during framed receive: {exc}")

--- a/Server/tests/integration/test_eviction_frame.py
+++ b/Server/tests/integration/test_eviction_frame.py
@@ -1,0 +1,165 @@
+"""Eviction-notice frame handling on the legacy TCP transport.
+
+When the Unity bridge sends a structured eviction frame (status="evicted"),
+the Python frame reader must raise EvictedByOtherClientError instead of
+returning the payload as a normal response. Non-eviction frames must
+pass through unchanged.
+"""
+
+import json
+import socket
+import struct
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from transport.legacy.unity_connection import (
+    EvictedByOtherClientError,
+    UnityConnection,
+)
+
+
+# locate server src dynamically to match test_transport_framing.py
+ROOT = Path(__file__).resolve().parents[2]
+candidates = [
+    ROOT / "src",
+]
+SRC = next((p for p in candidates if p.exists()), None)
+if SRC is None:
+    searched = "\n".join(str(p) for p in candidates)
+    pytest.skip(
+        "MCP for Unity server source not found. Tried:\n" + searched,
+        allow_module_level=True,
+    )
+
+
+def _start_eviction_server(eviction_payload: bytes):
+    """Start a TCP server that sends handshake then a single eviction frame."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    port = sock.getsockname()[1]
+    ready = threading.Event()
+
+    def _run():
+        ready.set()
+        conn, _ = sock.accept()
+        try:
+            conn.sendall(b"WELCOME UNITY-MCP 1 FRAMING=1\n")
+            time.sleep(0.02)
+            conn.sendall(struct.pack(">Q", len(eviction_payload)) + eviction_payload)
+            time.sleep(0.05)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+            sock.close()
+
+    threading.Thread(target=_run, daemon=True).start()
+    ready.wait()
+    return port
+
+
+def _start_passthrough_server(payload: bytes):
+    """Start a TCP server that sends handshake then a normal response frame."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    port = sock.getsockname()[1]
+    ready = threading.Event()
+
+    def _run():
+        ready.set()
+        conn, _ = sock.accept()
+        try:
+            conn.sendall(b"WELCOME UNITY-MCP 1 FRAMING=1\n")
+            time.sleep(0.02)
+            conn.sendall(struct.pack(">Q", len(payload)) + payload)
+            time.sleep(0.05)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+            sock.close()
+
+    threading.Thread(target=_run, daemon=True).start()
+    ready.wait()
+    return port
+
+
+def test_eviction_frame_raises_typed_exception():
+    eviction = {
+        "status": "evicted",
+        "reason": "stdio_single_client_stomped",
+        "error": "Another MCP client connected from 127.0.0.1:54321. "
+                 "Stdio transport allows only one MCP client at a time; "
+                 "this connection has been evicted.",
+        "evicted_at_unix_ms": 1748345678901,
+        "new_client_endpoint": "127.0.0.1:54321",
+    }
+    port = _start_eviction_server(json.dumps(eviction).encode("utf-8"))
+
+    conn = UnityConnection(host="127.0.0.1", port=port)
+    try:
+        assert conn.connect() is True
+        assert conn.use_framing is True
+        with pytest.raises(EvictedByOtherClientError) as excinfo:
+            conn.receive_full_response(conn.sock)
+
+        err = excinfo.value
+        assert "Another MCP client connected" in str(err)
+        assert err.reason == "stdio_single_client_stomped"
+        assert err.new_client_endpoint == "127.0.0.1:54321"
+        assert err.evicted_at_unix_ms == 1748345678901
+        assert err.payload["status"] == "evicted"
+    finally:
+        conn.disconnect()
+
+
+def test_non_eviction_frame_passes_through():
+    payload = b'{"status":"success","result":{"message":"pong"}}'
+    port = _start_passthrough_server(payload)
+
+    conn = UnityConnection(host="127.0.0.1", port=port)
+    try:
+        assert conn.connect() is True
+        resp = conn.receive_full_response(conn.sock)
+        assert resp == payload
+        # Sanity: regular responses must NOT trip the eviction branch even when
+        # they happen to be JSON dicts.
+        decoded = json.loads(resp.decode("utf-8"))
+        assert decoded["status"] == "success"
+    finally:
+        conn.disconnect()
+
+
+def test_non_json_payload_passes_through():
+    # Defensive: a non-JSON payload (e.g. binary, malformed UTF-8) must not
+    # raise inside the eviction-detection branch — it should be returned as-is
+    # so the existing JSON-validation path in send_command surfaces the right
+    # error.
+    payload = b'\x80\x81\x82 not valid utf-8 or json'
+    port = _start_passthrough_server(payload)
+
+    conn = UnityConnection(host="127.0.0.1", port=port)
+    try:
+        assert conn.connect() is True
+        resp = conn.receive_full_response(conn.sock)
+        assert resp == payload
+    finally:
+        conn.disconnect()
+
+
+def test_evicted_error_is_connection_error_subclass():
+    # The exception MUST subclass ConnectionError so existing connection-error
+    # handling paths in send_command's retry loop continue to work without
+    # explicit catches.
+    err = EvictedByOtherClientError("evicted", {"reason": "stdio_single_client_stomped"})
+    assert isinstance(err, ConnectionError)
+    assert err.reason == "stdio_single_client_stomped"
+    assert err.new_client_endpoint is None
+    assert err.evicted_at_unix_ms is None

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeReconnectTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeReconnectTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -147,6 +148,67 @@ namespace MCPForUnityTests.Editor.Services
                 }
 
                 Assert.IsTrue(firstClientDisconnected, "First client should be disconnected after second client connects");
+            }
+            finally
+            {
+                try { client1.Close(); } catch { }
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator NewClient_SendsStructuredEvictionFrame_BeforeClosingStaleClient()
+        {
+            if (!StdioBridgeHost.IsRunning)
+            {
+                Assert.Ignore("StdioBridgeHost is not running; skipping eviction-frame test.");
+                yield break;
+            }
+
+            int port = StdioBridgeHost.GetCurrentPort();
+
+            // --- First client: connect and consume handshake ---
+            var client1 = new TcpClient();
+            try
+            {
+                Assert.IsTrue(client1.ConnectAsync("127.0.0.1", port).Wait(ConnectTimeoutMs),
+                    "First client connect timed out");
+                client1.ReceiveTimeout = ReadTimeoutMs;
+                var stream1 = client1.GetStream();
+
+                string handshake1 = ReadLine(stream1, ReadTimeoutMs);
+                Assert.That(handshake1, Does.Contain("FRAMING=1"), "First client should receive handshake");
+
+                // --- Second client: connect — this triggers stale-client eviction ---
+                using (var client2 = new TcpClient())
+                {
+                    Assert.IsTrue(client2.ConnectAsync("127.0.0.1", port).Wait(ConnectTimeoutMs),
+                        "Second client connect timed out");
+                    client2.ReceiveTimeout = ReadTimeoutMs;
+                    var stream2 = client2.GetStream();
+
+                    string handshake2 = ReadLine(stream2, ReadTimeoutMs);
+                    Assert.That(handshake2, Does.Contain("FRAMING=1"), "Second client should receive handshake");
+
+                    // First client should now receive an eviction-notice frame before
+                    // its socket is closed. The bridge writes this frame with a 500ms
+                    // best-effort timeout, so we give it a comfortable 2000ms window.
+                    byte[] evictionFrame = ReadFrame(stream1, 2000);
+                    string evictionJson = Encoding.UTF8.GetString(evictionFrame);
+
+                    var parsed = JObject.Parse(evictionJson);
+                    Assert.AreEqual("evicted", (string)parsed["status"],
+                        "Eviction frame must have status=\"evicted\"");
+                    Assert.AreEqual("stdio_single_client_stomped", (string)parsed["reason"],
+                        "Eviction frame must have reason=\"stdio_single_client_stomped\"");
+                    Assert.That((string)parsed["error"], Is.Not.Null.And.Not.Empty,
+                        "Eviction frame must carry a human-readable error message");
+                    Assert.That((string)parsed["new_client_endpoint"], Is.Not.Null.And.Not.Empty,
+                        "Eviction frame must identify the stomping client's endpoint");
+                    Assert.That(parsed["evicted_at_unix_ms"], Is.Not.Null,
+                        "Eviction frame must carry an eviction timestamp");
+
+                    client2.Close();
+                }
             }
             finally
             {


### PR DESCRIPTION
## Problem

In stdio transport (single-client by design), when a new MCP client (e.g. a second Claude Code session) connects to the Unity bridge, the existing client's TCP socket is silently closed. The stale client sees only `Connection closed before reading expected bytes` — explicitly classified `isBenign` and only debug-logged in the bridge. From the stomped Claude session's POV, this looks identical to: Unity crashed, the bridge died, or a network blip — diagnosis requires manual inspection of Unity process state.

This is recurring enough that a downstream consumer wrote a dedicated rule (`unity-forbidden-operations.md` § "MCP timeout ≠ bridge disconnect — diagnose before escalating") to encode the manual diagnostic steps.

## Fix

Two coordinated changes — must land together to be useful:

1. **C# (`MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs`)**: Before closing each stale client, send a structured eviction frame:
   ```json
   {
     "status": "evicted",
     "reason": "stdio_single_client_stomped",
     "error": "Another MCP client connected from <ep>. Stdio transport allows only one MCP client at a time; this connection has been evicted. If you need concurrent MCP clients (e.g. multiple Claude Code sessions), switch the bridge to HTTP transport mode.",
     "new_client_endpoint": "127.0.0.1:54321",
     "evicted_at_unix_ms": 1748345678901
   }
   ```
   Best-effort write with 500ms timeout — does not block the accept loop if the socket is already half-dead.

2. **Python (`Server/src/transport/legacy/unity_connection.py`)**: Frame reader detects `status="evicted"` payloads and raises a new `EvictedByOtherClientError` (subclasses `ConnectionError`) instead of seeing the subsequent socket close as a generic IOException. Non-eviction frames pass through unchanged. Non-JSON / non-UTF8 payloads also pass through so the existing JSON-validation in `send_command` surfaces the correct error for malformed responses.

Downstream consumers (Claude Code sessions) now get a clear, actionable error: "Another MCP client connected from <ep>; switch to HTTP transport for concurrent clients" instead of "Connection closed before reading expected bytes."

## Test plan

- **C# (`StdioBridgeReconnectTests.cs`)** — new `NewClient_SendsStructuredEvictionFrame_BeforeClosingStaleClient`: 2 sequential TCP connects to the bridge, asserts first receives an eviction frame with all required fields (`status`, `reason`, `error`, `new_client_endpoint`, `evicted_at_unix_ms`).
- **Python (`Server/tests/integration/test_eviction_frame.py`)** — 4 new tests: typed exception raised with payload, non-eviction passthrough, non-JSON passthrough, exception subclasses `ConnectionError`. All 4 pass locally; existing `test_transport_framing.py` (4 tests) + `test_transport_characterization.py` (55 tests) regress to 0 failures.

## Notes

- Companion change for Gap 2 (per-exception classification in `Server/src/transport/unity_transport.py`) is on a sibling branch `feat/transport-error-classification` — orthogonal change that can land independently.
- Source review at consumer: `plans/reports/review-260527-unity-mcp-error-clarity.md` in DOTS-AI workspace.