### PR TITLE
fix(batch_execute): key the max-commands cache per Unity instance

### DIFF
--- a/Server/src/services/tools/batch_execute.py
+++ b/Server/src/services/tools/batch_execute.py
@@ -20,8 +20,13 @@ DEFAULT_MAX_COMMANDS_PER_BATCH = 25
 # Hard ceiling matching the C# AbsoluteMaxCommandsPerBatch.
 ABSOLUTE_MAX_COMMANDS_PER_BATCH = 100
 
-# Module-level cache for the Unity-configured limit (populated from editor state).
-_cached_max_commands: int | None = None
+# Per-instance cache for the Unity-configured limit (populated from editor state).
+# The limit is a Unity-side EditorPrefs value read through an instance-routed
+# get_editor_state query, so it can differ between the Unity instances a single
+# server process serves (HTTP transport is shared-process). A module-global
+# scalar applied whichever instance was read FIRST to every instance thereafter,
+# which wrongly rejects a valid batch on an instance with a higher limit.
+_cached_max_commands: dict[str | None, int] = {}
 
 
 async def _get_max_commands_from_editor_state(ctx: Context) -> int:
@@ -29,9 +34,10 @@ async def _get_max_commands_from_editor_state(ctx: Context) -> int:
     Attempt to read the configured batch limit from the Unity editor state.
     Falls back to DEFAULT_MAX_COMMANDS_PER_BATCH if unavailable.
     """
-    global _cached_max_commands
-    if _cached_max_commands is not None:
-        return _cached_max_commands
+    instance = await get_unity_instance_from_context(ctx)
+    cached = _cached_max_commands.get(instance)
+    if cached is not None:
+        return cached
 
     try:
         from services.resources.editor_state import get_editor_state
@@ -45,7 +51,7 @@ async def _get_max_commands_from_editor_state(ctx: Context) -> int:
             if isinstance(settings, dict):
                 limit = settings.get("batch_execute_max_commands")
                 if isinstance(limit, int) and 1 <= limit <= ABSOLUTE_MAX_COMMANDS_PER_BATCH:
-                    _cached_max_commands = limit
+                    _cached_max_commands[instance] = limit
                     return limit
     except Exception as exc:
         logger.debug("Could not read batch limit from editor state: %s", exc)
@@ -55,8 +61,7 @@ async def _get_max_commands_from_editor_state(ctx: Context) -> int:
 
 def invalidate_cached_max_commands() -> None:
     """Reset the cached limit so the next call re-reads from editor state."""
-    global _cached_max_commands
-    _cached_max_commands = None
+    _cached_max_commands.clear()
 
 
 @mcp_for_unity_tool(

--- a/Server/tests/test_batch_execute_instance_cache.py
+++ b/Server/tests/test_batch_execute_instance_cache.py
@@ -1,0 +1,81 @@
+"""Repro: batch_execute's max-commands cache was a module-global scalar, not
+keyed per Unity instance.
+
+The limit is a Unity-side EditorPrefs value read through an instance-routed
+get_editor_state query, so a single shared server process could apply whichever
+instance's limit was read FIRST to every instance thereafter — wrongly rejecting
+a valid batch on an instance configured with a higher limit.
+"""
+import pytest
+
+from models.models import MCPResponse
+from tests.integration.test_helpers import DummyContext
+import services.resources.editor_state as editor_state_module
+import services.tools.batch_execute as batch_execute_module
+from services.tools.batch_execute import invalidate_cached_max_commands
+
+
+LIMITS = {
+    "ProjectA@aaaaaa": 25,
+    "ProjectB@bbbbbb": 100,
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    invalidate_cached_max_commands()
+    yield
+    invalidate_cached_max_commands()
+
+
+@pytest.fixture
+def fake_editor_state(monkeypatch):
+    async def _fake_get_editor_state(ctx):
+        instance = await ctx.get_state("unity_instance")
+        return MCPResponse(
+            success=True,
+            message="ok",
+            data={"settings": {"batch_execute_max_commands": LIMITS[instance]}},
+        )
+
+    monkeypatch.setattr(editor_state_module, "get_editor_state", _fake_get_editor_state)
+
+
+def _ctx(instance: str) -> DummyContext:
+    ctx = DummyContext()
+    ctx._state["unity_instance"] = instance
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_limit_is_resolved_per_unity_instance(fake_editor_state):
+    """Instance B must see its own limit, not the one cached for instance A."""
+    ctx_a = _ctx("ProjectA@aaaaaa")
+    ctx_b = _ctx("ProjectB@bbbbbb")
+
+    assert await batch_execute_module._get_max_commands_from_editor_state(ctx_a) == 25
+    assert await batch_execute_module._get_max_commands_from_editor_state(ctx_b) == 100
+    # The first instance keeps its own value afterwards.
+    assert await batch_execute_module._get_max_commands_from_editor_state(ctx_a) == 25
+
+
+@pytest.mark.asyncio
+async def test_batch_not_rejected_using_another_instances_limit(fake_editor_state, monkeypatch):
+    """A 50-command batch is valid on ProjectB (limit 100) even after ProjectA ran."""
+    sent: list[dict] = []
+
+    async def _fake_send(send_fn, unity_instance, command_type, payload):
+        sent.append({"instance": unity_instance, "payload": payload})
+        return {"success": True, "data": {}}
+
+    monkeypatch.setattr(batch_execute_module, "send_with_unity_instance", _fake_send)
+
+    one_command = [{"tool": "manage_editor", "params": {"action": "get_state"}}]
+
+    # Instance A (limit 25) runs first and populates the cache.
+    await batch_execute_module.batch_execute(_ctx("ProjectA@aaaaaa"), one_command)
+    # Instance B allows 100 commands; 50 must be accepted, not rejected.
+    await batch_execute_module.batch_execute(_ctx("ProjectB@bbbbbb"), one_command * 50)
+
+    assert len(sent) == 2
+    assert len(sent[1]["payload"]["commands"]) == 50


### PR DESCRIPTION
## Problem

`_get_max_commands_from_editor_state` cached the Unity-configured batch limit in a **module-global scalar** (`_cached_max_commands`) that short-circuited before any per-instance lookup:

```python
_cached_max_commands: int | None = None
...
if _cached_max_commands is not None:
    return _cached_max_commands
```

But the limit is a Unity-side EditorPrefs value read through an **instance-routed** `get_editor_state` query. In shared-process HTTP transport mode (one Python server serving multiple Unity instances), whichever instance was read **first** set the limit for every instance thereafter, for the process lifetime.

Impact is asymmetric: a cached limit that's too **high** is harmless (Unity rejects it side). A cached limit that's too **low** wrongly **rejects a valid batch** — e.g. ProjectB (limit 100) submitting 50 commands gets *"supports up to 25 commands (configured in Unity)"*, quoting **ProjectA's** configuration, with no recovery short of a server restart. Reachable when two Unity major versions run on one machine (EditorPrefs is per-version) or under HTTP remote-hosted multi-user mode.

## Fix

Key the cache by `unity_instance` (`get_unity_instance_from_context` is already imported and resolved here for routing). `invalidate_cached_max_commands()` — which had **zero callers** — now clears the dict.

## Verification

Regression tests: instance B must see its own limit (100) after instance A (25) populated the cache, and a 50-command batch on B must not be rejected using A's limit. **Both fail pre-fix.** Broad unit suite **998 passed**.

## Scope note

This fixes the **cross-instance** facet only. A live limit change in the MCP Tools window is still invisible until the cache is cleared (a pre-existing staleness limitation of any caching here); wiring `invalidate_cached_max_commands` into the session-disconnect path or a short TTL is a separate, maintainer-owned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
