### PR TITLE
fix(find_in_file): guard against success response with explicit null data

### DIFF
--- a/Server/src/services/tools/find_in_file.py
+++ b/Server/src/services/tools/find_in_file.py
@@ -104,7 +104,11 @@ async def find_in_file(
     if not isinstance(read_resp, dict) or not read_resp.get("success"):
         return read_resp if isinstance(read_resp, dict) else {"success": False, "message": str(read_resp)}
 
-    data = read_resp.get("data", {})
+    # A successful response can still carry an explicit ``"data": null`` (e.g. a
+    # tool that returns ``data=response.get("data")``). ``.get("data", {})`` only
+    # substitutes the default when the KEY is absent, so ``or {}`` is required to
+    # avoid ``NoneType.get`` on the next line.
+    data = read_resp.get("data") or {}
     contents = data.get("contents")
     if not contents and data.get("contentsEncoded") and data.get("encodedContents"):
         try:

--- a/Server/tests/integration/test_find_in_file_null_data.py
+++ b/Server/tests/integration/test_find_in_file_null_data.py
@@ -1,0 +1,31 @@
+import pytest
+
+from .test_helpers import DummyContext
+import services.tools.find_in_file as find_mod
+
+
+@pytest.mark.asyncio
+async def test_find_in_file_success_with_null_data(monkeypatch):
+    """A success response carrying an explicit ``data: null`` must return a clean
+    error, not crash with ``AttributeError: 'NoneType' object has no attribute 'get'``.
+
+    Regression: ``read_resp.get("data", {})`` returns ``None`` (not ``{}``) when the
+    key is present but null, so the following ``data.get("contents")`` crashed. The
+    codebase itself produces such responses (e.g. a tool returning
+    ``data=response.get("data")`` where ``data`` is absent upstream)."""
+
+    async def fake_send(cmd, params, **kwargs):
+        return {"success": True, "data": None}
+
+    monkeypatch.setattr(find_mod, "async_send_command_with_retry", fake_send)
+
+    resp = await find_mod.find_in_file(
+        ctx=DummyContext(),
+        uri="Assets/Scripts/Foo.cs",
+        pattern="class",
+    )
+
+    # No crash — a clean, structured failure instead.
+    assert isinstance(resp, dict)
+    assert resp.get("success") is False
+    assert "Could not read file content" in resp.get("message", "")


### PR DESCRIPTION
## Problem

`find_in_file` crashes with `AttributeError: 'NoneType' object has no attribute 'get'` when Unity returns a **successful** response whose `data` field is explicitly `null`:

```python
data = read_resp.get("data", {})   # returns None, NOT {}, when key is present-but-null
contents = data.get("contents")     # 💥 AttributeError on None
```

`dict.get(key, default)` only substitutes the default when the **key is absent** — a present-but-null value returns `None`. The codebase itself produces such responses (e.g. a tool returning `data=response.get("data")` where the upstream key was absent, as in `manage_gameobject.py`), so this is reachable, not theoretical. The `success` guard just above (line 104) passes, so the crash happens on a response that looked healthy.

## Fix

One line — `or {}` so a null `data` degrades to an empty dict and the tool returns its existing clean error (`"Could not read file content."`) instead of crashing.

## Test

`Server/tests/integration/test_find_in_file_null_data.py` — mocks a `{"success": True, "data": None}` response. Verified it **fails on the pre-fix code** (`AttributeError` at the `data.get('contents')` line) and **passes on the fix**.