### PR TITLE
fix(refresh_unity): force mode must always import, even for scope=scripts

### DIFF
--- a/MCPForUnity/Editor/Tools/RefreshUnity.cs
+++ b/MCPForUnity/Editor/Tools/RefreshUnity.cs
@@ -60,7 +60,7 @@ namespace MCPForUnity.Editor.Tools
                     }
                     else
                     {
-                        AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
+                        AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
                         refreshTriggered = true;
                     }
                 }
@@ -82,7 +82,6 @@ namespace MCPForUnity.Editor.Tools
                     // completes before returning, preventing stalls when Unity is backgrounded.
                     AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
                     refreshTriggered = true;
-                    skipReason = null;
                 }
 
                 if (refreshTriggered)

--- a/MCPForUnity/Editor/Tools/RefreshUnity.cs
+++ b/MCPForUnity/Editor/Tools/RefreshUnity.cs
@@ -36,25 +36,37 @@ namespace MCPForUnity.Editor.Tools
 
             bool refreshTriggered = false;
             bool compileRequested = false;
+            string skipReason = null;
 
             try
             {
+                bool isForce = string.Equals(mode, "force", StringComparison.OrdinalIgnoreCase);
                 // Best-effort semantics: if_dirty currently behaves like force unless future dirty signals are added.
-                bool shouldRefresh = string.Equals(mode, "force", StringComparison.OrdinalIgnoreCase)
+                bool shouldRefresh = isForce
                                      || string.Equals(mode, "if_dirty", StringComparison.OrdinalIgnoreCase);
 
                 if (shouldRefresh)
                 {
-                    if (string.Equals(scope, "scripts", StringComparison.OrdinalIgnoreCase))
+                    bool isScriptsScope = string.Equals(scope, "scripts", StringComparison.OrdinalIgnoreCase);
+
+                    if (isScriptsScope && !isForce)
                     {
-                        // For scripts, requesting compilation is usually the meaningful action.
-                        // We avoid a heavyweight full refresh by default.
+                        // For scripts under the softer if_dirty mode, requesting compilation is usually
+                        // the meaningful action, so we avoid a heavyweight full refresh by default.
+                        // mode="force" bypasses this shortcut below — it must not silently no-op when
+                        // externally-created .cs files have no .meta and Unity's directory watcher never
+                        // flagged them (see issue #38).
+                        skipReason = "scripts_scope_if_dirty_skips_refresh_use_mode_force_to_import_new_files";
                     }
                     else
                     {
                         AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
                         refreshTriggered = true;
                     }
+                }
+                else
+                {
+                    skipReason = $"mode_{mode}_does_not_trigger_refresh";
                 }
 
                 if (string.Equals(compile, "request", StringComparison.OrdinalIgnoreCase))
@@ -70,6 +82,12 @@ namespace MCPForUnity.Editor.Tools
                     // completes before returning, preventing stalls when Unity is backgrounded.
                     AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
                     refreshTriggered = true;
+                    skipReason = null;
+                }
+
+                if (refreshTriggered)
+                {
+                    skipReason = null;
                 }
             }
             catch (Exception ex)
@@ -101,6 +119,7 @@ namespace MCPForUnity.Editor.Tools
                         refresh_triggered = refreshTriggered,
                         compile_requested = compileRequested,
                         resulting_state = "unknown",
+                        skip_reason = skipReason,
                     });
                 }
                 catch (Exception ex)
@@ -118,6 +137,7 @@ namespace MCPForUnity.Editor.Tools
                 refresh_triggered = refreshTriggered,
                 compile_requested = compileRequested,
                 resulting_state = resultingState,
+                skip_reason = skipReason,
                 hint = shouldWaitForReady
                     ? "Unity refresh completed; editor should be ready."
                     : "If Unity enters compilation/domain reload, poll editor_state until ready_for_tools is true."

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/RefreshUnityTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/RefreshUnityTests.cs
@@ -16,8 +16,7 @@ namespace MCPForUnityTests.Editor.Tools
             var resultObj = MCPForUnity.Editor.Tools.RefreshUnity.HandleCommand(new JObject
             {
                 ["mode"] = "force",
-                ["scope"] = "scripts",
-                ["compile"] = "request"
+                ["scope"] = "scripts"
             }).GetAwaiter().GetResult();
 
             Assert.IsInstanceOf<SuccessResponse>(resultObj);
@@ -25,8 +24,7 @@ namespace MCPForUnityTests.Editor.Tools
             var data = JObject.FromObject(success.Data);
 
             Assert.IsTrue(data["refresh_triggered"]?.Value<bool>(), "mode=force must always trigger a refresh, even for scope=scripts");
-            Assert.IsTrue(data["compile_requested"]?.Value<bool>());
-            Assert.IsNull(data["skip_reason"]?.ToString());
+            Assert.AreEqual(JTokenType.Null, data["skip_reason"]?.Type);
         }
 
         [Test]
@@ -62,7 +60,7 @@ namespace MCPForUnityTests.Editor.Tools
             var data = JObject.FromObject(success.Data);
 
             Assert.IsTrue(data["refresh_triggered"]?.Value<bool>());
-            Assert.IsNull(data["skip_reason"]?.ToString());
+            Assert.AreEqual(JTokenType.Null, data["skip_reason"]?.Type);
         }
     }
 }

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/RefreshUnityTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/RefreshUnityTests.cs
@@ -1,0 +1,68 @@
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using MCPForUnity.Editor.Helpers;
+
+namespace MCPForUnityTests.Editor.Tools
+{
+    /// <summary>
+    /// Tests for RefreshUnity tool functionality (issue #38: mode="force" must not
+    /// silently no-op when scope="scripts", and any skipped refresh must report why).
+    /// </summary>
+    public class RefreshUnityTests
+    {
+        [Test]
+        public void HandleCommand_ForceScripts_TriggersRefreshAndNoSkipReason()
+        {
+            var resultObj = MCPForUnity.Editor.Tools.RefreshUnity.HandleCommand(new JObject
+            {
+                ["mode"] = "force",
+                ["scope"] = "scripts",
+                ["compile"] = "request"
+            }).GetAwaiter().GetResult();
+
+            Assert.IsInstanceOf<SuccessResponse>(resultObj);
+            var success = (SuccessResponse)resultObj;
+            var data = JObject.FromObject(success.Data);
+
+            Assert.IsTrue(data["refresh_triggered"]?.Value<bool>(), "mode=force must always trigger a refresh, even for scope=scripts");
+            Assert.IsTrue(data["compile_requested"]?.Value<bool>());
+            Assert.IsNull(data["skip_reason"]?.ToString());
+        }
+
+        [Test]
+        public void HandleCommand_IfDirtyScripts_SkipsRefreshButReportsReason()
+        {
+            var resultObj = MCPForUnity.Editor.Tools.RefreshUnity.HandleCommand(new JObject
+            {
+                ["mode"] = "if_dirty",
+                ["scope"] = "scripts",
+                ["compile"] = "none"
+            }).GetAwaiter().GetResult();
+
+            Assert.IsInstanceOf<SuccessResponse>(resultObj);
+            var success = (SuccessResponse)resultObj;
+            var data = JObject.FromObject(success.Data);
+
+            Assert.IsFalse(data["refresh_triggered"]?.Value<bool>());
+            Assert.IsFalse(string.IsNullOrEmpty(data["skip_reason"]?.ToString()),
+                "A skipped refresh must always explain why via skip_reason (issue #38)");
+        }
+
+        [Test]
+        public void HandleCommand_ForceAssets_TriggersRefresh()
+        {
+            var resultObj = MCPForUnity.Editor.Tools.RefreshUnity.HandleCommand(new JObject
+            {
+                ["mode"] = "force",
+                ["scope"] = "assets"
+            }).GetAwaiter().GetResult();
+
+            Assert.IsInstanceOf<SuccessResponse>(resultObj);
+            var success = (SuccessResponse)resultObj;
+            var data = JObject.FromObject(success.Data);
+
+            Assert.IsTrue(data["refresh_triggered"]?.Value<bool>());
+            Assert.IsNull(data["skip_reason"]?.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #38 — `refresh_unity(mode="force", scope="scripts", compile="request")` silently no-op'd on refresh: externally-created `.cs` files (no `.meta`, never flagged by Unity's directory watcher) were never imported/compiled, while the tool reported success.

Root cause: `mode="force"` with `scope="scripts"` took the same shortcut as `mode="if_dirty"` and skipped `AssetDatabase.Refresh()` entirely, relying on script-compilation-only. That's fine for `if_dirty` (softer, best-effort) but wrong for `force`, which must actually force an import.

## Changes

- `MCPForUnity/Editor/Tools/RefreshUnity.cs`:
  - `mode="force"` now always calls `AssetDatabase.Refresh(ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport)` regardless of `scope`, and sets `refresh_triggered: true`.
  - `mode="if_dirty"` + `scope="scripts"` still takes the lightweight compile-only path (unchanged behavior for that combination), but the response now always includes a `skip_reason` string when a refresh was skipped — so `mode="if_dirty"` doesn't fail silently either.
  - `skip_reason` is `null`/omitted whenever a refresh actually happened.

## Test plan

- Added `TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/RefreshUnityTests.cs` covering:
  - `mode=force, scope=scripts` → `refresh_triggered=true`, no `skip_reason`
  - `mode=if_dirty, scope=scripts` → `refresh_triggered=false`, non-empty `skip_reason`
  - `mode=force, scope=assets` → `refresh_triggered=true`

**I could not compile or run these tests** — no Unity Editor is available in this environment. The change and tests were written by inspection against the existing `RunTestsTests.cs` pattern (same `HandleCommand(...).GetAwaiter().GetResult()` + `JObject.FromObject(success.Data)` style) and match the file's existing conventions. Please run the EditMode suite before merging.

---

## Follow-up commit `3015463d` — review fixes

Adversarial review found 2 blockers (both in the new tests) plus one production concern. All addressed:

- **`RefreshUnityTests.cs` ×2** — `Assert.IsNull(data["skip_reason"]?.ToString())` was provably always-failing: `skip_reason` is an anonymous-type member, so it serializes as an *explicit* JSON null; the token is present, and `JValue.ToString()` on a null value returns `""`, not null. Replaced with `Assert.AreEqual(JTokenType.Null, data["skip_reason"]?.Type)`.
- **`RefreshUnityTests.cs`** — dropped `["compile"] = "request"` and its assertion. It drove `CompilationPipeline.RequestScriptCompilation()`, triggering a domain reload *while the EditMode run was in flight*; blast radius was the whole suite. No other test in the repo requests compilation.
- **`RefreshUnity.cs:63`** — `ForceUpdate | ForceSynchronousImport` → `ForceSynchronousImport`, matching the fallback at `:83` which already omitted `ForceUpdate`.

### ⚠️ Note on the `ForceUpdate` removal — semantic change beyond #38

`ForceUpdate` at `:63` was **pre-existing in the base**, and that line also serves `scope=assets|all` for both modes. Removing it therefore changes behavior on paths unrelated to #38:

- an already-imported asset whose change Unity's hash/timestamp doesn't detect is no longer force-reimported, so `mode="force"` is marginally less "forceful";
- a `.cs` file arriving with a *stale or foreign* `.meta` (rather than none) is the one #38-adjacent case where `ForceUpdate` helped.

Rationale for accepting both: #38's root cause is that `Refresh` was **never called** on the force+scripts path, and plain `Refresh` discovers and imports new-on-disk files by contract — that is what fixes the issue. `ForceUpdate` only adds reimport of already-imported, unchanged assets, which is orthogonal and expensive. That cost is load-bearing here because this PR newly routes `mode="force", scope="scripts"` (previously an instant no-op) into a synchronous import, and `Server/src/core/config.py:34` sets a 30s socket timeout whose disconnect-recovery branch (`refresh_unity.py:259`) is gated on `compile == "request"` — so the default `compile="none"` path would surface a long import as a hard, unrecoverable client error.

Recording it here so the change isn't invisible to anyone later bisecting `refresh_unity(mode="force")` behavior.

### Verification status

Still **not compiled or executed** — no Unity Editor available, and this repo's `unity-tests` CI job silently skips when `UNITY_LICENSE`/`UNITY_EMAIL`/`UNITY_PASSWORD`/`UNITY_SERIAL` are unset (it reports a green check in ~6s without running anything). Both the original and the patched code were verified by adversarial review only. A licensed EditMode run before relying on this is still advisable.

Known coverage gaps, neither introduced here: `compile_requested` now has no C# test coverage, and the tests assert the `refresh_triggered` flag rather than observing a real import (the true test would drop a `.meta`-less `.cs` and assert `AssetDatabase.LoadAssetAtPath` resolves it).
