### PR TITLE
fix(cli/camera): correct run_command arg order + echo output (command group was crashing)

### DIFF
--- a/Server/src/cli/commands/camera.py
+++ b/Server/src/cli/commands/camera.py
@@ -51,8 +51,8 @@ def ping():
         unity-mcp camera ping
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "ping"})
-    format_output(result, config)
+    result = run_command("manage_camera", {"action": "ping"}, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("list")
@@ -65,8 +65,8 @@ def list_cameras():
         unity-mcp camera list
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "list_cameras"})
-    format_output(result, config)
+    result = run_command("manage_camera", {"action": "list_cameras"}, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("brain-status")
@@ -79,8 +79,8 @@ def brain_status():
         unity-mcp camera brain-status
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "get_brain_status"})
-    format_output(result, config)
+    result = run_command("manage_camera", {"action": "get_brain_status"}, config)
+    click.echo(format_output(result, config.format))
 
 
 # =============================================================================
@@ -125,8 +125,8 @@ def create(name, preset, follow, look_at, priority, fov):
     if props:
         params["properties"] = props
 
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("ensure-brain")
@@ -155,8 +155,8 @@ def ensure_brain(camera_ref, blend_style, blend_duration):
     if props:
         params["properties"] = props
 
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 # =============================================================================
@@ -189,8 +189,8 @@ def set_target(target, search_method, follow, look_at):
         "searchMethod": search_method,
         "properties": props if props else None,
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("set-lens")
@@ -228,8 +228,8 @@ def set_lens(target, search_method, fov, near, far, ortho_size, dutch):
         "searchMethod": search_method,
         "properties": props if props else None,
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("set-priority")
@@ -251,8 +251,8 @@ def set_priority(target, search_method, priority):
         "searchMethod": search_method,
         "properties": {"priority": priority},
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 # =============================================================================
@@ -286,8 +286,8 @@ def set_body(target, search_method, body_type, props):
         "searchMethod": search_method,
         "properties": properties if properties else None,
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("set-aim")
@@ -316,8 +316,8 @@ def set_aim(target, search_method, aim_type, props):
         "searchMethod": search_method,
         "properties": properties if properties else None,
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("set-noise")
@@ -346,8 +346,8 @@ def set_noise(target, search_method, amplitude, frequency):
         "searchMethod": search_method,
         "properties": props if props else None,
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 # =============================================================================
@@ -379,8 +379,8 @@ def add_extension(target, extension_type, search_method, props):
         "searchMethod": search_method,
         "properties": properties,
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("remove-extension")
@@ -402,8 +402,8 @@ def remove_extension(target, extension_type, search_method):
         "searchMethod": search_method,
         "properties": {"extensionType": extension_type},
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 # =============================================================================
@@ -432,8 +432,8 @@ def set_blend(style, duration):
     if props:
         params["properties"] = props
 
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("force")
@@ -453,8 +453,8 @@ def force_camera(target, search_method):
         "target": target,
         "searchMethod": search_method,
     })
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("release")
@@ -467,8 +467,8 @@ def release_override():
         unity-mcp camera release
     """
     config = get_config()
-    result = run_command(config, "manage_camera", {"action": "release_override"})
-    format_output(result, config)
+    result = run_command("manage_camera", {"action": "release_override"}, config)
+    click.echo(format_output(result, config.format))
 
 
 # =============================================================================
@@ -523,8 +523,8 @@ def screenshot(camera_ref, file_name, super_size, include_image, max_resolution,
         params["viewTarget"] = view_target
     if output_folder:
         params["outputFolder"] = output_folder
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))
 
 
 @camera.command("screenshot-multiview")
@@ -550,5 +550,5 @@ def screenshot_multiview(max_resolution, view_target, output_folder):
         params["viewTarget"] = view_target
     if output_folder:
         params["outputFolder"] = output_folder
-    result = run_command(config, "manage_camera", params)
-    format_output(result, config)
+    result = run_command("manage_camera", params, config)
+    click.echo(format_output(result, config.format))

--- a/Server/tests/test_cli.py
+++ b/Server/tests/test_cli.py
@@ -470,7 +470,9 @@ class TestCameraCommands:
             ])
             assert result.exit_code == 0
             mock_run.assert_called_once()
-            params = mock_run.call_args[0][2]
+            # run_command(command_type, params, config): command_type first, params second.
+            assert mock_run.call_args[0][0] == "manage_camera"
+            params = mock_run.call_args[0][1]
             assert params["captureSource"] == "scene_view"
             assert params["viewTarget"] == "Canvas"
             assert params["includeImage"] is True

--- a/Server/tests/test_cli_camera_arg_order.py
+++ b/Server/tests/test_cli_camera_arg_order.py
@@ -1,0 +1,65 @@
+"""Regression: camera CLI commands must call run_command with the correct
+positional argument order.
+
+Bug: every command in cli/commands/camera.py called
+    run_command(config, "manage_camera", params)
+but run_command's signature is run_command(command_type, params, config=None).
+The rotated args put the CLIConfig in the command_type slot and the params dict
+in the config slot, so send_command bound cfg=<params dict> and crashed on
+`cfg.host` (AttributeError) before its try-block — the whole `camera` command
+group was 100% non-functional. Commands also called format_output(result, config)
+(CLIConfig where a format string is expected, with no click.echo), so nothing
+printed. Every other command file uses run_command("manage_x", params, config)
+and click.echo(format_output(result, config.format)).
+"""
+
+from unittest.mock import patch
+import pytest
+from click.testing import CliRunner
+
+from cli.commands.camera import camera
+from cli.utils.config import CLIConfig
+
+
+@pytest.fixture
+def mock_config():
+    return CLIConfig(host="localhost", port=8080, format="text")
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.mark.parametrize(
+    "argv, expected_action",
+    [
+        (["ping"], "ping"),
+        (["list"], "list_cameras"),
+        (["brain-status"], "get_brain_status"),
+    ],
+)
+def test_camera_run_command_arg_order(runner, mock_config, argv, expected_action):
+    resp = {"success": True, "data": {}}
+    with patch("cli.commands.camera.get_config", return_value=mock_config):
+        with patch("cli.commands.camera.run_command", return_value=resp) as mock_run:
+            result = runner.invoke(camera, argv, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+    args = mock_run.call_args.args
+    # Correct order: (command_type, params, config)
+    assert args[0] == "manage_camera"          # pre-fix: this was the CLIConfig object
+    assert isinstance(args[1], dict)           # pre-fix: this was the string "manage_camera"
+    assert args[1]["action"] == expected_action
+    assert args[2] is mock_config              # config passed third
+
+
+def test_camera_ping_emits_output(runner, mock_config):
+    """format_output result must be echoed (pre-fix: no click.echo → empty)."""
+    resp = {"success": True, "data": {"pong": True}}
+    with patch("cli.commands.camera.get_config", return_value=mock_config):
+        with patch("cli.commands.camera.run_command", return_value=resp):
+            result = runner.invoke(camera, ["ping"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.strip() != ""         # pre-fix: nothing printed


### PR DESCRIPTION
## Problem

Every command in `cli/commands/camera.py` calls run_command with **rotated positional arguments**:

```python
run_command(config, "manage_camera", params)   # camera.py (wrong)
run_command("manage_scene", params, config)     # every other command file (correct)
```

`run_command`'s signature is `run_command(command_type, params, config=None)`. The swap puts the `CLIConfig` in the `command_type` slot and the params dict in the `config` slot. `send_command` then binds `cfg = config or get_config()` to the **params dict** (truthy) and, on the very next line — **before its try-block** — evaluates `url = f"http://{cfg.host}:..."`. `cfg.host` on a plain dict raises `AttributeError`, which is outside the try and not a `UnityConnectionError`, so `@handle_unity_errors` doesn't catch it either.

`camera` is registered in `main.py`, so **the entire command group** (`ping`, `list`, `create`, `screenshot`, …) hard-crashes with an uncaught traceback on every invocation — no Unity server even required.

Companion defect (same file): every result line is `format_output(result, config)` — passing a `CLIConfig` where `format_type: str` is expected, with **no `click.echo`**, so even past the crash nothing would print. Every other file does `click.echo(format_output(result, config.format))`.

## Fix

- All 18 `run_command` calls → `run_command("manage_camera", params, config)`.
- All 18 `format_output` calls → `click.echo(format_output(result, config.format))`.

## Test

- New `tests/test_cli_camera_arg_order.py` — asserts `run_command` is called `("manage_camera", <dict>, config)` and that output is emitted; **fails on the pre-fix code** (wrong arg order + empty output).
- The existing `TestCameraCommands.test_camera_screenshot_scene_view` extracted params from the buggy positional slot `[2]` — it had **codified the bug** (passed while the command group was dead). Corrected to slot `[1]` + asserts `command_type == "manage_camera"`.

Full CLI suite **193/193**.