### PR TITLE
fix(utils): normalize_color made opaque 0-255 colors transparent (float output)

### DIFF
--- a/Server/src/services/tools/utils.py
+++ b/Server/src/services/tools/utils.py
@@ -305,6 +305,18 @@ def normalize_color(value: Any, output_range: str = "float") -> tuple[list[float
                 return [c / 255.0 for c in components]
             return [float(c) for c in components]
 
+    def _opaque_alpha(rgb: list[float]) -> float:
+        """Fully-opaque alpha in the SAME scale as the RGB components.
+
+        _to_output_range decides 0-255-vs-0-1 by whether any component exceeds 1,
+        and scales the WHOLE list accordingly. A default alpha appended in the
+        wrong scale gets dragged along: for 0-255 RGB with float output, a 1.0
+        alpha would be divided by 255 to ~0.004 (nearly transparent). Matching
+        the RGB scale here makes the later conversion land on fully-opaque
+        (1.0 float / 255 int) for every input/output combination.
+        """
+        return 255.0 if any(c > 1 for c in rgb) else 1.0
+
     # Handle dict with r/g/b keys
     if isinstance(value, dict):
         if all(k in value for k in ("r", "g", "b")):
@@ -313,10 +325,7 @@ def normalize_color(value: Any, output_range: str = "float") -> tuple[list[float
                 if "a" in value:
                     color.append(float(value["a"]))
                 else:
-                    if output_range == "int" and all(0 <= c <= 1 for c in color):
-                        color.append(1.0)
-                    else:
-                        color.append(1.0 if output_range == "float" else 255)
+                    color.append(_opaque_alpha(color))
                 return _to_output_range(color), None
             except (ValueError, TypeError, KeyError):
                 return None, f"color dict values must be numbers, got {value}"
@@ -328,10 +337,7 @@ def normalize_color(value: Any, output_range: str = "float") -> tuple[list[float
             try:
                 color = [float(c) for c in value]
                 if len(color) == 3:
-                    if output_range == "int" and all(0 <= c <= 1 for c in color):
-                        color.append(1.0)
-                    else:
-                        color.append(1.0 if output_range == "float" else 255)
+                    color.append(_opaque_alpha(color))
                 return _to_output_range(color), None
             except (ValueError, TypeError):
                 return None, f"color values must be numbers, got {value}"
@@ -372,10 +378,7 @@ def normalize_color(value: Any, output_range: str = "float") -> tuple[list[float
             try:
                 color = [float(c) for c in parsed]
                 if len(color) == 3:
-                    if output_range == "int" and all(0 <= c <= 1 for c in color):
-                        color.append(1.0)
-                    else:
-                        color.append(1.0 if output_range == "float" else 255)
+                    color.append(_opaque_alpha(color))
                 return _to_output_range(color), None
             except (ValueError, TypeError):
                 return None, f"color values must be numbers, got {parsed}"
@@ -389,10 +392,7 @@ def normalize_color(value: Any, output_range: str = "float") -> tuple[list[float
             try:
                 color = [float(p) for p in parts]
                 if len(color) == 3:
-                    if output_range == "int" and all(0 <= c <= 1 for c in color):
-                        color.append(1.0)
-                    else:
-                        color.append(1.0 if output_range == "float" else 255)
+                    color.append(_opaque_alpha(color))
                 return _to_output_range(color), None
             except (ValueError, TypeError):
                 pass  # Fall through to error message

--- a/Server/tests/test_normalize_color_alpha.py
+++ b/Server/tests/test_normalize_color_alpha.py
@@ -1,0 +1,58 @@
+"""Regression tests for normalize_color default-alpha scaling.
+
+Bug: when RGB was given in 0-255 scale with float output and no explicit alpha,
+the default opaque alpha (1.0) was appended in float scale, then _to_output_range
+divided the WHOLE list by 255 (because RGB > 1) — collapsing alpha 1.0 -> ~0.004,
+i.e. a fully-opaque color rendered nearly transparent. The default alpha must be
+appended in the RGB's own scale so the range conversion lands on fully-opaque.
+"""
+
+from services.tools.utils import normalize_color
+
+
+def _approx(got, want, tol=1e-6):
+    return got is not None and len(got) == len(want) and all(abs(a - b) <= tol for a, b in zip(got, want))
+
+
+def test_255_rgb_float_output_stays_opaque():
+    # The core regression: opaque orange in 0-255 must NOT become transparent.
+    color, err = normalize_color([255, 128, 0], "float")
+    assert err is None
+    assert _approx(color, [1.0, 128 / 255, 0.0, 1.0]), color
+    assert color[3] == 1.0  # alpha fully opaque, not ~0.004
+
+
+def test_255_rgb_dict_float_output_stays_opaque():
+    color, err = normalize_color({"r": 255, "g": 128, "b": 0}, "float")
+    assert err is None
+    assert _approx(color, [1.0, 128 / 255, 0.0, 1.0]), color
+
+
+def test_normalized_rgb_float_output_unchanged():
+    color, err = normalize_color([1.0, 0.5, 0.0], "float")
+    assert err is None
+    assert _approx(color, [1.0, 0.5, 0.0, 1.0]), color
+
+
+def test_255_rgb_int_output_unchanged():
+    color, err = normalize_color([255, 128, 0], "int")
+    assert err is None
+    assert color == [255, 128, 0, 255]
+
+
+def test_normalized_rgb_int_output_becomes_255_opaque():
+    color, err = normalize_color([0.5, 0.5, 0.5], "int")
+    assert err is None
+    assert color == [128, 128, 128, 255]
+
+
+def test_explicit_alpha_is_respected():
+    # Explicit alpha (any scale) must survive untouched by the default-alpha path.
+    assert _approx(normalize_color([255, 128, 0, 255], "float")[0], [1.0, 128 / 255, 0.0, 1.0])
+    assert _approx(normalize_color([1.0, 0.5, 0.0, 0.5], "float")[0], [1.0, 0.5, 0.0, 0.5])
+
+
+def test_hex_float_output_stays_opaque():
+    color, err = normalize_color("#FF8000", "float")
+    assert err is None
+    assert _approx(color, [1.0, 128 / 255, 0.0, 1.0]), color


### PR DESCRIPTION
## Problem

`normalize_color` turns an **opaque** 0-255 color into a **nearly transparent** one when float output is requested and no explicit alpha is given:

```python
normalize_color([255, 128, 0], "float")
# -> [1.0, 0.502, 0.0, 0.00392]   # alpha should be 1.0, not ~0.004
normalize_color({"r": 255, "g": 128, "b": 0}, "float")
# -> same bug
```

The default opaque alpha (`1.0`) is appended in **float** scale, but `_to_output_range` then divides the **whole** list by 255 because the RGB components exceed 1 — so the `1.0` alpha becomes `1/255 ≈ 0.004`. Any tool that accepts 0-255 colors and normalizes to float (materials, UI, etc.) renders them almost invisible.

## Fix

Append the default opaque alpha in the **same scale as the RGB components** (a single `_opaque_alpha` helper, replacing 4 copies of the ad-hoc append block), so the range conversion always lands on fully-opaque — `1.0` for float output, `255` for int. Explicit alpha, hex strings, int output, and already-normalized 0-1 input are all unchanged.

## Test

`Server/tests/test_normalize_color_alpha.py` covers every input/output combination. Verified against the true pre-fix code: the two 0-255-float cases **fail** (transparent alpha), the other 5 guards pass; on the fix **all 7 pass**. Regression sweep with the param-normalizer suite: 14/14.