### PR TITLE
fix(transport): stop deliberate client closes logging as console errors

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -653,10 +653,18 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                         catch (Exception ex)
                         {
                             string msg = ex.Message ?? string.Empty;
+                            // Stop() cancels the CTS and then closes every active client, so a
+                            // pending read/write faults with OperationCanceledException or
+                            // ObjectDisposedException. Neither is an IOException — ObjectDisposedException
+                            // derives from InvalidOperationException — so the arms below never matched
+                            // them and expected domain-reload teardown surfaced as a console error.
+                            // Gated on shutdown so a genuine use-after-dispose while live still reports.
+                            bool shuttingDown = !isRunning || token.IsCancellationRequested;
                             bool isBenign =
                                 msg.IndexOf("Connection closed before reading expected bytes", StringComparison.OrdinalIgnoreCase) >= 0
                                 || msg.IndexOf("Read timed out", StringComparison.OrdinalIgnoreCase) >= 0
-                                || ex is IOException;
+                                || ex is IOException
+                                || (shuttingDown && (ex is ObjectDisposedException || ex is OperationCanceledException));
                             if (isBenign)
                             {
                                 if (IsDebugEnabled()) McpLog.Info($"Client handler: {msg}", always: false);

--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -38,6 +38,13 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
         private static readonly object startStopLock = new();
         private static readonly object clientsLock = new();
         private static readonly HashSet<TcpClient> activeClients = new();
+
+        // Clients whose socket we closed on purpose — stale-client eviction, or Stop().
+        // The owning handler is usually parked in a read at that moment, so closing the
+        // socket faults it with ObjectDisposedException. That is the expected consequence
+        // of our own close, not a fault, and must not reach the console as an error.
+        // Entries are removed when the handler exits (see HandleClientAsync's finally).
+        private static readonly HashSet<TcpClient> intentionallyClosed = new();
         private static CancellationTokenSource cts;
         private static Task listenerTask;
         private static int processingCommands = 0;
@@ -352,6 +359,55 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
             return newListener;
         }
 
+        /// <summary>
+        /// Closes a client socket that we are deliberately tearing down (stale-client
+        /// eviction or Stop()), recording it first so the owning handler can tell the
+        /// resulting ObjectDisposedException apart from a genuine fault.
+        /// </summary>
+        private static void CloseClientIntentionally(TcpClient client)
+        {
+            if (client == null) return;
+            lock (clientsLock)
+            {
+                // Only track a handler that is still live. Eviction writes a best-effort
+                // notice (up to 500ms) before closing, so the handler can exit in that
+                // window — and a handler that already ran its cleanup would never remove
+                // the entry again, pinning the TcpClient for the rest of the session.
+                // Stop() clears activeClients up front, so nothing is tracked on that
+                // path; shutdown is covered by the isRunning/token check at the catch.
+                if (activeClients.Contains(client)) intentionallyClosed.Add(client);
+            }
+            try { client.Close(); } catch { }
+        }
+
+        /// <summary>
+        /// Classifies an exception from the client read/write loop. Benign exceptions are
+        /// ordinary connection teardown and are logged at Info; everything else is a real
+        /// fault and reaches the console as an error.
+        /// </summary>
+        /// <param name="closedIntentionally">
+        /// True when we closed this socket ourselves (eviction/Stop) or the bridge is
+        /// shutting down — which makes a disposed-socket or cancellation fault expected.
+        /// </param>
+        internal static bool IsBenignClientException(Exception ex, bool closedIntentionally)
+        {
+            if (ex == null) return false;
+
+            string msg = ex.Message ?? string.Empty;
+            if (msg.IndexOf("Connection closed before reading expected bytes", StringComparison.OrdinalIgnoreCase) >= 0
+                || msg.IndexOf("Read timed out", StringComparison.OrdinalIgnoreCase) >= 0
+                || ex is IOException)
+            {
+                return true;
+            }
+
+            // ObjectDisposedException derives from InvalidOperationException, not
+            // IOException, so it never matched the arms above. Only treat it as benign
+            // when we are the ones who closed the socket — a use-after-dispose on a live
+            // connection is still a real bug and must keep reporting.
+            return closedIntentionally && (ex is ObjectDisposedException || ex is OperationCanceledException);
+        }
+
         public static void Stop()
         {
             Task toWait = null;
@@ -391,7 +447,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
             }
             foreach (var c in toClose)
             {
-                try { c.Close(); } catch { }
+                CloseClientIntentionally(c);
             }
 
             if (toWait != null)
@@ -545,7 +601,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                                 await WriteFrameAsync(stale.GetStream(), evictionBytes, noticeCts.Token).ConfigureAwait(false);
                             }
                             catch { /* best-effort; socket may already be dead */ }
-                            try { stale.Close(); } catch { }
+                            CloseClientIntentionally(stale);
                         }
                     }
 
@@ -653,19 +709,14 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                         catch (Exception ex)
                         {
                             string msg = ex.Message ?? string.Empty;
-                            // Stop() cancels the CTS and then closes every active client, so a
-                            // pending read/write faults with OperationCanceledException or
-                            // ObjectDisposedException. Neither is an IOException — ObjectDisposedException
-                            // derives from InvalidOperationException — so the arms below never matched
-                            // them and expected domain-reload teardown surfaced as a console error.
-                            // Gated on shutdown so a genuine use-after-dispose while live still reports.
-                            bool shuttingDown = !isRunning || token.IsCancellationRequested;
-                            bool isBenign =
-                                msg.IndexOf("Connection closed before reading expected bytes", StringComparison.OrdinalIgnoreCase) >= 0
-                                || msg.IndexOf("Read timed out", StringComparison.OrdinalIgnoreCase) >= 0
-                                || ex is IOException
-                                || (shuttingDown && (ex is ObjectDisposedException || ex is OperationCanceledException));
-                            if (isBenign)
+                            // We close a client's socket on two paths: stale-client eviction
+                            // (bridge still running) and Stop()/domain-reload teardown. Either
+                            // way the parked read here faults, and that is expected.
+                            bool closedIntentionally;
+                            lock (clientsLock) { closedIntentionally = intentionallyClosed.Contains(client); }
+                            closedIntentionally |= !isRunning || token.IsCancellationRequested;
+
+                            if (IsBenignClientException(ex, closedIntentionally))
                             {
                                 if (IsDebugEnabled()) McpLog.Info($"Client handler: {msg}", always: false);
                             }
@@ -679,7 +730,11 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                 }
                 finally
                 {
-                    lock (clientsLock) { activeClients.Remove(client); }
+                    lock (clientsLock)
+                    {
+                        activeClients.Remove(client);
+                        intentionallyClosed.Remove(client);
+                    }
                     int remaining;
                     lock (clientsLock) { remaining = activeClients.Count; }
                     McpLog.Info($"Client handler exited (remaining clients: {remaining})");

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeBenignExceptionTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeBenignExceptionTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using MCPForUnity.Editor.Services.Transport.Transports;
+
+namespace MCPForUnityTests.Editor.Services
+{
+    /// <summary>
+    /// Tests the client read/write loop's benign-exception classification.
+    ///
+    /// Regression: closing a client socket on purpose (stale-client eviction, or Stop())
+    /// faults the owning handler, which is parked in a read, with ObjectDisposedException.
+    /// That exception derives from InvalidOperationException — not IOException — so it fell
+    /// through to Debug.LogError. During an EditMode run Unity's LogAssert then failed
+    /// whichever unrelated test happened to be executing, so a full-suite run produced a
+    /// different bogus failure every time. See The1Studio/unity-mcp#40.
+    /// </summary>
+    [TestFixture]
+    public class StdioBridgeBenignExceptionTests
+    {
+        private static ObjectDisposedException DisposedStream()
+            => new ObjectDisposedException("System.Net.Sockets.NetworkStream");
+
+        // --- The regression itself -------------------------------------------------
+
+        [Test]
+        public void DisposedStream_WhenWeClosedTheSocket_IsBenign()
+        {
+            Assert.IsTrue(
+                StdioBridgeHost.IsBenignClientException(DisposedStream(), closedIntentionally: true),
+                "A socket we closed ourselves (eviction/Stop) must not report its parked read as an error.");
+        }
+
+        [Test]
+        public void DisposedStream_OnLiveConnection_IsNotBenign()
+        {
+            Assert.IsFalse(
+                StdioBridgeHost.IsBenignClientException(DisposedStream(), closedIntentionally: false),
+                "A use-after-dispose on a live connection is a real bug and must keep reporting.");
+        }
+
+        /// <summary>
+        /// The guard that keeps the fix narrow: ObjectDisposedException derives from
+        /// InvalidOperationException, so classifying by the base type would silently
+        /// swallow every unrelated InvalidOperationException from the read loop.
+        /// </summary>
+        [Test]
+        public void UnrelatedInvalidOperationException_IsNotBenign_EvenWhenClosedIntentionally()
+        {
+            Assert.IsFalse(
+                StdioBridgeHost.IsBenignClientException(
+                    new InvalidOperationException("collection was modified"), closedIntentionally: true),
+                "Only ObjectDisposedException is expected teardown — not its base type.");
+        }
+
+        [Test]
+        public void Cancellation_WhenShuttingDown_IsBenign()
+        {
+            Assert.IsTrue(
+                StdioBridgeHost.IsBenignClientException(new OperationCanceledException(), closedIntentionally: true),
+                "Stop() cancels the CTS before closing clients; the resulting cancellation is expected.");
+        }
+
+        [Test]
+        public void Cancellation_OnLiveConnection_IsNotBenign()
+        {
+            Assert.IsFalse(
+                StdioBridgeHost.IsBenignClientException(new OperationCanceledException(), closedIntentionally: false),
+                "Cancellation with no teardown in progress is not expected teardown.");
+        }
+
+        // --- Pre-existing classifications must be preserved ------------------------
+
+        [Test]
+        public void IOException_IsBenign_RegardlessOfTeardown()
+        {
+            Assert.IsTrue(StdioBridgeHost.IsBenignClientException(new IOException("peer reset"), closedIntentionally: false));
+            Assert.IsTrue(StdioBridgeHost.IsBenignClientException(new IOException("peer reset"), closedIntentionally: true));
+        }
+
+        [Test]
+        public void ConnectionClosedMessage_IsBenign_RegardlessOfTeardown()
+        {
+            var ex = new Exception("Connection closed before reading expected bytes");
+            Assert.IsTrue(StdioBridgeHost.IsBenignClientException(ex, closedIntentionally: false));
+        }
+
+        [Test]
+        public void ReadTimedOutMessage_IsBenign_RegardlessOfTeardown()
+        {
+            var ex = new Exception("Read timed out");
+            Assert.IsTrue(StdioBridgeHost.IsBenignClientException(ex, closedIntentionally: false));
+        }
+
+        [Test]
+        public void MessageMatching_IsCaseInsensitive()
+        {
+            var ex = new Exception("CONNECTION CLOSED BEFORE READING EXPECTED BYTES");
+            Assert.IsTrue(StdioBridgeHost.IsBenignClientException(ex, closedIntentionally: false));
+        }
+
+        // --- Everything else still reports ----------------------------------------
+
+        [Test]
+        public void UnrelatedException_IsNotBenign()
+        {
+            Assert.IsFalse(
+                StdioBridgeHost.IsBenignClientException(new FormatException("bad frame header"), closedIntentionally: true),
+                "A genuine protocol/parsing fault must always reach the console.");
+        }
+
+        [Test]
+        public void NullException_IsNotBenign()
+        {
+            Assert.IsFalse(StdioBridgeHost.IsBenignClientException(null, closedIntentionally: true));
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeBenignExceptionTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeBenignExceptionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e1dd7f0db7e4c27a627f3f777c65f6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeReconnectTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Services/StdioBridgeReconnectTests.cs
@@ -216,6 +216,63 @@ namespace MCPForUnityTests.Editor.Services
             }
         }
 
+        /// <summary>
+        /// Evicting a stale client must not put an error in the console. The evicted
+        /// handler is parked in a read when we close its socket, so it faults with
+        /// ObjectDisposedException — expected teardown, not a fault. While that reached
+        /// Debug.LogError, Unity's LogAssert failed whichever unrelated test happened to
+        /// be running, so every full-suite run produced a different bogus failure.
+        /// See The1Studio/unity-mcp#40.
+        ///
+        /// This covers the wiring (every deliberate close is routed through
+        /// CloseClientIntentionally); StdioBridgeBenignExceptionTests covers the
+        /// classification itself.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator EvictingStaleClient_DoesNotLogConsoleError()
+        {
+            if (!StdioBridgeHost.IsRunning)
+            {
+                Assert.Ignore("StdioBridgeHost is not running; skipping eviction-logging test.");
+                yield break;
+            }
+
+            int port = StdioBridgeHost.GetCurrentPort();
+
+            var client1 = new TcpClient();
+            try
+            {
+                Assert.IsTrue(client1.ConnectAsync("127.0.0.1", port).Wait(ConnectTimeoutMs),
+                    "First client connect timed out");
+                client1.ReceiveTimeout = ReadTimeoutMs;
+                string handshake1 = ReadLine(client1.GetStream(), ReadTimeoutMs);
+                Assert.That(handshake1, Does.Contain("FRAMING=1"), "First client should receive handshake");
+
+                // Second client connects — this evicts client1 and closes its socket.
+                using (var client2 = new TcpClient())
+                {
+                    Assert.IsTrue(client2.ConnectAsync("127.0.0.1", port).Wait(ConnectTimeoutMs),
+                        "Second client connect timed out");
+                    client2.ReceiveTimeout = ReadTimeoutMs;
+                    string handshake2 = ReadLine(client2.GetStream(), ReadTimeoutMs);
+                    Assert.That(handshake2, Does.Contain("FRAMING=1"), "Second client should receive handshake");
+
+                    client2.Close();
+                }
+
+                // The evicted handler faults on a threadpool continuation, so give it
+                // room to surface before asserting the console stayed clean.
+                for (int i = 0; i < 30; i++)
+                    yield return null;
+
+                LogAssert.NoUnexpectedReceived();
+            }
+            finally
+            {
+                try { client1.Close(); } catch { }
+            }
+        }
+
         #region Frame protocol helpers
 
         private static string ReadLine(NetworkStream stream, int timeoutMs)


### PR DESCRIPTION
## Problem

`StdioBridgeHost.HandleClientAsync` has a benign-teardown filter that suppresses expected socket-shutdown noise. `ObjectDisposedException` slipped through it and was logged via `McpLog.Error`, which Unity's strict `LogAssert` then attributed to **whichever EditMode test happened to be executing** — so a green suite produced one plausible-looking domain failure, landing on a different test on every run.

## Why it escaped (the non-obvious part)

The filter's type arm was `ex is IOException`.

- **`ObjectDisposedException` derives from `InvalidOperationException`**, not from `IOException`. It is not in the I/O exception family at all, so a filter written in terms of `IOException` can never match it.
- **`OperationCanceledException` derives directly from `Exception`** — likewise unmatched. `Stop()` cancels the CTS (line ~371) **before** it closes active clients (line ~394), so it *could* escape the same way on the shutdown path. Flagging the evidence level honestly: every one of the 87 logged occurrences reads `Cannot access a disposed object.` and **not one** reads `The operation was canceled.` This one is a reasoned hole, not an observed cause. It is handled here because it is identically gated and closing it costs nothing — not because it was measured.

The message-substring arms did not help either: neither `"Cannot access a disposed object."` nor `"The operation was canceled."` contains `"Connection closed before reading expected bytes"` or `"Read timed out"`.

Note that `ReadExactAsync` deliberately converts only *timeout* cancellations into `IOException("Read timed out")` — its filter is `catch (OperationCanceledException) when (!cancel.IsCancellationRequested)`. A genuine host-token cancellation is intentionally left to propagate.

## Which teardown path actually fires — measured, not assumed

We close a client socket on **two** paths, and it matters which one produces the reported flake:

1. **`Stop()` / domain-reload teardown** — `isRunning` is already `false` when the sockets close.
2. **Stale-client eviction** (`stale.Close()` when a second MCP client connects) — the bridge is **fully live**: `isRunning == true`, token not cancelled.

Correlating every occurrence in a 44 MB `Editor.log` against the bridge's own lifecycle lines:

| Nearest preceding lifecycle event | Count |
|---|---|
| `Closing N stale client(s) after new connection` (eviction) | 52 |
| `Client handler exited` (sibling in the *same* eviction batch) | 35 |
| Domain reload / `Stop()` | **0** |

**87/87 occurrences had an eviction closer than any reload**, each landing 29-84 log lines after one. The error count also tracks the eviction batch size — `Closing 2 stale client(s)` yields two errors, `Closing 4` yields four. (Measured independently twice, by two people; the first pass over a 26 MB snapshot of the same log counted 54/54 — hence the figure in commit `39cd2787`. Same conclusion, more data.)

This matters because it inverts the original scoping of this PR. An earlier revision gated the fix on `shuttingDown = !isRunning || token.IsCancellationRequested` and listed the eviction path as *deliberately out of scope*. On the evidence above that gate is `false` for all 87, so **that version would have been a no-op for the reported bug** while explicitly dismissing its actual cause. Multi-agent sessions make eviction the common case, not the exotic one: stdio permits one client, so every new agent connection stomps the previous one.

## Fix

Both deliberate closes now route through a single helper that records the client before closing it:

```csharp
private static void CloseClientIntentionally(TcpClient client)
{
    if (client == null) return;
    lock (clientsLock)
    {
        if (activeClients.Contains(client)) intentionallyClosed.Add(client);
    }
    try { client.Close(); } catch { }
}
```

The handler then treats a disposed/cancelled socket as benign **only when we are the ones who closed it** — or when the bridge is shutting down, which also covers the domain-reload case where statics reset without `Stop()` running:

```csharp
bool closedIntentionally;
lock (clientsLock) { closedIntentionally = intentionallyClosed.Contains(client); }
closedIntentionally |= !isRunning || token.IsCancellationRequested;

if (IsBenignClientException(ex, closedIntentionally)) { /* Info */ } else { /* Error */ }
```

A use-after-dispose on a **live** connection that we did not close still reports as an error.

Two details worth flagging for review:

- **Liveness guard on tracking.** Eviction writes a best-effort notice with a 500 ms timeout *before* closing, so the handler can exit in that window. Adding it to the set afterwards would pin the `TcpClient` for the rest of the session, since only the handler's `finally` removes entries. Tracking is therefore skipped for handlers no longer in `activeClients`. `Stop()` clears `activeClients` up front, so nothing is tracked on that path — shutdown is covered by the `isRunning`/token check instead.
- **Classification extracted** to `internal static bool IsBenignClientException(Exception, bool)` so it is directly testable. `MCPForUnity/Editor/AssemblyInfo.cs` already grants `InternalsVisibleTo("MCPForUnityTests.EditMode")`.

## Tests

`StdioBridgeBenignExceptionTests` (new, 11 cases) pins the classification, including the guard that keeps the fix narrow: **an unrelated `InvalidOperationException` is *not* benign**, so classifying by the base type can't regress in later. It also pins that the pre-existing `IOException` / message-substring arms still behave identically.

`StdioBridgeReconnectTests.EvictingStaleClient_DoesNotLogConsoleError` (new) covers the *wiring* rather than the predicate — it triggers a real eviction and asserts `LogAssert.NoUnexpectedReceived()`, so a future close site that forgets the helper is caught. It follows the file's existing `Assert.Ignore` convention when the bridge isn't running.

## Verification

- Both changed files parse clean under Roslyn (`csc -langversion:latest`): only `CS0246`/`CS0234` from absent Unity/Newtonsoft references, **zero `CS1xxx` syntax errors**.
- Root-cause correlation is from log evidence (table above), not inference.
- **Not run:** the Unity EditMode suite. The only editor available was mid-run on an unrelated project and off-limits, which is also why this was developed in an isolated worktree. The new tests are unexecuted and want a real run before merge.

Fixes #40

