### PR TITLE
fix(script_apply_edits): honor "replacement" in the pure-text regex_replace path

### DIFF
--- a/Server/src/services/tools/script_apply_edits.py
+++ b/Server/src/services/tools/script_apply_edits.py
@@ -1171,9 +1171,14 @@ async def script_apply_edits(
             for e in edits or []:
                 op = (e.get("op") or e.get("operation") or e.get(
                     "type") or e.get("mode") or "").strip().lower()
-                # aliasing for text field
+                # aliasing for text field — must include "replacement" (the
+                # canonical regex_replace key, per the docstring and normalizer).
+                # Omitting it made a regex_replace that supplies only
+                # "replacement" produce newText="" here, so Unity DELETED the
+                # matched span instead of replacing it (while returning success).
+                # The mixed-batch converter already includes this alias.
                 text_field = e.get("text") or e.get(
-                    "insert") or e.get("content") or ""
+                    "insert") or e.get("content") or e.get("replacement") or ""
                 if op == "anchor_insert":
                     anchor = e.get("anchor") or ""
                     position = (e.get("position") or "after").lower()

--- a/Server/tests/test_script_apply_edits_regex_replacement.py
+++ b/Server/tests/test_script_apply_edits_regex_replacement.py
@@ -1,0 +1,42 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import pytest
+from services.tools.script_apply_edits import script_apply_edits
+
+SOURCE = ("public class Player : MonoBehaviour\n{\n"
+          "    public int health = 100;\n}\n")
+
+@pytest.fixture
+def unity(monkeypatch):
+    captured = {}
+    async def fake_read(tool_name, params, instance_id=None, **kwargs):
+        assert params["action"] == "read"
+        return {"success": True, "data": {"contents": SOURCE}}
+    async def fake_send_mutation(ctx, unity_instance, tool_name, params, **kwargs):
+        captured["params"] = params
+        return {"success": True, "message": "ok"}
+    monkeypatch.setattr("services.tools.script_apply_edits.get_unity_instance_from_context",
+                        AsyncMock(return_value="unity-1"))
+    monkeypatch.setattr("services.tools.script_apply_edits.async_send_command_with_retry", fake_read)
+    monkeypatch.setattr("services.tools.script_apply_edits.send_mutation", fake_send_mutation)
+    return captured
+
+def _ctx():
+    return SimpleNamespace(info=AsyncMock(), error=AsyncMock())
+
+def test_regex_replace_honors_replacement_field(unity):
+    asyncio.run(script_apply_edits(_ctx(), name="Player", path="Assets/Scripts",
+        edits=[{"op": "regex_replace", "pattern": r"health = 100",
+                "replacement": "health = 250"}]))
+    spans = unity["params"]["edits"]
+    assert len(spans) == 1
+    assert spans[0]["newText"] == "health = 250", (
+        f"regex_replace dropped the replacement text -> newText={spans[0]['newText']!r} "
+        "(empty newText DELETES the matched code instead of replacing it)")
+
+def test_regex_replace_honors_text_field_alias(unity):
+    asyncio.run(script_apply_edits(_ctx(), name="Player", path="Assets/Scripts",
+        edits=[{"op": "regex_replace", "pattern": r"health = 100",
+                "text": "health = 250"}]))
+    assert unity["params"]["edits"][0]["newText"] == "health = 250"


### PR DESCRIPTION
## Problem — silent code destruction

The pure-text routing converter (`script_apply_edits.py:1175`) built its replacement from `text`/`insert`/`content` but **not** `replacement` — the canonical `regex_replace` key (advertised in the docstring and produced by the normalizer):

```python
text_field = e.get("text") or e.get("insert") or e.get("content") or ""   # missing "replacement"
```

So a `regex_replace` edit that supplies only `replacement` yielded `newText=""`, and Unity **DELETED the matched span** instead of replacing it — while the tool returned `success:true`.

```
regex_replace pattern="health = 100" replacement="health = 250"
→ span sent to Unity: {…, "newText": ""}   →  `public int ;`  (code destroyed)
```

The sibling **mixed-batch** converter (`:1029`) already includes the `replacement` alias — so an identical edit works when batched with a structured op but silently deletes when sent alone. Two other sites treat `replacement` as canonical (`:862`, `:441`), and the `content` alias renames into `replacement` (`:781`). No guard caught it — a span *was* computed, just an empty one.

## Fix

Add `or e.get("replacement")` so the pure-text converter matches the mixed-batch converter.

## Verification

- Regression test: `regex_replace` with only `replacement` sets `newText` to the replacement (was `""`); a control using `text` proves the span math is fine. **The replacement case fails on pre-fix code.**
- Unit suite: **982 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
