### PR TITLE
fix(refresh_unity): match the real reloading-rejection shape in is_reloading_rejection

### DIFF
--- a/Server/src/services/tools/refresh_unity.py
+++ b/Server/src/services/tools/refresh_unity.py
@@ -66,10 +66,22 @@ def is_reloading_rejection(resp: Any) -> bool:
 
     The command was never executed, so retrying is safe.
     """
-    if not isinstance(resp, dict) or resp.get("success"):
-        return False
-    data = resp.get("data") or {}
-    return data.get("reason") == "reloading" and resp.get("hint") == "retry"
+    # The real preflight rejection (UnityConnection.send_command) is an
+    # MCPResponse object with data=None and the reason only in its error MESSAGE
+    # ("Unity is reloading; please retry"), NOT a dict with data.reason. Match
+    # both shapes and route the reason through _extract_response_reason (which
+    # already handles MCPResponse + dict + the message fallback), so this
+    # predicate matches what production actually produces instead of a
+    # dict-with-data.reason shape nothing on this path emits.
+    if isinstance(resp, dict):
+        if resp.get("success"):
+            return False
+        hint = resp.get("hint")
+    else:
+        if getattr(resp, "success", None):
+            return False
+        hint = getattr(resp, "hint", None)
+    return hint == "retry" and _extract_response_reason(resp) == "reloading"
 
 
 def is_connection_lost_after_send(resp: Any) -> bool:

--- a/Server/tests/test_send_mutation_reload_repro.py
+++ b/Server/tests/test_send_mutation_reload_repro.py
@@ -1,0 +1,54 @@
+"""Repro: send_mutation never re-sends on the REAL reloading rejection.
+
+The real preflight rejection produced by UnityConnection.send_command is
+    MCPResponse(success=False, error="Unity is reloading; please retry", hint="retry")
+-- an MCPResponse object with data=None. is_reloading_rejection() used to require
+a dict AND data["reason"] == "reloading", so it returned False and the re-send
+branch in send_mutation was never taken.
+"""
+import pytest
+
+from models import MCPResponse
+from services.tools.refresh_unity import is_reloading_rejection, send_mutation
+
+
+class _Ctx:
+    """Minimal context stand-in (send_mutation only passes it to wait_for_editor_ready)."""
+
+
+# The exact object built at transport/legacy/unity_connection.py:365-369
+REAL_PREFLIGHT_REJECTION = MCPResponse(
+    success=False,
+    error="Unity is reloading; please retry",
+    hint="retry",
+)
+
+
+def test_is_reloading_rejection_matches_real_preflight_object():
+    assert is_reloading_rejection(REAL_PREFLIGHT_REJECTION) is True
+
+
+def test_is_reloading_rejection_matches_real_preflight_dump():
+    assert is_reloading_rejection(REAL_PREFLIGHT_REJECTION.model_dump()) is True
+
+
+@pytest.mark.asyncio
+async def test_send_mutation_resends_on_real_preflight_rejection(monkeypatch):
+    """First send hits the real reloading rejection -> mutation MUST be re-sent."""
+    from services.tools import refresh_unity as mod
+
+    calls = 0
+
+    async def fake_send(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return REAL_PREFLIGHT_REJECTION
+        return {"success": True, "data": {"retried": True}}
+
+    monkeypatch.setattr(mod.unity_transport, "send_with_unity_instance", fake_send)
+
+    resp = await send_mutation(_Ctx(), None, "manage_script", {"action": "create"})
+
+    assert calls == 2, "reloading rejection must trigger exactly one re-send"
+    assert resp == {"success": True, "data": {"retried": True}}


### PR DESCRIPTION
## Problem

`is_reloading_rejection()` required `isinstance(resp, dict)` **and** `resp["data"]["reason"] == "reloading"`. Nothing on `send_mutation`'s path produces that shape:

- The real preflight rejection (`UnityConnection.send_command`) is an **`MCPResponse` object with `data=None`**, and the reason lives only in its error **message** (`"Unity is reloading; please retry"`).
- The one site that emits `data={"reason":"reloading"}` is gated behind `retry_on_reload=True`, and `send_mutation` hardcodes `retry_on_reload=False` — so that producer is unreachable here.

So the predicate returned `False` on every real rejection, making `send_mutation`'s reload re-send branch **dead code**.

```
is_reloading_rejection(MCPResponse(...reloading..., hint=retry))  -> False   (bug)
_extract_response_reason(same object)                            -> "reloading"  (already correct)
```

## Impact

10 live `send_mutation` call sites (`manage_script` ×4, `script_apply_edits` ×5, `manage_ui`) lost their reload-retry. When Unity's status file says reloading, preflight rejects the command (never executed), `send_mutation` falls straight through, and the caller gets `success=False, error="Unity is reloading"` instead of a transparently retried success — even though re-sending is provably safe because the command never ran.

## Fix

Match both shapes (dict **and** `MCPResponse`) and route the reason through `_extract_response_reason` (already imported; handles `MCPResponse` + dict + the message fallback — the same heuristic `_is_reloading_response` and `refresh_unity` already trust). The `data.reason` path is preserved; the message/object path is added. `send_mutation:120` is the only functional caller.

## Verification

Regression tests: the real preflight-rejection object **and** its `model_dump` must both be recognized, and `send_mutation` must re-send once on it (2 sends). **All three fail pre-fix.** Existing predicate + `send_mutation` tests (**22**) stay green (the `data.reason` shape still matches); broad unit suite **996 passed**.

_Follow-up to #48, which fixed the parallel gap in `refresh_unity()` itself; this fixes the shared `is_reloading_rejection` predicate that `send_mutation` relies on._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
