### PR TITLE
fix(cli): apply script/code read --start-line / --line-count window client-side

### DIFF
--- a/Server/src/cli/commands/code.py
+++ b/Server/src/cli/commands/code.py
@@ -6,7 +6,7 @@ import click
 from typing import Optional, Any
 
 from cli.utils.config import get_config
-from cli.utils.output import format_output, print_error, print_info, print_success
+from cli.utils.output import format_output, print_error, print_info, print_success, slice_lines
 from cli.utils.connection import run_command, handle_unity_errors
 
 
@@ -148,7 +148,7 @@ def read(path: str, start_line: Optional[int], line_count: Optional[int]):
     if result.get("success") and result.get("data"):
         data = result.get("data", {})
         if isinstance(data, dict) and "contents" in data:
-            click.echo(data["contents"])
+            click.echo(slice_lines(data["contents"], start_line, line_count))
         else:
             click.echo(format_output(result, config.format))
     else:

--- a/Server/src/cli/commands/script.py
+++ b/Server/src/cli/commands/script.py
@@ -6,7 +6,7 @@ import click
 from typing import Optional, Any
 
 from cli.utils.config import get_config
-from cli.utils.output import format_output, print_error, print_success
+from cli.utils.output import format_output, print_error, print_success, slice_lines
 from cli.utils.connection import run_command, handle_unity_errors
 from cli.utils.parsers import parse_json_list_or_exit
 from cli.utils.confirmation import confirm_destructive_action
@@ -120,7 +120,7 @@ def read(path: str, start_line: Optional[int], line_count: Optional[int]):
     if result.get("success") and result.get("data"):
         data = result.get("data", {})
         if isinstance(data, dict) and "contents" in data:
-            click.echo(data["contents"])
+            click.echo(slice_lines(data["contents"], start_line, line_count))
         else:
             click.echo(format_output(result, config.format))
     else:

--- a/Server/src/cli/utils/output.py
+++ b/Server/src/cli/utils/output.py
@@ -24,6 +24,23 @@ def format_output(data: Any, format_type: str = "text") -> str:
         return format_as_text(data)
 
 
+def slice_lines(contents: str, start_line: int | None, line_count: int | None) -> str:
+    """Return the 1-based ``start_line`` / ``line_count`` window of ``contents``.
+
+    Unity's ``manage_script`` read handler dispatches to a two-argument
+    ``ReadScript(fullPath, relativePath)`` that reads the whole file and never
+    consults startLine/lineCount, so the CLI's ``--start-line`` / ``--line-count``
+    window must be applied client-side (the same way ``code search`` runs its
+    match pass locally). With neither bound set the text is returned untouched.
+    """
+    if start_line is None and line_count is None:
+        return contents
+    lines = contents.splitlines()
+    begin = max(0, (start_line or 1) - 1)
+    end = begin + line_count if line_count is not None else len(lines)
+    return "\n".join(lines[begin:end])
+
+
 def format_as_json(data: Any) -> str:
     """Format data as pretty-printed JSON."""
     try:

--- a/Server/tests/test_cli_script_read_line_window.py
+++ b/Server/tests/test_cli_script_read_line_window.py
@@ -1,0 +1,85 @@
+"""Regression: `script read` / `code read` must honour --start-line / --line-count.
+
+Both commands forward the window as startLine/lineCount to manage_script, but
+Unity's ManageScript.cs dispatches `case "read"` to ReadScript(fullPath,
+relativePath) — a two-argument helper that reads the whole file and never
+consults those keys. The CLI then echoed data["contents"] verbatim, so both
+documented flags were silently dropped and the user got the entire file. Fix:
+apply the 1-based line window client-side (like `code search` does its match
+pass locally).
+"""
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from cli.commands.code import code
+from cli.commands.script import script
+from cli.utils.config import CLIConfig
+
+FILE_BODY = "\n".join(f"L{i}" for i in range(1, 11))
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_config():
+    return CLIConfig(host="127.0.0.1", port=8080, format="text")
+
+
+def _read_response():
+    return {
+        "success": True,
+        "data": {
+            "uri": "mcpforunity://path/Assets/Scripts/A.cs",
+            "path": "Assets/Scripts/A.cs",
+            "contents": FILE_BODY,
+            "contentsEncoded": False,
+        },
+    }
+
+
+@pytest.mark.parametrize("group, module", [(script, "cli.commands.script"), (code, "cli.commands.code")])
+def test_read_applies_start_line_and_line_count(runner, mock_config, group, module):
+    """--start-line 3 --line-count 2 must print exactly L3 and L4."""
+    with patch(f"{module}.get_config", return_value=mock_config):
+        with patch(f"{module}.run_command", return_value=_read_response()):
+            result = runner.invoke(
+                group,
+                ["read", "Assets/Scripts/A.cs", "--start-line", "3", "--line-count", "2"],
+                catch_exceptions=False,
+            )
+
+    assert result.exit_code == 0
+    assert result.output == "L3\nL4\n"
+
+
+@pytest.mark.parametrize("group, module", [(script, "cli.commands.script"), (code, "cli.commands.code")])
+def test_read_start_line_only_reads_to_end(runner, mock_config, group, module):
+    with patch(f"{module}.get_config", return_value=mock_config):
+        with patch(f"{module}.run_command", return_value=_read_response()):
+            result = runner.invoke(
+                group,
+                ["read", "Assets/Scripts/A.cs", "--start-line", "9"],
+                catch_exceptions=False,
+            )
+
+    assert result.exit_code == 0
+    assert result.output == "L9\nL10\n"
+
+
+@pytest.mark.parametrize("group, module", [(script, "cli.commands.script"), (code, "cli.commands.code")])
+def test_read_without_window_is_unchanged(runner, mock_config, group, module):
+    """No window flags => byte-identical passthrough (no behaviour change)."""
+    with patch(f"{module}.get_config", return_value=mock_config):
+        with patch(f"{module}.run_command", return_value=_read_response()):
+            result = runner.invoke(
+                group, ["read", "Assets/Scripts/A.cs"], catch_exceptions=False
+            )
+
+    assert result.exit_code == 0
+    assert result.output == FILE_BODY + "\n"


### PR DESCRIPTION
## Problem

`unity-mcp script read --start-line N --line-count M` and `unity-mcp code read --start-line N --line-count M` (both flags documented in the commands' `--help` examples) **silently returned the entire file**.

The CLI forwards the window as `startLine`/`lineCount` to `manage_script`, but Unity's `ManageScript.cs` dispatches `case "read"` to `ReadScript(fullPath, relativePath)` — a **two-argument** helper that `File.ReadAllText`s the whole file and never consults those keys (a repo-wide grep confirms no `manage_script` read path reads `startLine`/`lineCount`; the CLI's HTTP path forwards params verbatim via `PluginHub` with no normalization). The CLI then echoed `data["contents"]` verbatim, so the window was dropped **end-to-end with no error**.

```
10-line file, --start-line 3 --line-count 2
  expected: L3\nL4\n
  actual:   L1..L10 (whole file)
```

## Fix

Apply the 1-based line window **client-side** — a new `output.slice_lines()` used by both read commands — mirroring how `code search` runs its match pass locally after reading the file. With neither bound set the contents are returned untouched (zero behaviour change, covered by a control test).

## Verification

Regression test drives both commands via `CliRunner` with `run_command` mocked: `--start-line 3 --line-count 2` prints exactly `L3`+`L4`; `--start-line 9` reads to end; no flags is byte-identical passthrough. **The 4 window cases fail pre-fix** (whole file echoed); broad unit suite **1015 passed**.

_Two related silent-drops on the HTTP CLI path (`editor tests --wait N` is a no-op; `instance set` targets a Unity-unimplemented meta-tool) are noted for separate issues — they need a design call, not this mechanical patch._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
