### PR TITLE
fix(tools): dispatch optional-package tools to an actionable error (fixes #20)

### DIFF
--- a/MCPForUnity/Editor/Tools/CommandRegistry.cs
+++ b/MCPForUnity/Editor/Tools/CommandRegistry.cs
@@ -97,12 +97,40 @@ namespace MCPForUnity.Editor.Tools
                         resourceCount++;
                 }
 
-                McpLog.Info($"Auto-discovered {toolCount} tools and {resourceCount} resources ({_handlers.Count} total handlers)", false);
+                // Tools gated behind an optional package leave no handler when that package is
+                // absent. Fill those gaps with a placeholder so callers get an actionable
+                // "install <package>" error instead of "Unknown or unsupported command type".
+                int placeholderCount = RegisterOptionalPackagePlaceholders();
+
+                McpLog.Info($"Auto-discovered {toolCount} tools and {resourceCount} resources ({_handlers.Count} total handlers, {placeholderCount} awaiting an optional package)", false);
             }
             catch (Exception ex)
             {
                 McpLog.Error($"Failed to auto-discover MCP commands: {ex.Message}");
             }
+        }
+
+        /// <summary>
+        /// Register a placeholder handler for every optional-package tool whose real handler was
+        /// compiled out. Returns how many placeholders were added.
+        /// </summary>
+        private static int RegisterOptionalPackagePlaceholders()
+        {
+            int count = 0;
+            foreach (var entry in OptionalPackageTools.CommandToPackage)
+            {
+                if (_handlers.ContainsKey(entry.Key)) continue;
+
+                string commandName = entry.Key;
+                string packageName = entry.Value;
+                _handlers[commandName] = new HandlerInfo(
+                    commandName,
+                    _ => OptionalPackageTools.MissingPackageResponse(commandName, packageName),
+                    null);
+                count++;
+            }
+
+            return count;
         }
 
         private static bool HasAttributeSafe<T>(Type type) where T : Attribute

--- a/MCPForUnity/Editor/Tools/OptionalPackageTools.cs
+++ b/MCPForUnity/Editor/Tools/OptionalPackageTools.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using MCPForUnity.Editor.Helpers;
+
+namespace MCPForUnity.Editor.Tools
+{
+    /// <summary>
+    /// Tools whose Unity-side handler is compiled out unless an optional package is installed.
+    /// Each entry mirrors a <c>#if</c> gate on a tool file and the matching versionDefine in
+    /// MCPForUnity.Editor.asmdef. The Python server advertises these tools unconditionally, so
+    /// without a placeholder the dispatcher answers a bare "Unknown or unsupported command type",
+    /// which tells the caller nothing about which package to install.
+    /// </summary>
+    internal static class OptionalPackageTools
+    {
+        /// <summary>Command name → the package whose presence defines its compile gate.</summary>
+        internal static readonly IReadOnlyDictionary<string, string> CommandToPackage =
+            new Dictionary<string, string>
+            {
+                ["manage_addressables"] = "com.unity.addressables",
+                ["manage_behavior"] = "com.unity.behavior",
+                ["manage_cinemachine"] = "com.unity.cinemachine",
+                ["manage_dots"] = "com.unity.entities",
+                ["manage_dots_graphics"] = "com.unity.entities.graphics",
+                ["manage_dots_physics"] = "com.unity.physics",
+                ["manage_dots_subscene"] = "com.unity.entities",
+                ["manage_input_system"] = "com.unity.inputsystem",
+                ["manage_localization"] = "com.unity.localization",
+                ["manage_navigation"] = "com.unity.ai.navigation",
+                ["manage_netcode"] = "com.unity.netcode.gameobjects",
+                ["manage_splines"] = "com.unity.splines",
+                ["manage_tilemap"] = "com.unity.2d.tilemap",
+                ["manage_timeline"] = "com.unity.timeline",
+                ["manage_vfx"] = "com.unity.visualeffectgraph",
+                ["validation_snapshot"] = "com.unity.entities",
+            };
+
+        internal static object MissingPackageResponse(string commandName, string packageName)
+        {
+            return new ErrorResponse(
+                $"'{commandName}' requires the {packageName} package, which is not installed in this project. "
+                + $"Install it from Window > Package Manager (or add \"{packageName}\" to Packages/manifest.json), "
+                + "wait for Unity to recompile, then retry.",
+                new { command = commandName, required_package = packageName });
+        }
+    }
+}

--- a/MCPForUnity/Editor/Tools/OptionalPackageTools.cs.meta
+++ b/MCPForUnity/Editor/Tools/OptionalPackageTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c2b41d9e6f84f0a9c3d5b2a8e17d640
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/CommandRegistryTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/CommandRegistryTests.cs
@@ -1,5 +1,6 @@
 using System;
 using NUnit.Framework;
+using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Tools;
 
 namespace MCPForUnityTests.Editor.Tools
@@ -22,6 +23,40 @@ namespace MCPForUnityTests.Editor.Tools
             {
                 CommandRegistry.GetHandler(unknown);
             }, "Should throw InvalidOperationException for unknown handler");
+        }
+
+        [Test]
+        public void OptionalPackageTools_AlwaysResolveToAHandler()
+        {
+            // Whether or not the optional package is installed, the command must dispatch.
+            // An absent package yields a placeholder that names the package to install,
+            // never "Unknown or unsupported command type".
+            foreach (var entry in OptionalPackageTools.CommandToPackage)
+            {
+                var handler = CommandRegistry.GetHandler(entry.Key);
+                Assert.IsNotNull(handler, $"Handler for '{entry.Key}' should not be null");
+
+                var result = handler(new Newtonsoft.Json.Linq.JObject());
+                Assert.IsNotNull(result, $"Handler for '{entry.Key}' should return a result for empty params");
+
+                if (result is ErrorResponse error && error.Error.Contains("not installed in this project"))
+                {
+                    StringAssert.Contains(entry.Value, error.Error,
+                        $"Placeholder for '{entry.Key}' should name the required package");
+                }
+            }
+        }
+
+        [Test]
+        public void MissingPackageResponse_NamesTheCommandAndPackage()
+        {
+            var response = OptionalPackageTools.MissingPackageResponse("manage_splines", "com.unity.splines")
+                as ErrorResponse;
+
+            Assert.IsNotNull(response, "Missing-package response should be an ErrorResponse");
+            Assert.IsFalse(response.Success, "Missing-package response should not report success");
+            StringAssert.Contains("manage_splines", response.Error);
+            StringAssert.Contains("com.unity.splines", response.Error);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Refs #20. Tools gated behind an optional Unity package (e.g. `manage_splines`, wrapped in `#if UNITY_SPLINES`) never compile when that package is absent, so `CommandRegistry` auto-discovery registers **no handler** for them. The Python server still advertises the tool, so any call — direct or through `batch_execute` — failed with:

```
Unknown or unsupported command type: manage_splines
```

That error names neither the missing package nor how to recover.

## Fix

- **`OptionalPackageTools.cs`** (new) — SSOT map of each optional-package command → the package whose `versionDefine` gates it (mirrors the `#if` gates in the tool files and the `versionDefines` in `MCPForUnity.Editor.asmdef`). Plus a `MissingPackageResponse` helper returning an actionable `ErrorResponse`.
- **`CommandRegistry.cs`** — after auto-discovery, register a placeholder handler for every optional-package command that has **no** real handler. When the package is installed, the real handler wins and the placeholder is never added (guarded by `ContainsKey`). When absent, `batch_execute`/direct calls now dispatch to an error that names the command and the package to install.

Tool listings are unchanged — placeholders live only in the dispatcher, not in `ToolDiscoveryService`, so `manage_tools` output and MCP tool schemas are unaffected.

Covers all 16 optional-package commands (`manage_addressables`, `manage_behavior`, `manage_cinemachine`, `manage_dots`, `manage_dots_graphics`, `manage_dots_physics`, `manage_dots_subscene`, `manage_input_system`, `manage_localization`, `manage_navigation`, `manage_netcode`, `manage_splines`, `manage_tilemap`, `manage_timeline`, `manage_vfx`, `validation_snapshot`).

## Tests

Added to `CommandRegistryTests.cs`:
- `OptionalPackageTools_AlwaysResolveToAHandler` — every optional-package command resolves to a non-null handler (never throws `Unknown command`); when the placeholder fires it names the package.
- `MissingPackageResponse_NamesTheCommandAndPackage` — the placeholder response is a failed `ErrorResponse` naming both command and package.

## Notes on scope

The issue also asked to add `mcp__UnityMCP__manage_splines` to the `t1k-unity-developer` agent's allowlist. That agent is owned by the `theonekit-unity` kit, **not** this repo, so it's out of scope here and should be handled via a `theonekit-unity` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)