### PR TITLE
fix(cli/probuilder): _parse_edges_param crashed on non-array --edges input

### DIFF
--- a/Server/src/cli/commands/probuilder.py
+++ b/Server/src/cli/commands/probuilder.py
@@ -21,6 +21,13 @@ def _parse_edges_param(edges: str) -> dict[str, Any]:
     except json.JSONDecodeError:
         print_error("Invalid JSON for edges parameter")
         raise SystemExit(1)
+    # json.loads may yield a non-list (int/dict/bool/str); indexing parsed[0]
+    # below would then crash uncaught (TypeError/KeyError). Require an array.
+    if not isinstance(parsed, list):
+        print_error(
+            "edges parameter must be a JSON array, e.g. '[0,1,2]' or '[{\"a\":0,\"b\":1}]'"
+        )
+        raise SystemExit(1)
     if parsed and isinstance(parsed[0], dict):
         return {"edges": parsed}
     return {"edgeIndices": parsed}

--- a/Server/tests/test_cli_probuilder_edges.py
+++ b/Server/tests/test_cli_probuilder_edges.py
@@ -1,0 +1,37 @@
+"""Regression: probuilder _parse_edges_param must reject non-array JSON cleanly.
+
+Bug: _parse_edges_param did `parsed = json.loads(edges)` then indexed
+`parsed[0]` — but json.loads can yield a non-list (int/dict/bool), so
+`probuilder extrude-edges/bevel-edges --edges 5` crashed with an uncaught
+TypeError ('int' object is not subscriptable) and `--edges '{"a":1}'` with a
+KeyError. It now raises a clean SystemExit with a helpful message, matching the
+existing invalid-JSON path.
+"""
+
+import pytest
+
+from cli.commands.probuilder import _parse_edges_param
+
+
+@pytest.mark.parametrize("bad", ["5", '{"a":1}', "true", "3.14"])
+def test_non_array_edges_exit_cleanly(bad):
+    # Pre-fix: TypeError / KeyError (uncaught). Post-fix: SystemExit(1).
+    with pytest.raises(SystemExit):
+        _parse_edges_param(bad)
+
+
+def test_invalid_json_still_exits():
+    with pytest.raises(SystemExit):
+        _parse_edges_param("not-json")
+
+
+def test_flat_index_list_parsed():
+    assert _parse_edges_param("[0, 1, 2]") == {"edgeIndices": [0, 1, 2]}
+
+
+def test_vertex_pair_list_parsed():
+    assert _parse_edges_param('[{"a":0,"b":1}]') == {"edges": [{"a": 0, "b": 1}]}
+
+
+def test_empty_list_is_edge_indices():
+    assert _parse_edges_param("[]") == {"edgeIndices": []}


### PR DESCRIPTION
## Problem

`_parse_edges_param` (used by `probuilder extrude-edges` and `bevel-edges`) does:

```python
parsed = json.loads(edges)          # can be int / dict / bool, not just a list
if parsed and isinstance(parsed[0], dict):   # parsed[0] crashes on non-list
```

So a plausible user mistake crashes the command with a raw, uncaught traceback:

| Input | Result (pre-fix) |
|---|---|
| `--edges 5` | `TypeError: 'int' object is not subscriptable` |
| `--edges '{"a":1}'` | `KeyError: 0` |
| `--edges true` | `TypeError: 'bool' object is not subscriptable` |

Only `json.JSONDecodeError` was guarded — a *valid* JSON scalar/object sails through to the crash.

## Fix

Add an `isinstance(parsed, list)` guard that raises a clean `SystemExit(1)` with a helpful message (`edges must be a JSON array, e.g. '[0,1,2]' or '[{"a":0,"b":1}]'`), matching the existing invalid-JSON path. Valid list inputs are unchanged.

## Test

`tests/test_cli_probuilder_edges.py` — the non-array cases (`5`, `{"a":1}`, `true`, `3.14`) **fail on the pre-fix code** (TypeError/KeyError) and pass on the fix; valid lists + invalid-JSON are regression guards. 8/8.