### PR TITLE
fix(rendering_stats): await get_unity_instance_from_context — resolves coroutine.strip error (#7)

### DIFF
--- a/Server/src/services/tools/manage_addressables.py
+++ b/Server/src/services/tools/manage_addressables.py
@@ -44,7 +44,7 @@ async def manage_addressables(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "group_name": group_name, "address": address,
               "guid": guid, "clean": clean, "page_size": page_size, "cursor": cursor}

--- a/Server/src/services/tools/manage_audio.py
+++ b/Server/src/services/tools/manage_audio.py
@@ -56,7 +56,7 @@ async def manage_audio(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_behavior.py
+++ b/Server/src/services/tools/manage_behavior.py
@@ -41,7 +41,7 @@ async def manage_behavior(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target, "variable_name": variable_name,
               "value": value, "page_size": page_size, "cursor": cursor}

--- a/Server/src/services/tools/manage_cinemachine.py
+++ b/Server/src/services/tools/manage_cinemachine.py
@@ -42,7 +42,7 @@ async def manage_cinemachine(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target, "properties": properties,
               "priority": priority, "page_size": page_size, "cursor": cursor}

--- a/Server/src/services/tools/manage_input_simulation.py
+++ b/Server/src/services/tools/manage_input_simulation.py
@@ -89,7 +89,7 @@ async def manage_input_simulation(
     page_size: Annotated[int | None, "Max results (default 50)"] = None,
     cursor: Annotated[int | None, "Pagination cursor"] = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params: dict[str, Any] = {
         "action": action,

--- a/Server/src/services/tools/manage_input_system.py
+++ b/Server/src/services/tools/manage_input_system.py
@@ -43,7 +43,7 @@ async def manage_input_system(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "asset": asset, "map_name": map_name,
               "action_name": action_name, "device_name": device_name,

--- a/Server/src/services/tools/manage_lighting.py
+++ b/Server/src/services/tools/manage_lighting.py
@@ -56,7 +56,7 @@ async def manage_lighting(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_localization.py
+++ b/Server/src/services/tools/manage_localization.py
@@ -43,7 +43,7 @@ async def manage_localization(
     value: Annotated[str, "Localized string value (for set_entry)"] | None = None,
     type: Annotated[str, "Table type: 'string' or 'asset' (for list_tables)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "locale_code": locale_code, "table": table,
               "key": key, "locale": locale, "value": value, "type": type}

--- a/Server/src/services/tools/manage_mesh.py
+++ b/Server/src/services/tools/manage_mesh.py
@@ -59,7 +59,7 @@ async def manage_mesh(
     count: Annotated[int, "Number of samples to return for sample_* and inspect actions (default 10)."] | None = None,
     offset: Annotated[int, "Start offset index for sampling (default 0)."] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_navigation.py
+++ b/Server/src/services/tools/manage_navigation.py
@@ -53,7 +53,7 @@ async def manage_navigation(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_netcode.py
+++ b/Server/src/services/tools/manage_netcode.py
@@ -42,7 +42,7 @@ async def manage_netcode(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target,
               "page_size": page_size, "cursor": cursor}

--- a/Server/src/services/tools/manage_physics2d.py
+++ b/Server/src/services/tools/manage_physics2d.py
@@ -52,7 +52,7 @@ async def manage_physics2d(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "origin": origin, "direction": direction,
               "max_distance": max_distance, "layer_mask": layer_mask,

--- a/Server/src/services/tools/manage_render_pipeline.py
+++ b/Server/src/services/tools/manage_render_pipeline.py
@@ -53,7 +53,7 @@ async def manage_render_pipeline(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_shader_tool.py
+++ b/Server/src/services/tools/manage_shader_tool.py
@@ -47,7 +47,7 @@ async def manage_shader_tool(
         "Used by: find, get_errors, get_info, get_passes."
     ] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_splines.py
+++ b/Server/src/services/tools/manage_splines.py
@@ -46,7 +46,7 @@ async def manage_splines(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target, "spline_index": spline_index,
               "knot_index": knot_index, "position": position, "rotation": rotation,

--- a/Server/src/services/tools/manage_terrain.py
+++ b/Server/src/services/tools/manage_terrain.py
@@ -62,7 +62,7 @@ async def manage_terrain(
     # Heightmap sample
     size: Annotated[int, "Patch size NxN in heightmap pixels, clamped to 64 (for get_heightmap_sample)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,

--- a/Server/src/services/tools/manage_tilemap.py
+++ b/Server/src/services/tools/manage_tilemap.py
@@ -46,7 +46,7 @@ async def manage_tilemap(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target, "position": position,
               "tile_asset": tile_asset, "min": min, "max": max,

--- a/Server/src/services/tools/manage_timeline.py
+++ b/Server/src/services/tools/manage_timeline.py
@@ -41,7 +41,7 @@ async def manage_timeline(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target, "time": time,
               "page_size": page_size, "cursor": cursor}

--- a/Server/src/services/tools/manage_ui_toolkit.py
+++ b/Server/src/services/tools/manage_ui_toolkit.py
@@ -44,7 +44,7 @@ async def manage_ui_toolkit(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target, "query": query,
               "property": property, "value": value, "filter": filter,

--- a/Server/src/services/tools/manage_video.py
+++ b/Server/src/services/tools/manage_video.py
@@ -43,7 +43,7 @@ async def manage_video(
     page_size: Annotated[int, "Max results to return (default 50)"] | None = None,
     cursor: Annotated[int, "Pagination cursor (0-based offset)"] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {"action": action, "target": target, "properties": properties,
               "time": time, "page_size": page_size, "cursor": cursor}

--- a/Server/src/services/tools/rendering_stats.py
+++ b/Server/src/services/tools/rendering_stats.py
@@ -54,7 +54,7 @@ async def rendering_stats(
     include_csv: Annotated[bool | None, "For get_session_report: include CSV data."] = True,
     filename: Annotated[str | None, "For load_session/analyze_session: session JSON filename."] = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params: dict[str, Any] = {"action": action}
     if frames is not None:

--- a/Server/src/services/tools/validation_snapshot.py
+++ b/Server/src/services/tools/validation_snapshot.py
@@ -47,7 +47,7 @@ async def validation_snapshot(
         "Current snapshot JSON (for 'compare' action)."
     ] | None = None,
 ) -> dict[str, Any]:
-    unity_instance = get_unity_instance_from_context(ctx)
+    unity_instance = await get_unity_instance_from_context(ctx)
 
     params = {
         "action": action,


### PR DESCRIPTION
## Summary

Fixes #7 (and sweeps the same defect class kit-wide).

`get_unity_instance_from_context` is declared `async def` in `Server/src/services/tools/__init__.py` (returns `str | None`). Any call site that omits `await` stores the **coroutine object** instead of the instance string. That object then flows into `send_with_unity_instance`, where downstream code expects a string and calls `.strip()` on it — failing at runtime with:

```
'coroutine' object has no attribute 'strip'
```

For `rendering_stats` this fails the shared handler entry path, so **every** action breaks (`get_stats`, `get_stats_aggregated`, `get_profiler`, `get_system_stats`) — exactly as #7 reports.

## Root cause

`Server/src/services/tools/rendering_stats.py:57`

```python
unity_instance = get_unity_instance_from_context(ctx)   # ← missing await
```

The enclosing `rendering_stats` handler is `async def`, so `await` is legal. Canonical correct form: `manage_components.py:72`.

## Scope — full sweep (per #7's recommendation)

Issue #7 explicitly recommends grepping for every remaining unawaited call site to avoid filing a fourth follow-up (#5 / PR #6 fixed 4 DOTS files; `rendering_stats` was the 5th instance). A full-tree grep found **22** tool files still calling `get_unity_instance_from_context(ctx)` without `await`:

```
rg "= get_unity_instance_from_context\(ctx\)" Server/src/services/tools/ | grep -v await
```

This PR fixes all 22:

- `rendering_stats.py` (the #7 target)
- `validation_snapshot.py`, `manage_addressables.py`, `manage_audio.py`, `manage_behavior.py`, `manage_cinemachine.py`, `manage_input_simulation.py`, `manage_input_system.py`, `manage_lighting.py`, `manage_localization.py`, `manage_mesh.py`, `manage_navigation.py`, `manage_netcode.py`, `manage_physics2d.py`, `manage_render_pipeline.py`, `manage_shader_tool.py`, `manage_splines.py`, `manage_terrain.py`, `manage_tilemap.py`, `manage_timeline.py`, `manage_ui_toolkit.py`, `manage_video.py`

## Verification

- Each of the 22 enclosing handlers verified `async def` → `await` is legal in every case.
- Each file imports the async `get_unity_instance_from_context` from `services.tools`.
- Post-fix: `rg "= get_unity_instance_from_context\(ctx\)" Server/src/ | grep -v await` returns **zero** sites.
- All 22 changed files pass `python -m py_compile`.
- Reproduced on **Unity 6000.3.15f1**.

Each change is a single line: `+ await`. No behavioral change beyond correctly awaiting the coroutine.

Resolves #7. Cross-references #5 / PR #6.