### PR TITLE
fix(manage_ui): read with null data crashes with AttributeError

### DIFF
--- a/Server/src/services/tools/manage_ui.py
+++ b/Server/src/services/tools/manage_ui.py
@@ -280,7 +280,12 @@ async def manage_ui(
     if isinstance(result, dict):
         # Decode base64 contents in read responses
         if action_lower == "read" and result.get("success"):
-            data = result.get("data", {})
+            # A successful read can carry an explicit ``"data": null`` — ``.get(k, {})``
+            # only substitutes the default when the key is ABSENT, so ``or {}`` is
+            # required to avoid ``AttributeError`` on the following ``data.get(...)``
+            # (this line sits outside the try/except below). Matches the sibling
+            # fixes in find_in_file / manage_script.apply_text_edits.
+            data = result.get("data") or {}
             if data.get("contentsEncoded") and data.get("encodedContents"):
                 try:
                     decoded = base64.b64decode(

--- a/Server/tests/integration/test_manage_ui_null_data.py
+++ b/Server/tests/integration/test_manage_ui_null_data.py
@@ -1,0 +1,38 @@
+import pytest
+
+from .test_helpers import DummyContext
+import services.tools.manage_ui as ui_mod
+
+
+@pytest.mark.asyncio
+async def test_manage_ui_read_success_with_null_data(monkeypatch):
+    """A successful ``read`` response carrying an explicit ``data: null`` must be
+    returned cleanly, not crash with ``AttributeError: 'NoneType' object has no
+    attribute 'get'``.
+
+    Regression: ``result.get("data", {})`` returns ``None`` (not ``{}``) when the
+    key is present but null — ``.get(key, default)`` only substitutes the default
+    when the key is ABSENT. The following ``data.get("contentsEncoded")`` then
+    crashed, and that line sits OUTSIDE the try/except around the base64 decode, so
+    the exception escaped the tool uncaught. Fixed with ``or {}`` to match the
+    sibling fixes in find_in_file / manage_script.apply_text_edits."""
+
+    async def fake_instance(ctx):
+        return None
+
+    async def fake_send(fn, unity_instance, command, params, **kwargs):
+        return {"success": True, "data": None}
+
+    monkeypatch.setattr(ui_mod, "get_unity_instance_from_context", fake_instance)
+    monkeypatch.setattr(ui_mod, "send_with_unity_instance", fake_send)
+
+    resp = await ui_mod.manage_ui(
+        ctx=DummyContext(),
+        action="read",
+        path="Assets/UI/MainMenu.uxml",
+    )
+
+    # No crash — the success response is returned unchanged.
+    assert isinstance(resp, dict)
+    assert resp.get("success") is True
+    assert resp.get("data") is None


### PR DESCRIPTION
## Problem

A successful `manage_ui(action="read")` response whose `data` key is **present but null** (`{"success": true, "data": null}`) crashed the tool:

```
AttributeError: 'NoneType' object has no attribute 'get'
  at manage_ui.py:284  → data.get("contentsEncoded")
```

`result.get("data", {})` (line 283) returns `None`, not `{}` — `.get(key, default)` only substitutes the default when the key is **absent**, not when it is present-and-null. Line 284 then dereferences `None`, and it sits **outside** the `try/except` around the base64 decode (the function has no outer `try`), so the exception escapes the tool uncaught.

## Why this response shape is real

`manage_ui read` returns the same base64 `encodedContents` payload as `manage_script read`, whose own code comment (`manage_script.py:134-137`) documents that a successful read can carry an explicit `data: null`. This exact crash class was already fixed in **find_in_file**, **manage_script.apply_text_edits**, **batch**, and **refresh_unity** — all use `.get("data") or {}`. `manage_ui` was the last remaining site.

## Fix

One line: `result.get("data", {})` -> `result.get("data") or {}` (matches the sibling fixes).

## Test

`tests/integration/test_manage_ui_null_data.py` — a `read` returning `{"success": True, "data": None}` must return cleanly. **Fails on pre-fix code** with the exact `AttributeError` at line 284; passes on the fix.
