### PR TITLE
fix(refresh_unity): re-send a refresh Unity rejected before executing it

### DIFF
--- a/Server/src/services/tools/refresh_unity.py
+++ b/Server/src/services/tools/refresh_unity.py
@@ -207,6 +207,28 @@ async def refresh_unity(
     # If we sent the command and connection closed, the refresh was likely triggered successfully.
     # Convert MCPResponse to dict if needed
     response_dict = response if isinstance(response, dict) else (response.model_dump() if hasattr(response, "model_dump") else response.__dict__)
+
+    # Unity REJECTED the command before executing it because it was already
+    # reloading (the transport's status-file preflight returns success=False /
+    # "Unity is reloading; please retry" without ever writing to the socket).
+    # The refresh therefore never ran — so this is NOT the "sent, then connection
+    # lost during the reload it triggered" case handled below. Re-sending is the
+    # FIRST real execution (not a #577 retry of a triggered reload); this mirrors
+    # send_mutation, whose is_reloading_rejection docstring states "The command
+    # was never executed, so retrying is safe." Without this, the block below
+    # reports success and clears the external-dirty flag for a refresh that never
+    # imported anything — a silently stale AssetDatabase reported as success.
+    if not response_dict.get("success", True) and _extract_response_reason(response_dict) == "reloading":
+        await wait_for_editor_ready(ctx)
+        response = await unity_transport.send_with_unity_instance(
+            _legacy_conn.async_send_command_with_retry,
+            unity_instance,
+            "refresh_unity",
+            params,
+            retry_on_reload=False,
+        )
+        response_dict = response if isinstance(response, dict) else (response.model_dump() if hasattr(response, "model_dump") else response.__dict__)
+
     if not response_dict.get("success", True):
         hint = response_dict.get("hint")
         err = (response_dict.get("error") or response_dict.get("message") or "").lower()

--- a/Server/tests/test_refresh_unity_reloading_rejection.py
+++ b/Server/tests/test_refresh_unity_reloading_rejection.py
@@ -1,0 +1,65 @@
+"""refresh_unity must re-send when Unity REJECTED the command because it is reloading.
+
+Distinct from tests/integration/test_refresh_unity_retry_recovery.py, which covers the
+"connection lost AFTER the command was sent" case (error='disconnected'). Here the
+transport's pre-send status-file preflight rejects the command outright
+(unity_connection.UnityConnection.send_command), so the refresh never reached Unity —
+yet refresh_unity used to report success and clear the external-dirty flag, leaving a
+silently stale AssetDatabase.
+"""
+import pytest
+
+from models import MCPResponse
+from services.state.external_changes_scanner import (
+    ExternalChangesState,
+    external_changes_scanner,
+)
+
+from .integration.test_helpers import DummyContext
+
+
+INSTANCE = "UnityMCPTests@cc8756d4cce0805a"
+
+
+@pytest.mark.asyncio
+async def test_refresh_unity_resends_after_reloading_rejection(monkeypatch):
+    from services.tools.refresh_unity import refresh_unity
+    import services.tools.refresh_unity as refresh_mod
+
+    ctx = DummyContext()
+    await ctx.set_state("unity_instance", INSTANCE)
+
+    external_changes_scanner._states[INSTANCE] = ExternalChangesState(
+        dirty=True, dirty_since_unix_ms=1
+    )
+
+    refresh_calls = []
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        if command_type == "refresh_unity":
+            refresh_calls.append(params)
+            if len(refresh_calls) == 1:
+                # Exact shape produced by UnityConnection.send_command's status-file
+                # preflight: the command was NEVER written to the socket.
+                return MCPResponse(
+                    success=False,
+                    error="Unity is reloading; please retry",
+                    hint="retry",
+                ).model_dump()
+            return {"success": True, "message": "Refreshed."}
+        if command_type == "get_editor_state":
+            return {"success": True, "data": {"advice": {"ready_for_tools": True}}}
+        raise ValueError(f"Unexpected command: {command_type}")
+
+    monkeypatch.setattr(refresh_mod.unity_transport,
+                        "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await refresh_unity(ctx, mode="force", scope="all", compile="request", wait_for_ready=True)
+    payload = resp.model_dump() if hasattr(resp, "model_dump") else resp
+
+    # The refresh was rejected before it ever ran -> it must be re-sent.
+    assert len(refresh_calls) == 2, (
+        "refresh_unity reported success without re-sending the rejected refresh "
+        f"(sent {len(refresh_calls)} time(s))"
+    )
+    assert payload["success"] is True


### PR DESCRIPTION
## Problem

When Unity is already reloading, the transport's status-file **preflight** rejects `refresh_unity` **before writing to the socket**:

```
{success: false, error: "Unity is reloading; please retry", hint: "retry"}
```

The command never ran. Because `refresh_unity` sends with `retry_on_reload=False`, that rejection returns verbatim, and `_extract_response_reason` maps its message to `"reloading"` — so it lands in the `is_connection_lost` / `hint=="retry"` branch, sets `recovered_from_disconnect=True`, **clears the external-dirty flag**, and returns `success` *"editor is ready."*

Net effect: the refresh imported nothing, yet the dirty flag is cleared (so `preflight(refresh_if_dirty)` won't retry later) and success is reported — a **silently stale AssetDatabase**.

## Why this is safe (not a #577 violation)

This is the **reject-before-execution** case, distinct from the *"sent, then connection lost during the reload it triggered"* case (`error="disconnected"`, `reason=None`) that the Option-A recovery path and `test_refresh_unity_retry_recovery` lock in — **that path is untouched**. Re-sending here is the **first real execution**, not a retry of an already-triggered reload. `is_reloading_rejection`'s own docstring states *"The command was never executed, so retrying is safe,"* and **`send_mutation` already re-sends on exactly this condition** — this makes `refresh_unity` consistent with its sibling.

## Fix

On a reloading rejection (`success=false` and `reason=="reloading"`), wait for editor readiness and re-send **once** (bounded — a second rejection falls through to the existing recovery path).

## Verification

Regression test drives `refresh_unity` with a mocked transport that rejects the first send (the exact preflight shape) and succeeds on the second: the refresh must be re-sent (2 sends). **Fails pre-fix** (1 send, false success). Broad unit suite **993 passed**; the Option-A / wait-for-ready / domain-reload mock tests (**26**) still pass.

## Design note

A maintainer may prefer routing `refresh_unity` through `send_mutation` directly (which already carries this contract) rather than inlining the re-send. This PR takes the minimal, surgical path and preserves the existing recovery branches verbatim; happy to refactor toward `send_mutation` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
