### PR TITLE
fix(read_console): surface Bee/Tundra build failures (was silent false-green)

### DIFF
--- a/MCPForUnity/Editor/Tools/ReadConsole.cs
+++ b/MCPForUnity/Editor/Tools/ReadConsole.cs
@@ -543,7 +543,14 @@ namespace MCPForUnity.Editor.Tools
                 for (int li = 1; li < messageLines.Length; li++)
                 {
                     string candidate = messageLines[li];
-                    if (candidate.IndexOf(": error ", StringComparison.OrdinalIgnoreCase) < 0)
+                    // Two shapes must both match. Path-prefixed diagnostics carry ": error "
+                    // (e.g. "Assets/A.cs(33,50): error CS0535: ..."), but csc FATAL errors are
+                    // emitted with NO path prefix at all — "error CS2001: Source file 'X.cs'
+                    // could not be found.", CS0006, CS1704. Those start the line with "error ",
+                    // so there is no preceding ": " and a ": error " scan alone skips them,
+                    // reproducing the content-free false-RED this hoist exists to prevent.
+                    if (!candidate.TrimStart().StartsWith("error ", StringComparison.OrdinalIgnoreCase)
+                        && candidate.IndexOf(": error ", StringComparison.OrdinalIgnoreCase) < 0)
                     {
                         continue;
                     }

--- a/MCPForUnity/Editor/Tools/ReadConsole.cs
+++ b/MCPForUnity/Editor/Tools/ReadConsole.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using MCPForUnity.Editor.Helpers; // For Response class
 using Newtonsoft.Json.Linq;
 using UnityEditor;
@@ -247,6 +248,37 @@ namespace MCPForUnity.Editor.Tools
             int resolvedCursor = Mathf.Max(0, cursor ?? 0);
             int pageEndExclusive = resolvedCursor + resolvedPageSize;
 
+            // Bee/Tundra build failures (e.g. compile errors in assemblies that the
+            // domain-reload pipeline never routes through the managed console — see
+            // MCPForUnity kit issue #53) are not console log entries. Synthesize them
+            // here so `read_console(types=["error"])` can never observe an empty error
+            // list while an assembly actually failed to build. Appended FIRST (before
+            // ordinary console entries) so paging/count never bury the highest-value
+            // diagnostic behind unrelated console noise.
+            if (types.Contains("error"))
+            {
+                try
+                {
+                    AppendBuildFailureEntries(
+                        formattedEntries,
+                        ref totalMatches,
+                        ref retrievedCount,
+                        usePaging,
+                        resolvedCursor,
+                        pageEndExclusive,
+                        count,
+                        filterText,
+                        format,
+                        includeStacktrace
+                    );
+                }
+                catch (Exception e)
+                {
+                    // Never let a build-log parsing failure break an ordinary read_console call.
+                    McpLog.Warn($"[ReadConsole] Failed to append Bee build-failure entries: {e.Message}");
+                }
+            }
+
             try
             {
                 // LogEntries requires calling Start/Stop around GetEntries/GetEntryInternal.
@@ -373,14 +405,17 @@ namespace MCPForUnity.Editor.Tools
                     }
                     else
                     {
-                        formattedEntries.Add(formattedEntry);
-                        retrievedCount++;
-
-                        // Apply count limit (after filtering)
+                        // Check the count limit BEFORE adding: with build failures now
+                        // prepended (see below), retrievedCount can already equal
+                        // count.Value when this loop starts, and an add-then-check order
+                        // would let exactly one extra entry through.
                         if (count.HasValue && retrievedCount >= count.Value)
                         {
                             break;
                         }
+
+                        formattedEntries.Add(formattedEntry);
+                        retrievedCount++;
                     }
                 }
             }
@@ -401,35 +436,6 @@ namespace MCPForUnity.Editor.Tools
                 {
                     McpLog.Error($"[ReadConsole] Failed to call EndGettingEntries: {e}");
                     // Don't return error here as we might have valid data, but log it.
-                }
-            }
-
-            // Bee/Tundra build failures (e.g. compile errors in assemblies that the
-            // domain-reload pipeline never routes through the managed console — see
-            // MCPForUnity kit issue #53) are not console log entries. Synthesize them
-            // here so `read_console(types=["error"])` can never observe an empty error
-            // list while an assembly actually failed to build.
-            if (types.Contains("error"))
-            {
-                try
-                {
-                    AppendBuildFailureEntries(
-                        formattedEntries,
-                        ref totalMatches,
-                        ref retrievedCount,
-                        usePaging,
-                        resolvedCursor,
-                        pageEndExclusive,
-                        count,
-                        filterText,
-                        format,
-                        includeStacktrace
-                    );
-                }
-                catch (Exception e)
-                {
-                    // Never let a build-log parsing failure break an ordinary read_console call.
-                    McpLog.Error($"[ReadConsole] Failed to append Bee build-failure entries: {e.Message}");
                 }
             }
 
@@ -462,11 +468,17 @@ namespace MCPForUnity.Editor.Tools
 
         // --- Bee/Tundra build-failure surfacing (kit issue #53) ---
 
-        // Bee/Tundra rewrites Library/Bee/tundra.log.json at the start of every build, so its
-        // mtime marks the most recent build attempt. Guard against resurrecting errors from a
-        // much older session (e.g. a stale file left behind hours ago) by ignoring the log
-        // once it falls outside this recency window.
-        private const int TundraLogStalenessMinutes = 15;
+        // Bee/Tundra truncates and rewrites Library/Bee/tundra.log.json at the start of every
+        // build — confirmed against real project logs, each containing exactly one
+        // {"msg":"init"...} line, always line 1 — so the file always describes exactly one
+        // build session: the most recent. Cross-session contamination cannot occur, so no
+        // staleness/mtime window is applied here. A prior version of this code deleted true
+        // positives with a 15-minute recency guard: a real project log with a live
+        // exitcode:1 failure sitting untouched for six days was reported as green.
+        private static readonly Regex CompilerErrorLineRegex = new Regex(
+            @"^(?<file>.+?)\((?<line>\d+)(?:,(?<col>\d+))?\)\s*:\s*error",
+            RegexOptions.Compiled
+        );
 
         private readonly struct BuildFailureEntry
         {
@@ -513,7 +525,42 @@ namespace MCPForUnity.Editor.Tools
                     new[] { '\n', '\r' },
                     StringSplitOptions.RemoveEmptyEntries
                 );
+
+                // Default to the "[Bee build failure] ... (exit code N):" header and the
+                // build-artifact output path — used only when no compiler diagnostic line is
+                // found in stdout below.
                 string messageOnly = messageLines.Length > 0 ? messageLines[0] : failure.Message;
+                string errorFile = failure.OutputFile;
+                int errorLine = 0;
+
+                // Promote the first real compiler diagnostic line (e.g.
+                // "Assets/Foo.cs(16,73): error CS0023: ...") from stdout into the primary
+                // message/file/line. The DEFAULT read_console() call shape is
+                // format="plain", includeStacktrace=false, so without this the caller only
+                // ever sees the header line — the actual diagnostic (lines 2..N) is dropped
+                // because it's only attached as stackTrace when includeStacktrace is true.
+                // That silently turned a real compile failure into a content-free false-RED.
+                for (int li = 1; li < messageLines.Length; li++)
+                {
+                    string candidate = messageLines[li];
+                    if (candidate.IndexOf(": error ", StringComparison.OrdinalIgnoreCase) < 0)
+                    {
+                        continue;
+                    }
+
+                    messageOnly = candidate.Trim();
+                    Match match = CompilerErrorLineRegex.Match(messageOnly);
+                    if (match.Success)
+                    {
+                        errorFile = match.Groups["file"].Value;
+                        if (int.TryParse(match.Groups["line"].Value, out int parsedLine))
+                        {
+                            errorLine = parsedLine;
+                        }
+                    }
+                    break;
+                }
+
                 string stackTrace =
                     includeStacktrace && messageLines.Length > 1
                         ? string.Join("\n", messageLines.Skip(1))
@@ -533,8 +580,8 @@ namespace MCPForUnity.Editor.Tools
                             type = LogType.Error.ToString(),
                             source = "BeeBuildLog", // distinguishes a synthesized build-log entry from a real console entry
                             message = messageOnly,
-                            file = failure.OutputFile,
-                            line = 0,
+                            file = errorFile,
+                            line = errorLine,
                             stackTrace = stackTrace,
                         };
                         break;
@@ -556,13 +603,15 @@ namespace MCPForUnity.Editor.Tools
                 }
                 else
                 {
-                    formattedEntries.Add(formattedEntry);
-                    retrievedCount++;
-
+                    // Check the count limit BEFORE adding — without this, reaching the
+                    // limit exactly on entry lets one extra entry through (add-then-check).
                     if (count.HasValue && retrievedCount >= count.Value)
                     {
                         break;
                     }
+
+                    formattedEntries.Add(formattedEntry);
+                    retrievedCount++;
                 }
             }
         }
@@ -585,17 +634,19 @@ namespace MCPForUnity.Editor.Tools
                     return failures;
                 }
 
-                DateTime lastWriteUtc = File.GetLastWriteTimeUtc(tundraLogPath);
-                if ((DateTime.UtcNow - lastWriteUtc).TotalMinutes > TundraLogStalenessMinutes)
-                {
-                    // Older than our recency window — treat as a leftover from a previous
-                    // session rather than resurrecting hours-old errors.
-                    return failures;
-                }
-
                 foreach (string line in File.ReadLines(tundraLogPath))
                 {
                     if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    // Cheap pre-filter before the JSON parse: real logs run tens of MB /
+                    // thousands of lines, and read_console's "types" defaults to include
+                    // "error" — so this runs on essentially every poll while an agent waits
+                    // on a domain reload. Skipping non-"noderesult" lines up front (init,
+                    // progress, etc.) avoids parsing the bulk of the file every call.
+                    if (line.IndexOf("\"msg\":\"noderesult\"", StringComparison.Ordinal) < 0)
                     {
                         continue;
                     }
@@ -640,7 +691,12 @@ namespace MCPForUnity.Editor.Tools
             }
             catch (Exception e)
             {
-                McpLog.Error(
+                // Warn, not Error: an Error here becomes a real console entry, and the most
+                // likely trigger (an IOException while Bee holds the log mid-build) fires
+                // exactly when an agent is polling read_console — each poll would log an
+                // error, become a console entry, and get returned by the next poll,
+                // self-amplifying.
+                McpLog.Warn(
                     $"[ReadConsole] Failed to parse Library/Bee/tundra.log.json for build failures: {e.Message}"
                 );
             }

--- a/MCPForUnity/Editor/Tools/ReadConsole.cs
+++ b/MCPForUnity/Editor/Tools/ReadConsole.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using MCPForUnity.Editor.Helpers; // For Response class
@@ -403,6 +404,35 @@ namespace MCPForUnity.Editor.Tools
                 }
             }
 
+            // Bee/Tundra build failures (e.g. compile errors in assemblies that the
+            // domain-reload pipeline never routes through the managed console — see
+            // MCPForUnity kit issue #53) are not console log entries. Synthesize them
+            // here so `read_console(types=["error"])` can never observe an empty error
+            // list while an assembly actually failed to build.
+            if (types.Contains("error"))
+            {
+                try
+                {
+                    AppendBuildFailureEntries(
+                        formattedEntries,
+                        ref totalMatches,
+                        ref retrievedCount,
+                        usePaging,
+                        resolvedCursor,
+                        pageEndExclusive,
+                        count,
+                        filterText,
+                        format,
+                        includeStacktrace
+                    );
+                }
+                catch (Exception e)
+                {
+                    // Never let a build-log parsing failure break an ordinary read_console call.
+                    McpLog.Error($"[ReadConsole] Failed to append Bee build-failure entries: {e.Message}");
+                }
+            }
+
             if (usePaging)
             {
                 bool truncated = totalMatches > pageEndExclusive;
@@ -428,6 +458,194 @@ namespace MCPForUnity.Editor.Tools
                 $"Retrieved {formattedEntries.Count} log entries.",
                 formattedEntries
             );
+        }
+
+        // --- Bee/Tundra build-failure surfacing (kit issue #53) ---
+
+        // Bee/Tundra rewrites Library/Bee/tundra.log.json at the start of every build, so its
+        // mtime marks the most recent build attempt. Guard against resurrecting errors from a
+        // much older session (e.g. a stale file left behind hours ago) by ignoring the log
+        // once it falls outside this recency window.
+        private const int TundraLogStalenessMinutes = 15;
+
+        private readonly struct BuildFailureEntry
+        {
+            public readonly string Message;
+            public readonly string OutputFile;
+
+            public BuildFailureEntry(string message, string outputFile)
+            {
+                Message = message;
+                OutputFile = outputFile;
+            }
+        }
+
+        /// <summary>
+        /// Parses Library/Bee/tundra.log.json for failed build nodes (non-zero exitcode) and
+        /// appends them to <paramref name="formattedEntries"/> using the same type/filterText/
+        /// count/paging semantics as the regular console-entry loop above. Never throws — a
+        /// missing, unreadable, or malformed log file simply yields no entries.
+        /// </summary>
+        private static void AppendBuildFailureEntries(
+            List<object> formattedEntries,
+            ref int totalMatches,
+            ref int retrievedCount,
+            bool usePaging,
+            int resolvedCursor,
+            int pageEndExclusive,
+            int? count,
+            string filterText,
+            string format,
+            bool includeStacktrace
+        )
+        {
+            foreach (BuildFailureEntry failure in GetTundraBuildFailures())
+            {
+                if (
+                    !string.IsNullOrEmpty(filterText)
+                    && failure.Message.IndexOf(filterText, StringComparison.OrdinalIgnoreCase) < 0
+                )
+                {
+                    continue;
+                }
+
+                string[] messageLines = failure.Message.Split(
+                    new[] { '\n', '\r' },
+                    StringSplitOptions.RemoveEmptyEntries
+                );
+                string messageOnly = messageLines.Length > 0 ? messageLines[0] : failure.Message;
+                string stackTrace =
+                    includeStacktrace && messageLines.Length > 1
+                        ? string.Join("\n", messageLines.Skip(1))
+                        : null;
+
+                object formattedEntry;
+                switch (format)
+                {
+                    case "plain":
+                        formattedEntry = messageOnly;
+                        break;
+                    case "json":
+                    case "detailed":
+                    default:
+                        formattedEntry = new
+                        {
+                            type = LogType.Error.ToString(),
+                            source = "BeeBuildLog", // distinguishes a synthesized build-log entry from a real console entry
+                            message = messageOnly,
+                            file = failure.OutputFile,
+                            line = 0,
+                            stackTrace = stackTrace,
+                        };
+                        break;
+                }
+
+                totalMatches++;
+
+                if (usePaging)
+                {
+                    if (totalMatches > resolvedCursor && totalMatches <= pageEndExclusive)
+                    {
+                        formattedEntries.Add(formattedEntry);
+                        retrievedCount++;
+                    }
+                    else if (totalMatches > pageEndExclusive)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    formattedEntries.Add(formattedEntry);
+                    retrievedCount++;
+
+                    if (count.HasValue && retrievedCount >= count.Value)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static List<BuildFailureEntry> GetTundraBuildFailures()
+        {
+            var failures = new List<BuildFailureEntry>();
+
+            try
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath)?.FullName;
+                if (string.IsNullOrEmpty(projectRoot))
+                {
+                    return failures;
+                }
+
+                string tundraLogPath = Path.Combine(projectRoot, "Library", "Bee", "tundra.log.json");
+                if (!File.Exists(tundraLogPath))
+                {
+                    return failures;
+                }
+
+                DateTime lastWriteUtc = File.GetLastWriteTimeUtc(tundraLogPath);
+                if ((DateTime.UtcNow - lastWriteUtc).TotalMinutes > TundraLogStalenessMinutes)
+                {
+                    // Older than our recency window — treat as a leftover from a previous
+                    // session rather than resurrecting hours-old errors.
+                    return failures;
+                }
+
+                foreach (string line in File.ReadLines(tundraLogPath))
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    JObject node;
+                    try
+                    {
+                        node = JObject.Parse(line);
+                    }
+                    catch (Exception)
+                    {
+                        // A partially-written/truncated line (e.g. build still in progress) —
+                        // skip it rather than failing the whole parse.
+                        continue;
+                    }
+
+                    if (node.Value<string>("msg") != "noderesult")
+                    {
+                        continue;
+                    }
+
+                    int? exitCode = node.Value<int?>("exitcode");
+                    if (!exitCode.HasValue || exitCode.Value == 0)
+                    {
+                        continue;
+                    }
+
+                    string stdout = node.Value<string>("stdout");
+                    string annotation = node.Value<string>("annotation");
+                    string outputFile = node.Value<string>("outputfile");
+
+                    string body = !string.IsNullOrWhiteSpace(stdout) ? stdout.Trim() : "(no output captured)";
+                    string label = !string.IsNullOrWhiteSpace(annotation) ? annotation : (outputFile ?? "unknown build node");
+
+                    failures.Add(
+                        new BuildFailureEntry(
+                            $"[Bee build failure] {label} (exit code {exitCode.Value}):\n{body}",
+                            outputFile
+                        )
+                    );
+                }
+            }
+            catch (Exception e)
+            {
+                McpLog.Error(
+                    $"[ReadConsole] Failed to parse Library/Bee/tundra.log.json for build failures: {e.Message}"
+                );
+            }
+
+            return failures;
         }
 
         // --- Internal Helpers ---

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
@@ -16,6 +16,7 @@ namespace MCPForUnityTests.Editor.Tools
             Path.Combine(Directory.GetParent(Application.dataPath).FullName, "Library", "Bee", "tundra.log.json");
 
         private string _preexistingTundraLogBackup;
+        private bool _hadPreexistingTundraLog;
 
         [SetUp]
         public void SaveExistingTundraLog()
@@ -24,24 +25,45 @@ namespace MCPForUnityTests.Editor.Tools
             // build. Back it up so these tests never leak fixture data into the real log
             // or lose the developer's genuine build state.
             _preexistingTundraLogBackup = null;
-            if (File.Exists(TundraLogPath))
+            _hadPreexistingTundraLog = File.Exists(TundraLogPath);
+            if (_hadPreexistingTundraLog)
             {
-                _preexistingTundraLogBackup = TundraLogPath + ".test-backup";
-                File.Copy(TundraLogPath, _preexistingTundraLogBackup, overwrite: true);
+                string backupPath = TundraLogPath + ".test-backup";
+                File.Copy(TundraLogPath, backupPath, overwrite: true);
+                // Only record the backup path once the copy has actually succeeded. If
+                // File.Copy throws (e.g. Bee holding the log mid-build — plausible, since
+                // EditMode tests run right after a compile), _preexistingTundraLogBackup
+                // must stay null so TearDown's _hadPreexistingTundraLog guard below can
+                // tell "no real log ever existed" apart from "a real log existed but its
+                // backup is unconfirmed" — and never delete the latter.
+                _preexistingTundraLogBackup = backupPath;
             }
         }
 
         [TearDown]
         public void RestoreExistingTundraLog()
         {
-            if (_preexistingTundraLogBackup != null && File.Exists(_preexistingTundraLogBackup))
+            try
             {
-                File.Copy(_preexistingTundraLogBackup, TundraLogPath, overwrite: true);
-                File.Delete(_preexistingTundraLogBackup);
+                if (_preexistingTundraLogBackup != null && File.Exists(_preexistingTundraLogBackup))
+                {
+                    File.Copy(_preexistingTundraLogBackup, TundraLogPath, overwrite: true);
+                    File.Delete(_preexistingTundraLogBackup);
+                }
+                else if (!_hadPreexistingTundraLog && File.Exists(TundraLogPath))
+                {
+                    // No real pre-existing log was ever present — safe to remove the
+                    // fixture file this test wrote.
+                    File.Delete(TundraLogPath);
+                }
+                // else: a real log existed but its backup could not be confirmed (SetUp's
+                // File.Copy most likely threw) — leave the file untouched rather than risk
+                // deleting a developer's genuine build log.
             }
-            else if (File.Exists(TundraLogPath))
+            finally
             {
-                File.Delete(TundraLogPath);
+                _preexistingTundraLogBackup = null;
+                _hadPreexistingTundraLog = false;
             }
         }
 
@@ -136,11 +158,17 @@ namespace MCPForUnityTests.Editor.Tools
         }
 
         [Test]
-        public void HandleCommand_Get_StaleTundraLog_IsIgnored()
+        public void HandleCommand_Get_OldMtimeTundraLog_IsStillSurfaced()
         {
-            // Arrange — a failed node, but the log file itself is old (simulating a leftover
-            // from a previous session). Must not be resurrected as a "current" error.
-            string uniqueMarker = $"TundraStaleMarker_{Guid.NewGuid():N}";
+            // Arrange — a failed node whose log file has an old mtime (e.g. a build that
+            // failed hours/days ago and was never re-run). Bee truncates and rewrites
+            // tundra.log.json at the START of every build (confirmed against real project
+            // logs — each contains exactly one {"msg":"init"...} line, always line 1), so the
+            // file always describes exactly one build session: the most recent one. There is
+            // no cross-session contamination for an mtime guard to defend against, so an old
+            // mtime must NOT hide a live, still-unresolved failure (this was the issue #53
+            // regression: a wall-clock staleness window silently deleted true positives).
+            string uniqueMarker = $"TundraOldMtimeMarker_{Guid.NewGuid():N}";
             string ndjson =
                 "{\"msg\":\"noderesult\",\"annotation\":\"Csc " + uniqueMarker + ".dll\",\"index\":1,\"exitcode\":1,\"outputfile\":\"Library/ScriptAssemblies/" + uniqueMarker + ".dll\",\"stdout\":\"error CS1061: " + uniqueMarker + "\"}\n";
             WriteTundraLog(ndjson);
@@ -161,17 +189,74 @@ namespace MCPForUnityTests.Editor.Tools
             Assert.IsTrue(result.Value<bool>("success"), result.ToString());
             var data = result["data"] as JArray ?? new JArray();
 
-            bool foundStale = false;
+            bool found = false;
             foreach (var entry in data)
             {
                 if (entry["message"]?.ToString().Contains(uniqueMarker) == true)
                 {
-                    foundStale = true;
+                    found = true;
                     break;
                 }
             }
 
-            Assert.IsFalse(foundStale, "An old tundra.log.json outside the staleness window must not be resurrected as a current error.");
+            Assert.IsTrue(found, "A live build failure must be surfaced regardless of the log file's mtime — Bee owns truncation/rewrite, not this tool.");
+        }
+
+        [Test]
+        public void HandleCommand_Get_DefaultCallShape_SurfacesActualCompilerDiagnostic()
+        {
+            // Arrange — a build node with a non-zero exitcode carrying a real compiler
+            // diagnostic in stdout. Regression coverage for the false-green-turned-content
+            // -free-false-red bug: the DEFAULT read_console() call shape (format="plain",
+            // includeStacktrace=false — see read_console.py) must surface the actual
+            // "error CS####" diagnostic text, not just the
+            // "[Bee build failure] ... (exit code N):" header with zero content. The
+            // existing "detailed" test above only incidentally passed because the unique
+            // marker also happened to sit in the header's annotation text.
+            string uniqueMarker = $"TundraDefaultShapeMarker_{Guid.NewGuid():N}";
+            string ndjson =
+                "{\"msg\":\"noderesult\",\"annotation\":\"Csc Other.dll\",\"index\":1,\"exitcode\":1,\"outputfile\":\"Library/ScriptAssemblies/Other.dll\",\"stdout\":\"Assets/Tests/Broken.cs(16,73): error CS0023: " + uniqueMarker + "\"}\n";
+            WriteTundraLog(ndjson);
+
+            // Only "action" and "count" are set — format/includeStacktrace/types all take
+            // the tool's real defaults, matching a plain read_console() call.
+            var paramsObj = new JObject
+            {
+                ["action"] = "get",
+                ["count"] = 1000,
+            };
+
+            // Act
+            var result = ToJObject(ReadConsole.HandleCommand(paramsObj));
+
+            // Assert
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JArray;
+            Assert.IsNotNull(data, "Data array should not be null.");
+
+            bool foundDiagnostic = false;
+            foreach (var entry in data)
+            {
+                // In "plain" format (the default) each entry IS the message string, not an
+                // object — unlike the "detailed"/"json" format used by the other tests here.
+                string entryText = entry.Type == JTokenType.Object
+                    ? entry["message"]?.ToString()
+                    : entry.ToString();
+
+                if (entryText != null
+                    && entryText.Contains(uniqueMarker)
+                    && entryText.Contains("error CS0023")
+                    && entryText.Contains("Broken.cs"))
+                {
+                    foundDiagnostic = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(
+                foundDiagnostic,
+                "Default read_console() call (format=\"plain\", includeStacktrace=false) must surface the actual compiler diagnostic line (\"Broken.cs(16,73): error CS0023: ...\"), not just the build-failure header."
+            );
         }
 
         [Test]

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using UnityEngine;
@@ -9,6 +10,170 @@ namespace MCPForUnityTests.Editor.Tools
 {
     public class ReadConsoleTests
     {
+        // --- Bee/Tundra build-failure surfacing (kit issue #53) ---
+
+        private static string TundraLogPath =>
+            Path.Combine(Directory.GetParent(Application.dataPath).FullName, "Library", "Bee", "tundra.log.json");
+
+        private string _preexistingTundraLogBackup;
+
+        [SetUp]
+        public void SaveExistingTundraLog()
+        {
+            // Some CI/dev machines may already have a real tundra.log.json from an actual
+            // build. Back it up so these tests never leak fixture data into the real log
+            // or lose the developer's genuine build state.
+            _preexistingTundraLogBackup = null;
+            if (File.Exists(TundraLogPath))
+            {
+                _preexistingTundraLogBackup = TundraLogPath + ".test-backup";
+                File.Copy(TundraLogPath, _preexistingTundraLogBackup, overwrite: true);
+            }
+        }
+
+        [TearDown]
+        public void RestoreExistingTundraLog()
+        {
+            if (_preexistingTundraLogBackup != null && File.Exists(_preexistingTundraLogBackup))
+            {
+                File.Copy(_preexistingTundraLogBackup, TundraLogPath, overwrite: true);
+                File.Delete(_preexistingTundraLogBackup);
+            }
+            else if (File.Exists(TundraLogPath))
+            {
+                File.Delete(TundraLogPath);
+            }
+        }
+
+        private static void WriteTundraLog(string ndjson)
+        {
+            string dir = Path.GetDirectoryName(TundraLogPath);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(TundraLogPath, ndjson);
+            File.SetLastWriteTimeUtc(TundraLogPath, DateTime.UtcNow);
+        }
+
+        [Test]
+        public void HandleCommand_Get_SurfacesTundraBuildFailure()
+        {
+            // Arrange — a build node with a non-zero exitcode, as produced by a real compile
+            // failure (e.g. CS1061) in an editor-test assembly.
+            string uniqueMarker = $"TundraFailureMarker_{Guid.NewGuid():N}";
+            string ndjson =
+                "{\"msg\":\"noderesult\",\"annotation\":\"Csc " + uniqueMarker + ".dll\",\"index\":1,\"exitcode\":0,\"outputfile\":\"Library/ScriptAssemblies/Ok.dll\",\"stdout\":\"\"}\n" +
+                "{\"msg\":\"noderesult\",\"annotation\":\"Csc " + uniqueMarker + ".dll\",\"index\":2,\"exitcode\":1,\"outputfile\":\"Library/ScriptAssemblies/" + uniqueMarker + ".dll\",\"stdout\":\"Assets/Tests/Broken.cs(10,20): error CS1061: " + uniqueMarker + "\"}\n";
+            WriteTundraLog(ndjson);
+
+            var paramsObj = new JObject
+            {
+                ["action"] = "get",
+                ["types"] = new JArray { "error" },
+                ["format"] = "detailed",
+                ["count"] = 1000,
+            };
+
+            // Act
+            var result = ToJObject(ReadConsole.HandleCommand(paramsObj));
+
+            // Assert
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JArray;
+            Assert.IsNotNull(data, "Data array should not be null.");
+
+            bool found = false;
+            foreach (var entry in data)
+            {
+                if (entry["message"]?.ToString().Contains(uniqueMarker) == true)
+                {
+                    Assert.AreEqual("Error", entry["type"]?.ToString(), "Build-failure entry should be typed as Error.");
+                    Assert.AreEqual("BeeBuildLog", entry["source"]?.ToString(), "Build-failure entry should carry a distinct source so callers can tell it apart from a real console entry.");
+                    found = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(
+                found,
+                $"read_console(types=[\"error\"]) did not surface the failed Bee build node — this is the false-green regression from issue #53."
+            );
+        }
+
+        [Test]
+        public void HandleCommand_Get_CleanTundraLog_ProducesNoBuildFailureEntries()
+        {
+            // Arrange — every node succeeded (exitcode 0); nothing should be synthesized.
+            string uniqueMarker = $"TundraCleanMarker_{Guid.NewGuid():N}";
+            string ndjson =
+                "{\"msg\":\"noderesult\",\"annotation\":\"Csc " + uniqueMarker + ".dll\",\"index\":1,\"exitcode\":0,\"outputfile\":\"Library/ScriptAssemblies/" + uniqueMarker + ".dll\",\"stdout\":\"\"}\n";
+            WriteTundraLog(ndjson);
+
+            var paramsObj = new JObject
+            {
+                ["action"] = "get",
+                ["types"] = new JArray { "error" },
+                ["format"] = "detailed",
+                ["count"] = 1000,
+            };
+
+            // Act
+            var result = ToJObject(ReadConsole.HandleCommand(paramsObj));
+
+            // Assert
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JArray ?? new JArray();
+
+            bool foundSpurious = false;
+            foreach (var entry in data)
+            {
+                if (entry["message"]?.ToString().Contains(uniqueMarker) == true)
+                {
+                    foundSpurious = true;
+                    break;
+                }
+            }
+
+            Assert.IsFalse(foundSpurious, "A clean tundra.log.json (all exitcode 0) must not synthesize any build-failure entries.");
+        }
+
+        [Test]
+        public void HandleCommand_Get_StaleTundraLog_IsIgnored()
+        {
+            // Arrange — a failed node, but the log file itself is old (simulating a leftover
+            // from a previous session). Must not be resurrected as a "current" error.
+            string uniqueMarker = $"TundraStaleMarker_{Guid.NewGuid():N}";
+            string ndjson =
+                "{\"msg\":\"noderesult\",\"annotation\":\"Csc " + uniqueMarker + ".dll\",\"index\":1,\"exitcode\":1,\"outputfile\":\"Library/ScriptAssemblies/" + uniqueMarker + ".dll\",\"stdout\":\"error CS1061: " + uniqueMarker + "\"}\n";
+            WriteTundraLog(ndjson);
+            File.SetLastWriteTimeUtc(TundraLogPath, DateTime.UtcNow.AddHours(-2));
+
+            var paramsObj = new JObject
+            {
+                ["action"] = "get",
+                ["types"] = new JArray { "error" },
+                ["format"] = "detailed",
+                ["count"] = 1000,
+            };
+
+            // Act
+            var result = ToJObject(ReadConsole.HandleCommand(paramsObj));
+
+            // Assert
+            Assert.IsTrue(result.Value<bool>("success"), result.ToString());
+            var data = result["data"] as JArray ?? new JArray();
+
+            bool foundStale = false;
+            foreach (var entry in data)
+            {
+                if (entry["message"]?.ToString().Contains(uniqueMarker) == true)
+                {
+                    foundStale = true;
+                    break;
+                }
+            }
+
+            Assert.IsFalse(foundStale, "An old tundra.log.json outside the staleness window must not be resurrected as a current error.");
+        }
+
         [Test]
         public void HandleCommand_Clear_Works()
         {


### PR DESCRIPTION
## Summary

Fixes #53

`read_console(types=["error"])` could return **zero errors** while an editor-test (or any) assembly was actually failing to compile — the compiler diagnostics never route through the managed Unity console; they only ever land in `Library/Bee/tundra.log.json`. An agent following the documented `refresh_unity -> read_console -> run_tests` verification loop would see a clean console and report "compile clean" against a stale DLL — a silent false-green, worse than a loud error.

## Fix

- `ReadConsole.GetConsoleEntries` now additionally parses `Library/Bee/tundra.log.json` (newline-delimited JSON) for `noderesult` entries with a non-zero `exitcode`, and synthesizes each as a `type=Error` entry carrying `source="BeeBuildLog"` — so callers can tell a build-log-derived entry apart from a real console entry while it still surfaces under the standard `types=["error"]` filter.
- Synthesized entries flow through the *same* `filterText` / `count` / paging logic as regular console entries (`AppendBuildFailureEntries`), so existing callers using paging/count/filterText see consistent behavior.
- **Staleness handling:** Bee/Tundra rewrites `tundra.log.json` at the start of every build, so its mtime marks the most recent build attempt. I chose a **15-minute recency window** on the file's `LastWriteTimeUtc` — if the log wasn't touched within that window it's ignored entirely. This guards against the mirror-image failure mode explicitly called out in the issue: resurrecting hours-old errors from an unrelated earlier build/branch. A build that's still in-flight (log actively being appended) naturally refreshes the mtime, so the window doesn't race a legitimate long build.
- **Never throws:** a missing file, unreadable file, or a malformed/truncated NDJSON line (e.g. build still writing) is caught and simply yields no synthesized entries — ordinary `read_console` calls are unaffected. Errors are logged via `McpLog.Error` for visibility, never propagated.

## Tests

Added to `TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ReadConsoleTests.cs`:
- `HandleCommand_Get_SurfacesTundraBuildFailure` — writes a fixture `tundra.log.json` with a non-zero-`exitcode` `noderesult` entry, asserts `read_console(types=["error"])` returns a matching `type=Error, source=BeeBuildLog` entry.
- `HandleCommand_Get_CleanTundraLog_ProducesNoBuildFailureEntries` — all-`exitcode:0` fixture, asserts nothing is synthesized.
- `HandleCommand_Get_StaleTundraLog_IsIgnored` — a failing fixture with `LastWriteTimeUtc` backdated 2 hours, asserts it's not resurrected.

Tests back up/restore any pre-existing `tundra.log.json` in `[SetUp]`/`[TearDown]` so they don't clobber a developer's real build log.

## Honesty note

**I could not compile or run this locally** — no Unity Editor is available in this environment. The change was written by careful inspection of the existing `ReadConsole.cs` control flow (loop variables, paging/count semantics, `Response.cs` shapes) and matched against the exact JSON shape from the issue's repro logs. Please run `tools/check-unity-versions.sh` / the EditMode suite in CI before merging.

## Scope

Touched only `MCPForUnity/Editor/Tools/ReadConsole.cs` and its EditMode tests — no other read_console-adjacent files (RefreshUnity.cs, ManageInputSimulation.cs, BatchExecute.cs) were modified.