### PR TITLE
fix(cli): guard comma-separated vector/color parsing against ValueError crash

### DIFF
--- a/Server/src/cli/commands/graphics.py
+++ b/Server/src/cli/commands/graphics.py
@@ -1,6 +1,7 @@
 import click
 from cli.utils.connection import handle_unity_errors, run_command, get_config
 from cli.utils.output import format_output
+from cli.utils.parsers import parse_float_list, parse_int_list
 
 
 @click.group("graphics")
@@ -398,7 +399,7 @@ def feature_configure(index, name, prop):
 def feature_reorder(order):
     """Reorder renderer features."""
     config = get_config()
-    order_list = [int(x.strip()) for x in order.split(",")]
+    order_list = parse_int_list(order, "order")
     params = {"action": "feature_reorder", "order": order_list}
     result = run_command("manage_graphics", params, config)
     click.echo(format_output(result, config.format))
@@ -472,11 +473,11 @@ def skybox_set_ambient(mode, intensity, color, equator_color, ground_color):
     if intensity is not None:
         params["intensity"] = intensity
     if color:
-        params["color"] = [float(x) for x in color.split(",")]
+        params["color"] = parse_float_list(color, "color")
     if equator_color:
-        params["equator_color"] = [float(x) for x in equator_color.split(",")]
+        params["equator_color"] = parse_float_list(equator_color, "equator_color")
     if ground_color:
-        params["ground_color"] = [float(x) for x in ground_color.split(",")]
+        params["ground_color"] = parse_float_list(ground_color, "ground_color")
     result = run_command("manage_graphics", params, config)
     click.echo(format_output(result, config.format))
 
@@ -498,7 +499,7 @@ def skybox_set_fog(fog_enabled, mode, color, density, start, end):
     if mode:
         params["fog_mode"] = mode
     if color:
-        params["fog_color"] = [float(x) for x in color.split(",")]
+        params["fog_color"] = parse_float_list(color, "color")
     if density is not None:
         params["fog_density"] = density
     if start is not None:

--- a/Server/src/cli/commands/physics.py
+++ b/Server/src/cli/commands/physics.py
@@ -2,6 +2,7 @@ import click
 
 from cli.utils.connection import handle_unity_errors, run_command, get_config
 from cli.utils.output import format_output
+from cli.utils.parsers import parse_float_list, parse_int_list
 
 
 def _coerce_cli_value(value: str):
@@ -151,8 +152,8 @@ def raycast(origin, direction, max_distance, dimension):
     config = get_config()
     params = {
         "action": "raycast",
-        "origin": [float(x) for x in origin.split(",")],
-        "direction": [float(x) for x in direction.split(",")],
+        "origin": parse_float_list(origin, "origin"),
+        "direction": parse_float_list(direction, "direction"),
         "dimension": dimension,
     }
     if max_distance is not None:
@@ -293,12 +294,12 @@ def remove_joint(target, joint_type, component_index):
 def overlap(shape, position, size, dimension):
     """Perform a physics overlap query."""
     config = get_config()
-    pos_parts = [float(x) for x in position.split(",")]
+    pos_parts = parse_float_list(position, "position")
     # Try to parse size as float first, then as array
     try:
         parsed_size = float(size)
     except ValueError:
-        parsed_size = [float(x) for x in size.split(",")]
+        parsed_size = parse_float_list(size, "size")
     params = {
         "action": "overlap",
         "shape": shape,
@@ -321,8 +322,8 @@ def raycast_all(origin, direction, max_distance, dimension):
     config = get_config()
     params = {
         "action": "raycast_all",
-        "origin": [float(x) for x in origin.split(",")],
-        "direction": [float(x) for x in direction.split(",")],
+        "origin": parse_float_list(origin, "origin"),
+        "direction": parse_float_list(direction, "direction"),
         "dimension": dimension,
     }
     if max_distance is not None:
@@ -341,8 +342,8 @@ def linecast(start, end, dimension):
     config = get_config()
     params = {
         "action": "linecast",
-        "start": [float(x) for x in start.split(",")],
-        "end": [float(x) for x in end.split(",")],
+        "start": parse_float_list(start, "start"),
+        "end": parse_float_list(end, "end"),
         "dimension": dimension,
     }
     result = run_command("manage_physics", params, config)
@@ -363,12 +364,12 @@ def shapecast(shape, origin, direction, size, max_distance, dimension):
     try:
         parsed_size = float(size)
     except ValueError:
-        parsed_size = [float(x) for x in size.split(",")]
+        parsed_size = parse_float_list(size, "size")
     params = {
         "action": "shapecast",
         "shape": shape,
-        "origin": [float(x) for x in origin.split(",")],
-        "direction": [float(x) for x in direction.split(",")],
+        "origin": parse_float_list(origin, "origin"),
+        "direction": parse_float_list(direction, "direction"),
         "size": parsed_size,
         "dimension": dimension,
     }
@@ -392,7 +393,7 @@ def apply_force(target, force, force_mode, dimension, torque, position):
     params = {
         "action": "apply_force",
         "target": target,
-        "force": [float(x) for x in force.split(",")],
+        "force": parse_float_list(force, "force"),
         "force_mode": force_mode,
     }
     if dimension:
@@ -401,9 +402,9 @@ def apply_force(target, force, force_mode, dimension, torque, position):
         try:
             params["torque"] = [float(torque)]
         except ValueError:
-            params["torque"] = [float(x) for x in torque.split(",")]
+            params["torque"] = parse_float_list(torque, "torque")
     if position:
-        params["position"] = [float(x) for x in position.split(",")]
+        params["position"] = parse_float_list(position, "position")
     result = run_command("manage_physics", params, config)
     click.echo(format_output(result, config.format))
 

--- a/Server/src/cli/utils/parsers.py
+++ b/Server/src/cli/utils/parsers.py
@@ -3,7 +3,39 @@ import json
 import sys
 from typing import Any
 
+import click
+
 from cli.utils.output import print_error, print_info
+
+
+def parse_float_list(value: str, name: str = "value") -> list[float]:
+    """Parse a comma-separated ``"x,y,z"`` string into a list of floats.
+
+    Raises ``click.BadParameter`` (a clean CLI error + non-zero exit) instead of
+    letting a malformed component (trailing comma, empty part, non-number) crash
+    the command with an uncaught ``ValueError`` traceback. Mirrors the guarded
+    pattern in ``prefab._parse_vector3``.
+    """
+    try:
+        return [float(p.strip()) for p in value.split(",")]
+    except ValueError as e:
+        raise click.BadParameter(
+            f"{name} must be comma-separated numbers, got: '{value}'"
+        ) from e
+
+
+def parse_int_list(value: str, name: str = "value") -> list[int]:
+    """Parse a comma-separated ``"1,2,3"`` string into a list of ints.
+
+    Like :func:`parse_float_list`, raises ``click.BadParameter`` on a malformed
+    component instead of an uncaught ``ValueError``.
+    """
+    try:
+        return [int(p.strip()) for p in value.split(",")]
+    except ValueError as e:
+        raise click.BadParameter(
+            f"{name} must be comma-separated integers, got: '{value}'"
+        ) from e
 
 
 def parse_value_safe(value: str) -> Any:

--- a/Server/tests/test_cli_vector_parse.py
+++ b/Server/tests/test_cli_vector_parse.py
@@ -1,0 +1,58 @@
+"""Regression: comma-separated vector/color CLI options must reject malformed
+input cleanly instead of crashing with an uncaught ValueError.
+
+Bug: physics.py (14 sites) and graphics.py (5 sites) built params with a bare
+`[float(x) for x in origin.split(",")]` (and `int(x)` for graphics order), so a
+plausible typo like `--origin "0,0,"` (trailing comma) or `--origin "0,,0"`
+(empty component) raised an uncaught ValueError — a raw traceback with no message
+to the user. The codebase's own prefab._parse_vector3 shows the intended guarded
+pattern (click.BadParameter). Fixed via parsers.parse_float_list/parse_int_list.
+"""
+
+import pytest
+import click
+from click.testing import CliRunner
+
+from cli.utils.parsers import parse_float_list, parse_int_list
+from cli.commands.physics import physics
+from cli.commands.graphics import graphics
+
+
+# ── unit tests on the shared helpers ──────────────────────────────────────────
+
+def test_parse_float_list_valid():
+    assert parse_float_list("0,1.5,-2") == [0.0, 1.5, -2.0]
+    assert parse_float_list("1, 2 , 3") == [1.0, 2.0, 3.0]  # whitespace tolerated
+
+
+@pytest.mark.parametrize("bad", ["0,0,", "0,,0", "a,b,c", "", "1,x"])
+def test_parse_float_list_bad_raises_badparameter(bad):
+    with pytest.raises(click.BadParameter):
+        parse_float_list(bad, "origin")
+
+
+def test_parse_int_list_valid_and_bad():
+    assert parse_int_list("2,0,1") == [2, 0, 1]
+    with pytest.raises(click.BadParameter):
+        parse_int_list("2,0,", "order")
+
+
+# ── CLI-level: malformed input must NOT surface an uncaught ValueError ─────────
+
+def test_physics_raycast_malformed_origin_no_crash():
+    r = CliRunner().invoke(physics, ["raycast", "--origin", "0,0,", "--direction", "0,-1,0"])
+    # Pre-fix: r.exception is an uncaught ValueError with empty output.
+    assert not isinstance(r.exception, ValueError)
+    assert r.exit_code != 0
+
+
+def test_graphics_malformed_color_no_crash():
+    r = CliRunner().invoke(graphics, ["skybox-set-ambient", "--color", "1,1,"])
+    assert not isinstance(r.exception, ValueError)
+    assert r.exit_code != 0
+
+
+def test_graphics_malformed_order_no_crash():
+    r = CliRunner().invoke(graphics, ["feature-reorder", "--order", "2,0,"])
+    assert not isinstance(r.exception, ValueError)
+    assert r.exit_code != 0


### PR DESCRIPTION
## Problem

`physics.py` (14 sites) and `graphics.py` (5 sites) parse comma-separated vector / color / index options with a bare comprehension and **no guard**:

```python
"origin": [float(x) for x in origin.split(",")],   # physics
order_list = [int(x.strip()) for x in order.split(",")]  # graphics --order
```

So a plausible user typo crashes the command with an **uncaught `ValueError`** — a raw traceback with **no message** to the user:

| Input | Result |
|---|---|
| `physics raycast --origin "0,0,"` (trailing comma) | `ValueError: could not convert string to float: ''` |
| `physics raycast --origin "0,,0"` (empty component) | `ValueError` |
| `graphics feature-reorder --order "2,0,"` | `ValueError: invalid literal for int()` |

The crash happens at param-build time, **before** any network call, and `@handle_unity_errors` only catches `UnityConnectionError` — so it propagates uncaught. The codebase's own `prefab._parse_vector3` already shows the intended guarded pattern (`click.BadParameter`).

## Fix

Add `parse_float_list` / `parse_int_list` to `cli/utils/parsers.py` — they raise `click.BadParameter` (clean "Error: …" message + non-zero exit) on a malformed component, mirroring `prefab._parse_vector3`. All **19 sites** across physics.py + graphics.py route through them. Valid inputs are unchanged.

## Test

`tests/test_cli_vector_parse.py` — unit tests for both helpers (valid + malformed) plus CLI-level tests (physics `raycast`, graphics `skybox-set-ambient` / `feature-reorder`) that **fail on the pre-fix commands** (uncaught `ValueError`) and pass on the fix. 10/10.

_Found by a delegated bug-hunt; verified end-to-end. Same crash-on-plausible-input class as the earlier camera (#26) and probuilder (#27) CLI fixes._