### PR TITLE
fix(utils): reject non-finite (NaN/Infinity) color components in normalize_color

### DIFF
--- a/Server/src/services/tools/utils.py
+++ b/Server/src/services/tools/utils.py
@@ -289,6 +289,15 @@ def normalize_color(value: Any, output_range: str = "float") -> tuple[list[float
 
     def _to_output_range(components: list[float], from_hex: bool = False) -> list:
         """Convert color components to the requested output range."""
+        # Reject non-finite components (NaN / +-Infinity). Python's json.loads
+        # accepts `NaN`/`Infinity` literals, so a JSON-string color param can
+        # smuggle them in; the scale heuristics below use `c > 1`, which is
+        # always False for NaN, so a bad value would otherwise pass straight
+        # through to Unity as an invalid Color. Raise so the callers' existing
+        # `except (ValueError, TypeError)` surfaces the "must be numbers" error.
+        # Hex components are parsed from int() and are always finite.
+        if not from_hex and not all(math.isfinite(c) for c in components):
+            raise ValueError("color components must be finite numbers")
         if output_range == "int":
             if from_hex:
                 # Already 0-255 from hex parsing

--- a/Server/tests/test_normalize_color_finite.py
+++ b/Server/tests/test_normalize_color_finite.py
@@ -1,0 +1,40 @@
+"""normalize_color must reject non-finite (NaN / +-Infinity) color components.
+
+Python's json.loads accepts `NaN`/`Infinity` literals, so a JSON-string color
+param (a documented input format) can smuggle them in. The scale heuristics use
+`c > 1`, which is always False for NaN, so a non-finite value would otherwise
+pass straight through to Unity as an invalid Color.
+"""
+import math
+
+import pytest
+
+from services.tools.utils import normalize_color
+
+
+@pytest.mark.parametrize("bad", [
+    [float("nan"), 0.0, 0.0],
+    [float("inf"), 0.0, 0.0],
+    [0.0, float("-inf"), 0.0],
+    "[NaN, 0.0, 0.0]",            # JSON string — json.loads accepts NaN
+    "[Infinity, 0.0, 0.0]",
+    {"r": float("nan"), "g": 0.0, "b": 0.0},
+    "(nan, 0, 0)",               # tuple-style string
+])
+def test_non_finite_color_is_rejected(bad):
+    color, err = normalize_color(bad, "float")
+    assert color is None, f"expected rejection for {bad!r}, got {color!r}"
+    assert err is not None
+
+
+@pytest.mark.parametrize("good,out", [
+    ([0.5, 0.2, 0.1], "float"),
+    ([255, 128, 0], "int"),
+    ("#ff0000", "float"),          # hex path stays finite + valid
+    ({"r": 0.1, "g": 0.2, "b": 0.3}, "float"),
+])
+def test_finite_color_still_accepted(good, out):
+    color, err = normalize_color(good, out)
+    assert err is None, f"valid color {good!r} was wrongly rejected: {err}"
+    assert color is not None
+    assert all(math.isfinite(c) for c in color)


### PR DESCRIPTION
## Problem

`normalize_color` converts inputs to `float` but never validated finiteness. Its scale heuristics use `c > 1` (in `_to_output_range` and `_opaque_alpha`), which is **always False for NaN**, so a non-finite value passes straight through to Unity as an invalid `Color` instead of being rejected — despite the function's contract of returning an error for bad color input.

It's reachable: `color` is a documented **JSON-string** input format, and Python's `json.loads` accepts the `NaN` / `Infinity` literals, so a client sending `color="[NaN, 0, 0]"` (or a list/dict/tuple-string carrying `nan`/`inf`) smuggles a non-finite component all the way through:

```
normalize_color("[NaN, 0.0, 0.0]", "float")  ->  ([nan, 0.0, 0.0, 1.0], None)   # no error
```

## Fix

One guard at the top of `_to_output_range` — the common funnel for every numeric path (list, dict, JSON, tuple-string) — raises `ValueError` on a non-finite component, which the callers' existing `except (ValueError, TypeError)` turns into the standard *"color values must be numbers"* error. The **hex** path is exempt (`from_hex=True`; components come from `int()` and are always finite).

## Verification

Regression test: `NaN`/`Infinity` via list, JSON string, dict, and tuple-string are all **rejected**; valid float/int/hex/dict colors still parse. The non-finite cases **fail pre-fix** (accepted). Broad unit suite **1009 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
