### PR TITLE
fix(batch_execute): stop connection-level retry replaying applied mutations (#18)

### DIFF
--- a/Server/src/services/tools/batch_execute.py
+++ b/Server/src/services/tools/batch_execute.py
@@ -144,9 +144,16 @@ async def batch_execute(
     if max_parallelism is not None:
         payload["maxParallelism"] = int(max_parallelism)
 
+    # batch_execute applies non-idempotent mutations sequentially with no
+    # completion registry, so a connection-level replay re-runs every command
+    # that already succeeded (issue #18: a 4-command batch produced 16 nodes).
+    # Opt out of the retry the same way refresh_unity does for its
+    # reload-triggering commands (issue #577). A timeout now surfaces as a
+    # visible error instead of silent scene duplication.
     return await send_with_unity_instance(
         async_send_command_with_retry,
         unity_instance,
         "batch_execute",
         payload,
+        retry_on_reload=False,
     )

--- a/Server/tests/test_batch_execute_instance_cache.py
+++ b/Server/tests/test_batch_execute_instance_cache.py
@@ -64,8 +64,8 @@ async def test_batch_not_rejected_using_another_instances_limit(fake_editor_stat
     """A 50-command batch is valid on ProjectB (limit 100) even after ProjectA ran."""
     sent: list[dict] = []
 
-    async def _fake_send(send_fn, unity_instance, command_type, payload):
-        sent.append({"instance": unity_instance, "payload": payload})
+    async def _fake_send(send_fn, unity_instance, command_type, payload, **kwargs):
+        sent.append({"instance": unity_instance, "payload": payload, "kwargs": kwargs})
         return {"success": True, "data": {}}
 
     monkeypatch.setattr(batch_execute_module, "send_with_unity_instance", _fake_send)
@@ -79,3 +79,31 @@ async def test_batch_not_rejected_using_another_instances_limit(fake_editor_stat
 
     assert len(sent) == 2
     assert len(sent[1]["payload"]["commands"]) == 50
+
+
+@pytest.mark.asyncio
+async def test_batch_opts_out_of_connection_level_retry(fake_editor_state, monkeypatch):
+    """batch_execute must send retry_on_reload=False (issue #18).
+
+    The batch applies non-idempotent mutations sequentially with no completion
+    registry, so a connection-level replay re-runs every command that already
+    succeeded — a 4-command batch produced 16 nodes. The kwarg is the whole fix,
+    so assert it explicitly rather than trusting the call site.
+    """
+    sent: list[dict] = []
+
+    async def _fake_send(send_fn, unity_instance, command_type, payload, **kwargs):
+        sent.append({"command_type": command_type, "kwargs": kwargs})
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(batch_execute_module, "send_with_unity_instance", _fake_send)
+
+    await batch_execute_module.batch_execute(
+        _ctx("ProjectA@aaaaaa"),
+        [{"tool": "manage_editor", "params": {"action": "get_state"}}],
+    )
+
+    assert len(sent) == 1
+    assert sent[0]["command_type"] == "batch_execute"
+    # Explicitly False, not merely absent: absent means the default (True) applies.
+    assert sent[0]["kwargs"].get("retry_on_reload") is False


### PR DESCRIPTION
Refs #18. This is the **mitigation half** — deliberately not the full protocol.

## Root cause, confirmed in code

**C# side** — `MCPForUnity/Editor/Tools/BatchExecute.cs:69-166` is a plain sequential `foreach (var token in commandsToken)`. No batch token, no completion registry, no dedup. `grep "idempot|batch_id|batchId|dedup"` over `BatchExecute.cs` + `unity_connection.py` → **zero hits**.

**Python side** — `batch_execute.py:142-147` called `async_send_command_with_retry(...)` *without* `retry_on_reload`, taking the default `True` (signature at `unity_connection.py:945-953`). That flows to `:872-874`:

```python
send_max_attempts = None if retry_on_reload else 0
response = conn.send_command(command_type, params, max_attempts=send_max_attempts)
```

and `send_command` (`:303-317`) then does `attempts = max(config.max_retries, 5)`. **A timeout replays the full batch payload up to 5 more times, re-running every command that already succeeded** — which is exactly the reported 4 → 16 duplication.

## The fix is one keyword, and the escape hatch already exists

`unity_connection.py:872` carries the comment *"If retry_on_reload=False, disable connection-level retries too (issue #577)"* — the mechanism was already built for compile/reload-triggering commands. `refresh_unity.py:118,127,202` already uses it.

`batch_execute` is mutating and non-idempotent, so it belongs in the same class. A timeout now surfaces as a **visible error instead of silent scene duplication** — strictly the better failure mode, and aligned with errors-over-silent-fallbacks.

## Why this issue sat open

It was deferred five times as "needs an idempotency protocol, architecture work." That's true of the *complete* fix, but it obscured that a one-parameter mitigation was available the whole time. Silent hierarchy duplication is a data-loss-class bug; it shouldn't wait on protocol design.

## Deliberately out of scope

Real idempotency — per-batch GUID minted in Python, completion registry in `BatchExecute.cs` keyed on it, replay returning recorded per-command results rather than re-executing. That genuinely needs a live editor to exercise the timeout/domain-reload path. It should be its own issue; this PR shouldn't block on it.

## Upstream

`BatchExecute.cs` has **zero The1Studio commits** (upstream: `18c3e031` dsarno #757, `0d2d10c5` #741, `ad3756ee` #727). This is an upstream bug and the patch is worth upstreaming to CoplayDev — landing fork-local first since it's affecting users now.

## Verification

Python syntax checked. Not exercised against a live editor — the change is a single kwarg matching an existing, tested call pattern in `refresh_unity.py`. Reviewer should confirm the `max_attempts=0` dispatch in `Server/tests/`.
