### PR TITLE
fix(script_apply_edits): don't drop anchor matches when "}" is a regex quantifier

### DIFF
--- a/Server/src/services/tools/script_apply_edits.py
+++ b/Server/src/services/tools/script_apply_edits.py
@@ -493,7 +493,14 @@ def _find_best_anchor_match(pattern: str, text: str, flags: int, prefer_last: bo
 
     if is_closing_brace_pattern and prefer_last:
         # Use heuristics to find the best closing brace match
-        return _find_best_closing_brace_match(matches, text)
+        best = _find_best_closing_brace_match(matches, text)
+        if best is not None:
+            return best
+        # The scorer found no real (non-string) '}' inside any match, so the '}'
+        # in the pattern was not a closing brace at all — e.g. a quantifier like
+        # `\s{4}` / `\w{2,}`. Returning its None discarded matches the regex
+        # genuinely produced (reported as anchor_not_found, or silently dropped a
+        # regex_replace). Fall through to the default instead.
 
     # Default behavior: use last match if prefer_last, otherwise first match
     return matches[-1] if prefer_last else matches[0]

--- a/Server/tests/integration/test_anchor_quantifier_bug.py
+++ b/Server/tests/integration/test_anchor_quantifier_bug.py
@@ -1,0 +1,34 @@
+import re
+from services.tools.script_apply_edits import _find_best_anchor_match
+
+CODE = (
+    'public class PlayerController : MonoBehaviour\n'
+    '{\n'
+    '    void Start()\n'
+    '    {\n'
+    '    }\n'
+    '\n'
+    '    void Update()\n'
+    '    {\n'
+    '    }\n'
+    '}\n'
+)
+
+def test_quantifier_anchor_still_matches():
+    pattern = r'^\s{4}void \w+\(\)\s*$'
+    raw = list(re.finditer(pattern, CODE, re.MULTILINE))
+    assert len(raw) == 2, "sanity: the regex really does match twice"
+    match = _find_best_anchor_match(pattern, CODE, re.MULTILINE, prefer_last=True)
+    assert match is not None, "anchor has 2 real matches but helper reported none"
+    assert match.group(0).strip() == "void Update()"
+
+def test_trailing_ws_quantifier_anchor_still_matches():
+    pattern = r'^\s{4}void \w+\(\)\s*'
+    assert len(list(re.finditer(pattern, CODE, re.MULTILINE))) == 2
+    assert _find_best_anchor_match(pattern, CODE, re.MULTILINE, prefer_last=True) is not None
+
+def test_real_closing_brace_still_uses_heuristic():
+    # A genuine closing-brace anchor must still route through the scorer and match.
+    pattern = r'^\s*}\s*$'
+    m = _find_best_anchor_match(pattern, CODE, re.MULTILINE, prefer_last=True)
+    assert m is not None and m.group(0).strip() == "}"


### PR DESCRIPTION
## Problem

`_find_best_anchor_match` flags any anchor regex containing `}` plus `$` (or a trailing `\s*`) as a "closing-brace pattern" and returned `_find_best_closing_brace_match`'s result **verbatim**. That scorer returns `None` when no **literal** `}` sits inside any match (it only records offsets where `text[offset] == "}"`). So an anchor whose `}` is a regex **quantifier** — `\s{4}`, `\w{2,}`, `\d{1,3}` — was reported as "no match" even though the regex matched, and the `None` was indistinguishable from "pattern didn't match".

Two live call sites:
- **mixed batch** (`anchor_insert` + a text op) → returns `anchor_not_found`, a hard false negative on an anchor that *does* match.
- **pure-text batch with `regex_replace`** → silently **drops** the edit; the siblings apply and the tool returns `success:true` while the replace never happened.

A stock `^\s{4}void \w+\(\)\s*$` anchor over a MonoBehaviour with `Start()`/`Update()` reproduces it.

## Fix

Fall through to the default match selection when the brace scorer returns `None` (the `}` was a quantifier, not a closing brace) instead of discarding matches the regex genuinely produced. A genuine closing-brace anchor still routes through the scorer.

## Verification

- Regression test: two quantifier anchors (`{4}` with and without a trailing `$`) resolve to their last match; a real `^\s*}\s*$` closing-brace control still matches. **The quantifier cases fail on pre-fix code.**
- Unit suite: **982 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
