### PR TITLE
fix(manage_texture): as_sprite=False aborts the whole texture operation

### DIFF
--- a/Server/src/services/tools/manage_texture.py
+++ b/Server/src/services/tools/manage_texture.py
@@ -138,9 +138,13 @@ def _normalize_sprite_settings(value: Any) -> tuple[dict | None, str | None]:
             result["pixelsPerUnit"] = float(value["pixelsPerUnit"])
         return result, None
 
-    if isinstance(value, bool) and value:
-        # Just enable sprite mode with defaults
-        return {"pivot": [0.5, 0.5], "pixelsPerUnit": 100}, None
+    if isinstance(value, bool):
+        # True → enable sprite mode with defaults; False → not a sprite (no
+        # settings). `False` is a type-valid value of the `dict | bool` param
+        # (and the stringified "false" parsed above), so it must NOT fall through
+        # to the error branch — doing so aborted the whole texture operation with
+        # the self-contradictory "must be a dict or boolean, got bool".
+        return ({"pivot": [0.5, 0.5], "pixelsPerUnit": 100} if value else None), None
 
     return None, f"as_sprite must be a dict or boolean, got {type(value).__name__}"
 

--- a/Server/tests/integration/test_manage_texture.py
+++ b/Server/tests/integration/test_manage_texture.py
@@ -275,3 +275,61 @@ class TestManageTextureIntegration:
 
         assert resp["success"] is False
         assert "positive" in resp["message"].lower()
+
+
+class TestManageTextureAsSpriteFalse:
+    """Regression: as_sprite=False (a type-valid value of the dict|bool param)
+    must NOT abort the texture operation. Pre-fix, `isinstance(value, bool) and
+    value` let False fall through to the error branch, returning the
+    self-contradictory 'as_sprite must be a dict or boolean, got bool' and never
+    contacting Unity."""
+
+    @pytest.mark.parametrize("as_sprite_value", [False, "false"])
+    def test_as_sprite_false_does_not_abort(self, monkeypatch, as_sprite_value):
+        captured = {}
+
+        async def fake_send(func, instance, cmd, params, **kwargs):
+            captured["params"] = params
+            return {"success": True, "message": "Created texture"}
+
+        monkeypatch.setattr(manage_texture_mod, "send_with_unity_instance", fake_send)
+        monkeypatch.setattr(manage_texture_mod, "preflight", noop_preflight)
+
+        resp = run_async(manage_texture_mod.manage_texture(
+            ctx=DummyContext(),
+            action="create",
+            path="Assets/TestTextures/Plain.png",
+            width=64,
+            height=64,
+            fill_color=[255, 0, 0, 255],
+            as_sprite=as_sprite_value,
+        ))
+
+        # Pre-fix: success False, message "as_sprite must be a dict or boolean,
+        # got bool", and fake_send never called (no captured params).
+        assert resp["success"] is True
+        assert "params" in captured, "transport should have been called"
+        assert captured["params"].get("spriteSettings") is None
+
+    def test_as_sprite_true_still_enables_defaults(self, monkeypatch):
+        captured = {}
+
+        async def fake_send(func, instance, cmd, params, **kwargs):
+            captured["params"] = params
+            return {"success": True, "message": "Created texture"}
+
+        monkeypatch.setattr(manage_texture_mod, "send_with_unity_instance", fake_send)
+        monkeypatch.setattr(manage_texture_mod, "preflight", noop_preflight)
+
+        resp = run_async(manage_texture_mod.manage_texture(
+            ctx=DummyContext(),
+            action="create",
+            path="Assets/TestTextures/Sprite.png",
+            width=64,
+            height=64,
+            fill_color=[255, 0, 0, 255],
+            as_sprite=True,
+        ))
+
+        assert resp["success"] is True
+        assert captured["params"]["spriteSettings"] == {"pivot": [0.5, 0.5], "pixelsPerUnit": 100}


### PR DESCRIPTION
## Problem

`manage_texture`'s `as_sprite` parameter is typed `dict | bool`, so `False` is a type-valid value meaning *"not a sprite"*. But `_normalize_sprite_settings` guarded its boolean branch with `isinstance(value, bool) and value`:

```python
if isinstance(value, bool) and value:      # only True handled
    return {"pivot": [0.5, 0.5], "pixelsPerUnit": 100}, None
return None, f"as_sprite must be a dict or boolean, got {type(value).__name__}"
```

So `False` fell through to the error branch and returned the **self-contradictory** message *"as_sprite must be a dict or boolean, got bool"* (a bool rejected for not being a boolean). Since `manage_texture` aborts on any sprite error **before** the transport call:

```python
sprite_settings, sprite_error = _normalize_sprite_settings(as_sprite)
if sprite_error:
    return {"success": False, "message": sprite_error}
```

an explicit `as_sprite=False` **failed the entire texture operation and never contacted Unity**. The stringified `as_sprite="false"` hits the same path (`parse_json_payload("false") → False`), which matters because this codebase deliberately accepts stringified booleans.

## Fix

Handle the whole boolean domain: `True` → sprite defaults, `False` → no sprite settings (`None`), operation proceeds.

```python
if isinstance(value, bool):
    return ({"pivot": [0.5, 0.5], "pixelsPerUnit": 100} if value else None), None
```

## Test

Parametrized regression tests (`False` and `"false"`) driving the real `manage_texture` through a mocked transport — **both fail on pre-fix code** (`success: False`, transport never called) — plus one asserting `as_sprite=True` still emits the defaults. Suite: 13/13.
