### PR TITLE
test(manage_camera): update stale capture_source error-message assertion

### DIFF
--- a/Server/tests/test_manage_camera.py
+++ b/Server/tests/test_manage_camera.py
@@ -423,7 +423,8 @@ def test_screenshot_invalid_capture_source(mock_unity):
         )
     )
     assert result["success"] is False
-    assert "capture_source must be either" in result["message"]
+    assert "capture_source must be" in result["message"]
+    assert "'game_view', 'scene_view', or 'screen'" in result["message"]
     assert "params" not in mock_unity
 
 


### PR DESCRIPTION
## Problem

`tests/test_manage_camera.py::test_screenshot_invalid_capture_source` asserts the old error string:

```python
assert "capture_source must be either" in result["message"]
```

but `build_screenshot_params` (utils.py) was updated to return the clearer, value-listing message `"capture_source must be 'game_view', 'scene_view', or 'screen'."`. The test wasn't updated, so it has been **failing (red) on beta** — surfacing as a persistent non-flaky failure on every PR's Python Tests run.

## Fix

Update the assertion to the current message (and check the enumerated valid values), so the suite is green and the test guards real behavior. No production code change.

Verified: `test_screenshot_invalid_capture_source` passes.