### PR TITLE
fix(cli): surface message-only success responses in text output

### DIFF
--- a/Server/src/cli/utils/output.py
+++ b/Server/src/cli/utils/output.py
@@ -74,6 +74,14 @@ def format_as_text(data: Any, indent: int = 0) -> str:
                             f"{prefix}  [{i}] {_format_list_item(item)}")
             else:
                 lines.append(f"{prefix}{key}: {value}")
+        if not lines and "success" in data and data.get("message"):
+            # Success envelope with no payload: C# SuccessResponse declares
+            # `data` with NullValueHandling.Ignore, so `new SuccessResponse("...")`
+            # emits only {success, message}. Every field above was skipped as a
+            # meta field, leaving lines empty — surface the message instead of
+            # rendering a blank string. Mirrors the error branch, which already
+            # falls back to `message`.
+            return f"{prefix}✅ {data['message']}"
         return "\n".join(lines)
 
     if isinstance(data, list):

--- a/Server/tests/test_cli_output_success_message.py
+++ b/Server/tests/test_cli_output_success_message.py
@@ -1,0 +1,39 @@
+"""Regression tests for message-only success envelopes in CLI text output.
+
+Unity's `SuccessResponse` declares `data` with `NullValueHandling.Ignore`
+(MCPForUnity/Editor/Helpers/Response.cs), and many handlers return a bare
+`{success, message}` object (e.g. LightBakingOps.CancelBake). `format_as_text`
+skips the meta fields `success`/`error`/`message`, so those responses used to
+render as an empty string and the CLI printed a blank line.
+"""
+
+from cli.utils.output import format_as_text, format_output
+
+
+def test_message_only_success_response_prints_message():
+    """`graphics bake-cancel` shape: success + message, no data key."""
+    out = format_as_text({"success": True, "message": "Light bake cancelled."})
+    assert "Light bake cancelled." in out
+
+
+def test_message_only_success_response_via_format_output():
+    out = format_output({"success": True, "message": "Bake data cleared."}, "text")
+    assert out.strip() != ""
+    assert "Bake data cleared." in out
+
+
+def test_success_with_payload_still_renders_payload_only():
+    """Unchanged behavior: a real payload wins over the message."""
+    out = format_as_text({"success": True, "message": "ok", "data": {"a": 1}})
+    assert out == "a: 1"
+
+
+def test_error_response_unchanged():
+    out = format_as_text({"success": False, "message": "Boom"})
+    assert out == "❌ Error: Boom"
+
+
+def test_extra_top_level_keys_are_not_replaced_by_message():
+    """Guard: the message fallback must not swallow real top-level content."""
+    out = format_as_text({"success": True, "message": "ok", "count": 3})
+    assert "count: 3" in out


### PR DESCRIPTION
## Problem

`format_as_text` renders a `{"success": true, "message": "..."}` envelope with **no `data` key** as an **empty string**. The success branch recurses only when a `data`/`result` payload exists; with none, `result == data`, no recursion happens, and the field loop then skips `success`/`error`/`message` as meta fields — leaving `lines == []` → `""`. The **error** branch already falls back to `message`; the success branch did not.

This is the normal Unity contract, not an edge case: C# `SuccessResponse` declares `data` with `NullValueHandling.Ignore`, so `new SuccessResponse("...")` emits only `{success, message}` (65 message-only call sites, plus hand-rolled `{success, message}` objects like `LightBakingOps.CancelBake`). So `mcp-for-unity graphics bake-cancel` succeeds in Unity but prints a single **blank line** — the user cannot distinguish success from a no-op. `--format json` is unaffected.

## Fix

When the field loop produced no lines and it is a success envelope with a message, surface the message — guarded on `not lines`, so an envelope with extra top-level keys still renders those.

## Verification

Regression tests: message-only success (bare + via `format_output`) shows the message; a real payload still wins; the error branch is unchanged; extra top-level keys are not swallowed. **The two message-only cases fail pre-fix.** Broad unit suite **992 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
