### PR TITLE
test(batch_execute): assert every registered tool dispatches (#20)

### DIFF
--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BatchExecuteDispatchCoverageTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BatchExecuteDispatchCoverageTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Newtonsoft.Json.Linq;
+using MCPForUnity.Editor.Services;
+using MCPForUnity.Editor.Tools;
+
+namespace MCPForUnityTests.Editor.Tools
+{
+    /// <summary>
+    /// Regression coverage for issue #20: batch_execute must route every registered command
+    /// type through the same handler that direct MCP calls use, instead of a hand-maintained
+    /// subset. This walks the live tool registry (the same reflection-based discovery
+    /// batch_execute itself relies on via CommandRegistry) so a newly-added tool is covered
+    /// automatically — no per-tool test entry required.
+    /// </summary>
+    public class BatchExecuteDispatchCoverageTests
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            CommandRegistry.Initialize();
+        }
+
+        [Test]
+        public void EveryRegisteredTool_IsDispatchableThroughBatchExecute()
+        {
+            IToolDiscoveryService discovery = new ToolDiscoveryService();
+            List<string> toolNames = discovery.DiscoverAllTools()
+                .Select(t => t.Name)
+                // batch_execute dispatching itself is out of scope for this coverage check.
+                .Where(name => name != "batch_execute")
+                .ToList();
+
+            Assert.IsNotEmpty(toolNames, "Tool discovery should find at least one registered tool.");
+
+            var commands = new JArray();
+            foreach (var name in toolNames)
+            {
+                commands.Add(new JObject
+                {
+                    ["tool"] = name,
+                    // Intentionally minimal/empty params: this test only proves the command
+                    // *reaches* its handler, not that a no-arg call succeeds semantically.
+                    ["params"] = new JObject()
+                });
+            }
+
+            var batchParams = new JObject { ["commands"] = commands };
+
+            var maxCommands = BatchExecute.GetMaxCommandsPerBatch();
+            if (commands.Count > maxCommands)
+            {
+                // Stay under the configured per-batch ceiling by chunking instead of tripping
+                // the "too many commands" guard rail.
+                for (int i = 0; i < toolNames.Count; i += maxCommands)
+                {
+                    var chunk = new JArray(toolNames.Skip(i).Take(maxCommands)
+                        .Select(name => (JToken)new JObject
+                        {
+                            ["tool"] = name,
+                            ["params"] = new JObject()
+                        }));
+                    AssertChunkDispatches(new JObject { ["commands"] = chunk });
+                }
+            }
+            else
+            {
+                AssertChunkDispatches(batchParams);
+            }
+        }
+
+        private static void AssertChunkDispatches(JObject batchParams)
+        {
+            var result = BatchExecute.HandleCommand(batchParams).GetAwaiter().GetResult();
+            var resultObj = JObject.FromObject(result);
+            var results = (JArray)resultObj["data"]["results"];
+
+            foreach (var entry in results)
+            {
+                string tool = entry.Value<string>("tool");
+
+                // A tool may legitimately fail on empty params (missing required "action", no
+                // scene selection, disabled optional package, etc.) — that's fine. What must
+                // never happen is the dispatcher not knowing the command at all.
+                string error = entry["error"]?.Value<string>()
+                    ?? entry["result"]?["error"]?.Value<string>();
+
+                Assert.IsFalse(
+                    error != null && error.Contains("Unknown or unsupported command type"),
+                    $"'{tool}' should be dispatchable through batch_execute, got: {error}");
+            }
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BatchExecuteDispatchCoverageTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/BatchExecuteDispatchCoverageTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d026c14ab2b45f8ab4eedd9a5298221
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #20

## Finding: the dispatcher fix already landed generically in #21

`batch_execute` already routes every command through `CommandRegistry.InvokeCommandAsync(toolName, ...)` (`MCPForUnity/Editor/Tools/BatchExecute.cs`) — there is no hardcoded per-tool switch/table to add `manage_splines` to. Dispatch is fully data-driven off the reflection-based `CommandRegistry`, which is exactly the pattern the issue asked to generalize toward.

The actual root cause the issue reported — `manage_splines` (and other optional-package-gated tools) throwing the opaque `Unknown or unsupported command type: manage_splines` when `com.unity.splines` isn't installed — was already fixed for the **entire** `OptionalPackageTools.CommandToPackage` set (16 tools: addressables, behavior, cinemachine, dots/dots_graphics/dots_physics/dots_subscene, input_system, localization, navigation, netcode, splines, tilemap, timeline, vfx, validation_snapshot) by #21, which registers an actionable placeholder handler (`"'<tool>' requires the <package> package..."`) for any `[McpForUnityTool]` whose real handler is compiled out. That PR was merged and auto-closed this issue, then reopened because the *second* ask (agent allowlist) and verification were still outstanding.

## Audit performed (per the issue's "fix generally, not just manage_splines" ask)

Cross-checked every `#if <DEFINE>`-gated tool file in `MCPForUnity/Editor/Tools/` against `MCPForUnity.Editor.asmdef`'s `versionDefines` and `OptionalPackageTools.CommandToPackage`:

| Tool | Gate define | In `CommandToPackage`? |
|---|---|---|
| manage_addressables | UNITY_ADDRESSABLES | yes |
| manage_behavior | UNITY_BEHAVIOR | yes |
| manage_cinemachine | UNITY_CINEMACHINE | yes |
| manage_dots | UNITY_ENTITIES | yes |
| manage_dots_graphics | UNITY_ENTITIES_GRAPHICS | yes |
| manage_dots_physics | UNITY_PHYSICS | yes |
| manage_dots_subscene | UNITY_ENTITIES | yes |
| manage_input_system | UNITY_INPUT_SYSTEM | yes |
| manage_localization | UNITY_LOCALIZATION | yes |
| manage_navigation | UNITY_AI_NAVIGATION | yes |
| manage_netcode | UNITY_NETCODE | yes |
| manage_splines | UNITY_SPLINES | yes |
| manage_tilemap | UNITY_TILEMAP | yes |
| manage_timeline | UNITY_TIMELINE | yes |
| validation_snapshot | UNITY_ENTITIES | yes |

No package-gated tool is missing a placeholder. (`manage_script`'s `USE_ROSLYN` gate and `manage_asset`/`manage_build`/`manage_material`/`refresh_unity`'s `UNITY_EDITOR` gate are compiler/platform defines, not optional-package gates, and are out of scope for `OptionalPackageTools`.)

## What this PR adds

A regression test, `BatchExecuteDispatchCoverageTests.EveryRegisteredTool_IsDispatchableThroughBatchExecute`, that:
- Walks the **live tool registry** via `ToolDiscoveryService.DiscoverAllTools()` (the same reflection source `CommandRegistry` uses) instead of a hardcoded tool-name list, so a newly added tool is covered automatically without a test edit.
- Dispatches every discovered tool (chunked under `BatchExecute.GetMaxCommandsPerBatch()`) through `BatchExecute.HandleCommand` with empty params.
- Asserts none of them return `"Unknown or unsupported command type"` — i.e., every registered command reaches its handler through `batch_execute`, even with a no-op/failing call (missing required args, package not installed, etc. are all acceptable failures; being *unrecognized* is not).

This complements the existing `CommandRegistryTests.OptionalPackageTools_AlwaysResolveToAHandler` (checks `CommandRegistry.GetHandler` directly) by proving the same guarantee holds through the actual `batch_execute` entry point end-to-end.

## Scope note

Per the orchestrator's instructions, the issue's secondary ask — adding `manage_splines` to the `t1k-unity-developer` agent's MCP tool allowlist — is a `theonekit-unity` kit change, not a `unity-mcp` change, and is intentionally **not** touched here.

## Verification caveat

No Unity Editor was available in this environment, so this could not be compiled or run. The test follows the exact structural pattern of the adjacent, already-passing `BatchExecuteKeyPreservationTests.cs` and `CommandRegistryTests.cs` in the same directory (same `CommandRegistry.Initialize()` setup, same `BatchExecute.HandleCommand(...).GetAwaiter().GetResult()` invocation, same `JObject.FromObject(result)` assertion style), so it should compile, but please run it in CI/Editor before merge.