### PR TITLE
fix(manage_script): guard apply_text_edits against AttributeError on data=null read

### DIFF
--- a/Server/src/services/tools/manage_script.py
+++ b/Server/src/services/tools/manage_script.py
@@ -131,7 +131,11 @@ async def apply_text_edits(
         )
         if not (isinstance(read_resp, dict) and read_resp.get("success")):
             return read_resp if isinstance(read_resp, dict) else {"success": False, "message": str(read_resp)}
-        data = read_resp.get("data", {})
+        # A successful `manage_script read` can carry an explicit ``"data": null``
+        # (same shape guarded in find_in_file); ``.get("data", {})`` only substitutes
+        # the default when the KEY is absent, so ``or {}`` is required to avoid
+        # ``NoneType.get`` on the next line.
+        data = read_resp.get("data") or {}
         contents = data.get("contents")
         if not contents and data.get("contentsEncoded") and data.get("encodedContents"):
             try:

--- a/Server/tests/integration/test_apply_text_edits_null_data.py
+++ b/Server/tests/integration/test_apply_text_edits_null_data.py
@@ -1,0 +1,36 @@
+"""Regression: apply_text_edits must not crash when the read-back returns data=null.
+
+Bug: when an edit needs normalization (LSP range / index form), apply_text_edits
+re-reads the file via `manage_script read`, then did
+    data = read_resp.get("data", {}); data.get("contents")
+A successful read can carry an explicit `"data": null`, so `.get("data", {})`
+returned None and `None.get("contents")` raised an uncaught AttributeError (no
+surrounding try/except). Same shape + fix as the find_in_file null-data guard.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from .test_helpers import DummyContext, setup_script_tools
+
+
+@pytest.mark.asyncio
+async def test_apply_text_edits_survives_null_data_on_read():
+    tools = setup_script_tools()
+    apply = tools["apply_text_edits"]
+
+    async def fake_send(cmd, params, **kwargs):
+        if isinstance(params, dict) and params.get("action") == "read":
+            return {"success": True, "data": None}  # success + explicit null data
+        return {"success": True, "data": {}}
+
+    with patch(
+        "transport.legacy.unity_connection.async_send_command_with_retry", fake_send
+    ):
+        # A range-form edit forces normalization → triggers the read path.
+        resp = await apply(
+            DummyContext(), uri="Assets/X.cs", edits=[{"range": [0, 0], "text": "// x\n"}]
+        )
+
+    # Pre-fix: raised AttributeError. Post-fix: a normal dict response.
+    assert isinstance(resp, dict)


### PR DESCRIPTION
## Problem

When an edit needs normalization (LSP `range` object or `range:[a,b]` index form), `apply_text_edits` re-reads the file via `manage_script read` and then:

```python
if not (isinstance(read_resp, dict) and read_resp.get("success")):
    return ...
data = read_resp.get("data", {})     # None if data is explicitly null
contents = data.get("contents")       # None.get(...) → AttributeError
```

A **successful** read can carry an explicit `"data": null` — the *exact* shape `find_in_file` was recently fixed for (its guard comment notes `manage_script read` returns `data:null` on success). `.get("data", {})` only substitutes the default when the key is absent, so this crashes with an uncaught `AttributeError` — and unlike the `manage_*` wrappers there is **no surrounding try/except**, so it propagates out of the tool. Reproduced with a range-form edit + a `{success:True, data:null}` read.

## Fix

`read_resp.get("data") or {}` — byte-identical to the accepted `find_in_file` null-data fix.

## Test

`tests/integration/test_apply_text_edits_null_data.py` — **fails on pre-fix** (AttributeError at line 135) and passes on the fix.

_Found by a delegated hunt as the twin of the earlier find_in_file (#24) fix; verified + reproduced end-to-end._