### PR TITLE
fix(cli/batch): guard 'batch run' against AttributeError on data=null response

### DIFF
--- a/Server/src/cli/commands/batch.py
+++ b/Server/src/cli/commands/batch.py
@@ -73,7 +73,10 @@ def batch_run(file: str, parallel: bool, fail_fast: bool):
     click.echo(format_output(result, config.format))
 
     if isinstance(result, dict):
-        results = result.get("data", {}).get("results", [])
+        # A failed/empty batch can return an explicit ``"data": null``; .get(k, {})
+        # only substitutes the default when the key is ABSENT, so ``or {}`` is
+        # needed to avoid ``NoneType.get`` (cf. input_simulation.py's isinstance guard).
+        results = (result.get("data") or {}).get("results", [])
         succeeded = sum(1 for r in results if r.get("success"))
         failed = len(results) - succeeded
 

--- a/Server/tests/test_cli_batch_null_data.py
+++ b/Server/tests/test_cli_batch_null_data.py
@@ -1,0 +1,47 @@
+"""Regression: `batch run` must not crash when the batch response has data=null.
+
+Bug: batch_run did `result.get("data", {}).get("results", [])`, but .get(k, {})
+only substitutes the default when the key is ABSENT — a failed/empty batch can
+return an explicit `"data": null`, so the chain became `None.get("results")` and
+raised an uncaught AttributeError. Sibling input_simulation.py guards this exact
+shape with isinstance(result.get("data"), dict).
+"""
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from cli.commands.batch import batch
+
+
+def _run_with_response(resp):
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump([{"tool": "manage_gameobject", "params": {"action": "create"}}], f)
+        fn = f.name
+    try:
+        with patch("cli.commands.batch.run_command", return_value=resp):
+            return CliRunner().invoke(batch, ["run", fn])
+    finally:
+        os.unlink(fn)
+
+
+def test_batch_run_success_with_null_data_no_crash():
+    # A failed batch commonly returns data=null. Pre-fix: AttributeError.
+    r = _run_with_response({"success": False, "message": "batch failed", "data": None})
+    assert not isinstance(r.exception, AttributeError)
+
+
+def test_batch_run_normal_results_still_summarized():
+    r = _run_with_response(
+        {"success": True, "data": {"results": [{"success": True}, {"success": False}]}}
+    )
+    assert not isinstance(r.exception, AttributeError)
+    assert "1 succeeded, 1 failed" in r.output
+
+
+def test_batch_run_missing_data_key_no_crash():
+    r = _run_with_response({"success": True})  # no data key at all
+    assert not isinstance(r.exception, AttributeError)


### PR DESCRIPTION
## Problem

`batch run` summarizes results with:

```python
if isinstance(result, dict):
    results = result.get("data", {}).get("results", [])   # crashes if data is null
```

`dict.get(key, default)` only substitutes the default when the **key is absent** — a failed or empty batch commonly returns an explicit `"data": null`, so the chain becomes `None.get("results")` → **uncaught `AttributeError`**. There is no `success` guard before this line, so *any* batch-level failure crashes the CLI with a raw traceback. Reproduced: a `{"success": false, "data": null}` response → `AttributeError: 'NoneType' object has no attribute 'get'`.

The sibling `input_simulation.py` guards this exact shape (`isinstance(result.get("data"), dict)`), confirming `data: null` is a real response shape.

## Fix

`(result.get("data") or {}).get("results", [])` — same one-line pattern as the earlier `find_in_file` null-data fix.

## Test

`tests/test_cli_batch_null_data.py` — the `data: null` case **fails on pre-fix** (AttributeError) and passes on the fix; normal-results + missing-key cases guard regressions. 3/3.

_Found by a delegated bug-hunt (ranked as a secondary candidate); verified + reproduced end-to-end._