### PR TITLE
fix(manage_gameobject): default prefab folder so save_as_prefab isn't written to "None/…"

### DIFF
--- a/Server/src/services/tools/manage_gameobject.py
+++ b/Server/src/services/tools/manage_gameobject.py
@@ -196,8 +196,12 @@ async def manage_gameobject(
             if "prefabPath" not in params:
                 if "name" not in params or not params["name"]:
                     return {"success": False, "message": "Cannot create default prefab path: 'name' parameter is missing."}
-                # Use the provided prefab_folder (which has a default) and the name to construct the path
-                constructed_path = f"{prefab_folder}/{params['name']}.prefab"
+                # prefab_folder has NO default (it's None unless the caller passes it),
+                # so coalesce to the project convention — otherwise the path becomes
+                # the literal string "None/<name>.prefab" for a normal
+                # create+save_as_prefab call.
+                folder = prefab_folder or "Assets/Prefabs"
+                constructed_path = f"{folder}/{params['name']}.prefab"
                 # Ensure clean path separators (Unity prefers '/')
                 params["prefabPath"] = constructed_path.replace("\\", "/")
             elif not params["prefabPath"].lower().endswith(".prefab"):

--- a/Server/tests/integration/test_manage_gameobject_param_coercion.py
+++ b/Server/tests/integration/test_manage_gameobject_param_coercion.py
@@ -63,3 +63,59 @@ async def test_manage_gameobject_create_with_tag(monkeypatch):
     assert p["name"] == "TestObject"
     assert p["tag"] == "Player"
     assert p["position"] == [1.0, 2.0, 3.0]
+
+
+@pytest.mark.asyncio
+async def test_manage_gameobject_save_as_prefab_default_folder(monkeypatch):
+    """create + save_as_prefab with no prefab_folder/prefab_path must build a
+    sensible default prefabPath — NOT the literal string 'None/<name>.prefab'."""
+    captured = {}
+
+    async def fake_send(cmd, params, **kwargs):
+        captured["params"] = params
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(
+        manage_go_mod,
+        "async_send_command_with_retry",
+        fake_send,
+    )
+
+    resp = await manage_go_mod.manage_gameobject(
+        ctx=DummyContext(),
+        action="create",
+        name="MyCube",
+        save_as_prefab=True,  # no prefab_folder, no prefab_path
+    )
+
+    assert resp.get("success") is True
+    p = captured["params"]
+    assert p["prefabPath"] == "Assets/Prefabs/MyCube.prefab"
+    assert not p["prefabPath"].startswith("None/")
+
+
+@pytest.mark.asyncio
+async def test_manage_gameobject_save_as_prefab_explicit_folder(monkeypatch):
+    """An explicit prefab_folder is honored."""
+    captured = {}
+
+    async def fake_send(cmd, params, **kwargs):
+        captured["params"] = params
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(
+        manage_go_mod,
+        "async_send_command_with_retry",
+        fake_send,
+    )
+
+    resp = await manage_go_mod.manage_gameobject(
+        ctx=DummyContext(),
+        action="create",
+        name="MyCube",
+        save_as_prefab=True,
+        prefab_folder="Assets/Custom/Prefabs",
+    )
+
+    assert resp.get("success") is True
+    assert captured["params"]["prefabPath"] == "Assets/Custom/Prefabs/MyCube.prefab"


### PR DESCRIPTION
## Bug

`manage_gameobject`'s `prefab_folder` param has **no default** (it's `None` unless the caller passes it), but the auto-path branch built `f"{prefab_folder}/{name}.prefab"` assuming a real folder (the inline comment even claimed "prefab_folder (which has a default)").

So a normal `create name="MyCube" save_as_prefab=True` (no `prefab_folder`/`prefab_path`) produced the literal path **`None/MyCube.prefab`** — writing the prefab to a bogus top-level folder named `None`.

## Fix

Coalesce to the project convention: `folder = prefab_folder or "Assets/Prefabs"`.

## Test

Default folder → `Assets/Prefabs/MyCube.prefab` (never `None/…`); explicit `prefab_folder` honored. The default test **fails against the pre-fix code**; full param-coercion suite 4/4.

Found by an adversarial bug-hunt.