### PR TITLE
fix(read_console): honor count="all"/"*" as unlimited (was silently capped at 10)

### DIFF
--- a/Server/src/services/tools/read_console.py
+++ b/Server/src/services/tools/read_console.py
@@ -102,12 +102,19 @@ async def read_console(
     # (and can exceed the plugin command timeout when Unity has a large console).
     # To keep the tool responsive by default, we cap the default to a reasonable number of most-recent entries.
     # If a client truly wants everything, it can pass count="all" (or count="*") explicitly.
-    if isinstance(count, str) and count.strip().lower() in ("all", "*"):
+    wants_all = isinstance(count, str) and count.strip().lower() in ("all", "*")
+    if wants_all:
         count = None
     else:
         count = coerce_int(count)
 
-    if action == "get" and count is None:
+    # Cap the default to a responsive number of recent entries — but NOT when the
+    # caller explicitly asked for everything via count="all"/"*". Without the
+    # `not wants_all` guard this rewrote the "all" sentinel's None back to 10, so
+    # "give me the whole console" silently returned only the 10 newest entries
+    # (the C# handler and the null-preserving params_dict below already honor None
+    # as "no limit" — only this default-fill defeated it).
+    if action == "get" and count is None and not wants_all:
         count = 10
 
     # Prepare parameters for the C# handler

--- a/Server/tests/integration/test_read_console_count_all.py
+++ b/Server/tests/integration/test_read_console_count_all.py
@@ -1,0 +1,33 @@
+import pytest
+from .test_helpers import DummyContext, DummyMCP
+
+
+def setup_console_tools():
+    mcp = DummyMCP()
+    import services.tools.read_console  # noqa: F401
+    from services.registry import get_registered_tools
+    for tool_info in get_registered_tools():
+        if tool_info['name'] == 'read_console':
+            mcp.tools[tool_info['name']] = tool_info['func']
+    return mcp.tools
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sentinel", ["all", "*", "ALL"])
+async def test_read_console_count_all_sends_null(monkeypatch, sentinel):
+    tools = setup_console_tools()
+    read_console = tools["read_console"]
+    captured = {}
+
+    async def fake_send_with_unity_instance(_send_fn, _inst, _cmd, params, **_kw):
+        captured["params"] = params
+        return {"success": True, "data": {"lines": []}}
+
+    import services.tools.read_console as mod
+    monkeypatch.setattr(mod, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await read_console(ctx=DummyContext(), action="get", count=sentinel)
+    assert resp["success"] is True
+    assert captured["params"]["count"] is None, (
+        f"count={sentinel!r} should mean 'all' (null), got {captured['params']['count']!r}"
+    )


### PR DESCRIPTION
## Problem

`read_console` normalizes `count="all"`/`"*"` to `None` (no limit), but the next line unconditionally rewrote `None -> 10` for `action="get"` (the default). Since `action` defaults to `"get"`, every read hit that default-fill — so the documented "give me everything" sentinel silently returned only the **10 most recent** console entries. The "all" branch was dead code.

Both ends already honor the sentinel: `ReadConsole.cs` caps only `if (count.HasValue && ...)`, and `params_dict` deliberately preserves a null count. Only the Python default-fill defeated it.

## Fix

Track `wants_all` and skip the default-10 fill when the caller explicitly asked for everything. Scoped strictly to the sentinel — default-count-10 and paging are unchanged.

## Verification

Regression test: `count` in `{"all","*","ALL"}` sends `params["count"] is None`. **Fails on pre-fix code** (got 10); the existing truncate/paging suite still passes (9 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
