### PR TITLE
fix(cli): guard remaining null-data crashes in CLI commands

### DIFF
--- a/Server/src/cli/commands/editor.py
+++ b/Server/src/cli/commands/editor.py
@@ -350,7 +350,7 @@ def run_tests(mode: str, async_mode: bool, wait: Optional[int], details: bool, f
 
     # For async mode, just show job ID
     if async_mode and result.get("success"):
-        job_id = result.get("data", {}).get("job_id")
+        job_id = (result.get("data") or {}).get("job_id")
         if job_id:
             click.echo(f"Test job started: {job_id}")
             print_info("Poll with: unity-mcp editor poll-test " + job_id)
@@ -401,7 +401,7 @@ def poll_test(job_id: str, wait: int, details: bool, failed_only: bool):
     click.echo(format_output(result, config.format))
 
     if isinstance(result, dict) and result.get("success"):
-        data = result.get("data", {})
+        data = result.get("data") or {}
         status = data.get("status", "unknown")
         if status == "succeeded":
             print_success("Tests completed successfully")

--- a/Server/src/cli/commands/instance.py
+++ b/Server/src/cli/commands/instance.py
@@ -67,7 +67,7 @@ def set_instance(instance_id: str):
     }, config)
     click.echo(format_output(result, config.format))
     if result.get("success"):
-        data = result.get("data", {})
+        data = result.get("data") or {}
         active = data.get("instance", instance_id)
         print_success(f"Active instance set to: {active}")
 

--- a/Server/src/cli/commands/scene.py
+++ b/Server/src/cli/commands/scene.py
@@ -339,7 +339,7 @@ def validate(repair: bool):
     result = run_command("manage_scene", params, config)
     click.echo(format_output(result, config.format))
     if result.get("success"):
-        data = result.get("data", {})
+        data = result.get("data") or {}
         total = data.get("totalIssues", 0)
         repaired = data.get("repaired", 0)
         if total == 0:

--- a/Server/src/cli/commands/shader.py
+++ b/Server/src/cli/commands/shader.py
@@ -40,7 +40,7 @@ def read_shader(path: str):
     }, config)
 
     # If successful, display the contents nicely
-    if result.get("success") and result.get("data", {}).get("contents"):
+    if result.get("success") and (result.get("data") or {}).get("contents"):
         click.echo(result["data"]["contents"])
     else:
         click.echo(format_output(result, config.format))

--- a/Server/tests/test_cli_null_data_guards.py
+++ b/Server/tests/test_cli_null_data_guards.py
@@ -1,0 +1,80 @@
+"""Regression: CLI commands must not crash when Unity returns an explicit
+``"data": null`` alongside ``"success": true``.
+
+``dict.get("data", {})`` only substitutes the ``{}`` default when the key is
+ABSENT — a present-but-null ``data`` returns ``None``, so the following
+``data.get(...)`` (or ``.get("data", {}).get(...)``) raised
+``AttributeError: 'NoneType' object has no attribute 'get'``, uncaught, crashing
+the command. The sibling async-job-id extraction in ``build.py`` / ``packages.py``
+already guards this exact shape with ``(result.get("data") or {})``; these five
+commands were the remaining unguarded copies.
+
+Each test drives the real Click command through a mocked transport that returns
+``{"success": True, "data": None}`` and asserts no ``AttributeError`` escapes.
+Every assertion below fails on the pre-fix code.
+"""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from cli.commands.editor import editor
+from cli.commands.scene import scene
+from cli.commands.instance import instance
+from cli.commands.shader import shader
+from cli.utils.config import CLIConfig
+
+
+CONFIG = CLIConfig(host="localhost", port=8080, format="text")
+NULL_DATA = {"success": True, "data": None}
+
+
+def _run(module, group, args, response):
+    with patch(f"cli.commands.{module}.get_config", return_value=CONFIG), \
+            patch(f"cli.commands.{module}.run_command", return_value=response):
+        return CliRunner().invoke(group, args)
+
+
+def test_editor_tests_async_null_data_no_crash():
+    # `editor tests --async` → run_tests, line ~353.
+    r = _run("editor", editor, ["tests", "--async"], NULL_DATA)
+    assert not isinstance(r.exception, AttributeError), r.exception
+
+
+def test_editor_poll_test_null_data_no_crash():
+    # `editor poll-test <job>` → poll_test, line ~404.
+    r = _run("editor", editor, ["poll-test", "job123"], NULL_DATA)
+    assert not isinstance(r.exception, AttributeError), r.exception
+
+
+def test_scene_validate_null_data_no_crash():
+    # `scene validate` → validate, line ~342.
+    r = _run("scene", scene, ["validate"], NULL_DATA)
+    assert not isinstance(r.exception, AttributeError), r.exception
+
+
+def test_instance_set_null_data_no_crash():
+    # `instance set <id>` → set_instance, line ~70.
+    r = _run("instance", instance, ["set", "unity-123"], NULL_DATA)
+    assert not isinstance(r.exception, AttributeError), r.exception
+
+
+def test_shader_read_null_data_no_crash():
+    # `shader read <path>` → read_shader, line ~43.
+    r = _run("shader", shader, ["read", "Assets/Shaders/Missing.shader"], NULL_DATA)
+    assert not isinstance(r.exception, AttributeError), r.exception
+
+
+def test_editor_tests_async_normal_path_still_works():
+    # Fix must not disturb the normal (non-null) job-id path.
+    resp = {"success": True, "data": {"job_id": "abc123"}}
+    r = _run("editor", editor, ["tests", "--async"], resp)
+    assert r.exit_code == 0
+    assert "abc123" in r.output
+
+
+def test_shader_read_normal_contents_still_work():
+    resp = {"success": True, "data": {"contents": 'Shader "Custom/Test" {}'}}
+    r = _run("shader", shader, ["read", "Assets/Shaders/Test.shader"], resp)
+    assert r.exit_code == 0
+    assert 'Shader "Custom/Test"' in r.output


### PR DESCRIPTION
## Problem

Five CLI commands crashed with an **uncaught** `AttributeError: 'NoneType' object has no attribute 'get'` when Unity returned a success response carrying an explicit `"data": null`:

| Command | File:line | Expression |
|---|---|---|
| `editor tests --async` | editor.py:353 | `result.get("data", {}).get("job_id")` |
| `editor poll-test` | editor.py:404 | `data = result.get("data", {})` |
| `scene validate` | scene.py:342 | `data = result.get("data", {})` |
| `instance set` | instance.py:70 | `data = result.get("data", {})` |
| `shader read` | shader.py:43 | `result.get("data", {}).get("contents")` |

`dict.get("data", {})` only substitutes the `{}` default when the key is **absent** — a present-but-null `data` returns `None`, so the following `.get(...)` dereferenced `None`. All five sit behind an `if result.get("success")` guard and none are inside a `try/except`, so the exception escaped the command.

## Why this shape is real (not theoretical)

The maintainers' own code already guards it: the identical async-job-id extraction is written `(result.get("data") or {}).get("job_id")` in **build.py** (`build run`, `build batch`) and **packages.py**, and **input_simulation.py** guards its copy with `isinstance(result.get("data"), dict)`. These five commands were the remaining unguarded copies of the same pattern. The existing `tests/test_cli_batch_null_data.py` documents `{"success": true, "data": null}` as a real Unity response shape.

## Fix

`.get("data") or {}` (and `(result.get("data") or {})` for the inline chains) — a one-line change per site, matching the guarded siblings.

## Test

`tests/test_cli_null_data_guards.py` drives each real Click command through a mocked null-data transport. **All five null-data cases fail on the pre-fix code** with `AttributeError`; two normal-path cases confirm the guarded chains still return contents / job-id correctly. Existing editor/scene/instance/shader/cli suites: 445 passed, 0 regressions.
