### PR TITLE
fix(focus_nudge): honor UNITY_MCP_NUDGE_DURATION_S (override was a no-op)

### DIFF
--- a/Server/src/utils/focus_nudge.py
+++ b/Server/src/utils/focus_nudge.py
@@ -44,9 +44,14 @@ _BASE_NUDGE_INTERVAL_S = _parse_env_float("UNITY_MCP_NUDGE_BASE_INTERVAL_S", 1.0
 # Can be overridden via UNITY_MCP_NUDGE_MAX_INTERVAL_S environment variable
 _MAX_NUDGE_INTERVAL_S = _parse_env_float("UNITY_MCP_NUDGE_MAX_INTERVAL_S", 10.0)
 
-# Default duration to keep Unity focused during a nudge
+# Default duration to keep Unity focused during a nudge.
+# _BASE_FOCUS_DURATION_S is the UNSCALED baseline; the env override is scaled
+# relative to it below. Keep the two separate: if the env-resolved value is used
+# as the scale denominator, the ratio is always 1.0 when the env var is set, so
+# UNITY_MCP_NUDGE_DURATION_S is silently ignored.
 # Can be overridden via UNITY_MCP_NUDGE_DURATION_S environment variable
-_DEFAULT_FOCUS_DURATION_S = _parse_env_float("UNITY_MCP_NUDGE_DURATION_S", 3.0)
+_BASE_FOCUS_DURATION_S = 3.0
+_DEFAULT_FOCUS_DURATION_S = _parse_env_float("UNITY_MCP_NUDGE_DURATION_S", _BASE_FOCUS_DURATION_S)
 
 _last_nudge_time: float = 0.0
 _consecutive_nudges: int = 0
@@ -111,9 +116,9 @@ def _get_current_focus_duration() -> float:
     # Scale by ratio of configured to default duration (if UNITY_MCP_NUDGE_DURATION_S is set)
     scale = 1.0
     if os.environ.get("UNITY_MCP_NUDGE_DURATION_S") is not None:
-        configured_duration = _parse_env_float("UNITY_MCP_NUDGE_DURATION_S", _DEFAULT_FOCUS_DURATION_S)
-        if _DEFAULT_FOCUS_DURATION_S > 0:
-            scale = configured_duration / _DEFAULT_FOCUS_DURATION_S
+        configured_duration = _parse_env_float("UNITY_MCP_NUDGE_DURATION_S", _BASE_FOCUS_DURATION_S)
+        if _BASE_FOCUS_DURATION_S > 0:
+            scale = configured_duration / _BASE_FOCUS_DURATION_S
     duration = base_duration * scale
     if duration <= 0:
         return _DEFAULT_FOCUS_DURATION_S

--- a/Server/tests/test_focus_nudge_duration_env.py
+++ b/Server/tests/test_focus_nudge_duration_env.py
@@ -1,0 +1,25 @@
+import importlib
+import pytest
+
+@pytest.mark.parametrize("consecutive, expected", [(0, 6.0), (1, 10.0), (2, 16.0), (3, 24.0)])
+def test_nudge_duration_env_var_scales_ladder(monkeypatch, consecutive, expected):
+    monkeypatch.setenv("UNITY_MCP_NUDGE_DURATION_S", "6.0")
+    from utils import focus_nudge
+    focus_nudge = importlib.reload(focus_nudge)
+    try:
+        focus_nudge._consecutive_nudges = consecutive
+        assert focus_nudge._get_current_focus_duration() == expected
+    finally:
+        monkeypatch.delenv("UNITY_MCP_NUDGE_DURATION_S", raising=False)
+        importlib.reload(focus_nudge)
+
+def test_nudge_duration_unset_env_keeps_base_ladder(monkeypatch):
+    monkeypatch.delenv("UNITY_MCP_NUDGE_DURATION_S", raising=False)
+    from utils import focus_nudge
+    focus_nudge = importlib.reload(focus_nudge)
+    observed = []
+    for n in range(4):
+        focus_nudge._consecutive_nudges = n
+        observed.append(focus_nudge._get_current_focus_duration())
+    focus_nudge._consecutive_nudges = 0
+    assert observed == [3.0, 5.0, 8.0, 12.0]


### PR DESCRIPTION
## Problem

`_get_current_focus_duration` scales its duration ladder by `configured_duration / _DEFAULT_FOCUS_DURATION_S`. But `_DEFAULT_FOCUS_DURATION_S` is itself `_parse_env_float("UNITY_MCP_NUDGE_DURATION_S", 3.0)` — so whenever the env var is set, **both sides of the ratio are the same number**, `scale` is always exactly `1.0`, and the user's `UNITY_MCP_NUDGE_DURATION_S` setting is silently ignored.

The docstring states the contract it fails: *"if `UNITY_MCP_NUDGE_DURATION_S=6.0` (2× default), all durations are doubled: (6, 10, 16, 24 seconds)"*.

```
UNITY_MCP_NUDGE_DURATION_S=6.0   →  actual 3/5/8/12   expected 6/10/16/24
```

Reachable from `run_tests.py` (both the `wait_timeout` polling loop and the fire-and-forget path call `nudge_unity_focus` with no explicit duration), so a user who raises the env var to give background Unity more time to un-stall PlayMode tests gets none of it.

## Fix

Keep an unscaled `_BASE_FOCUS_DURATION_S = 3.0` separate from the env-resolved value, and use the base as the scale denominator.

## Verification

- Regression test: `UNITY_MCP_NUDGE_DURATION_S=6.0` doubles the ladder to `6/10/16/24`; a control with the env unset keeps `3/5/8/12` (so the fix can't be faked by scaling unconditionally). **The four env cases fail on pre-fix code.** Full unit suite **987 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
