### PR TITLE
fix(input_simulation): write bitfield key/button controls via queued state events

### DIFF
--- a/MCPForUnity/Editor/Helpers/Response.cs
+++ b/MCPForUnity/Editor/Helpers/Response.cs
@@ -25,6 +25,11 @@ namespace MCPForUnity.Editor.Helpers
         [JsonIgnore]
         public object data => Data;
 
+        // Mutable, opt-in: lets a caller flag a successful action that may not have had
+        // its intended effect (e.g. input simulated while the Game view lacks focus).
+        [JsonProperty("warning", NullValueHandling = NullValueHandling.Ignore)]
+        public string Warning { get; set; }
+
         public SuccessResponse(string message, object data = null)
         {
             Message = message;

--- a/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
+++ b/MCPForUnity/Editor/MCPForUnity.Editor.asmdef
@@ -70,7 +70,7 @@
         },
         {
             "name": "com.unity.inputsystem",
-            "expression": "",
+            "expression": "1.1",
             "define": "UNITY_INPUT_SYSTEM"
         },
         {

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
 #if UNITY_INPUT_SYSTEM
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 #endif
 
@@ -37,15 +39,38 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
         // written via InputState.Change — that overload only supports byte-aligned state
         // memory and throws "Cannot change state of bitfield control ... using this method".
         // The supported way to flip a bitfield control is to write the value into a fresh
-        // state event for the owning device, then queue that event (same pattern Unity's
-        // own OnScreenControl uses for on-screen buttons/keys).
-        static void WriteButton(UnityEngine.InputSystem.Controls.ButtonControl control, float value)
+        // state event for the owning device, then queue that event.
+        //
+        // StateEvent.From snapshots the device's FULL current state at event-creation time.
+        // Two such events queued back-to-back WITHOUT an intervening update do NOT
+        // accumulate — each snapshots the state as of its own creation, so the second
+        // silently overwrites every control the first one touched (a dropped modifier, or
+        // a key left stuck down). Every control belonging to the SAME logical transition
+        // (e.g. a modifier + its key going down together) MUST therefore be written into
+        // ONE event via WriteButtons, and InputSystem.Update() is forced unconditionally
+        // after every queue so the next snapshot in a sequence observes this transition
+        // already applied. Correctness must not depend on the caller's "flush" parameter —
+        // see key_combo below, which is exactly the sequence that broke without this.
+        static void WriteButton(ButtonControl control, float value)
         {
             using (StateEvent.From(control.device, out var eventPtr))
             {
                 control.WriteValueIntoEvent(value, eventPtr);
                 InputSystem.QueueEvent(eventPtr);
             }
+            InputSystem.Update();
+        }
+
+        // Writes multiple controls of the SAME device into a single state event so they
+        // land as one atomic transition. See WriteButton for why this matters.
+        static void WriteButtons(InputDevice device, params (ButtonControl control, float value)[] writes)
+        {
+            using (StateEvent.From(device, out var eventPtr))
+            {
+                foreach (var (control, value) in writes) control.WriteValueIntoEvent(value, eventPtr);
+                InputSystem.QueueEvent(eventPtr);
+            }
+            InputSystem.Update();
         }
 
         static void Btn(int b, float v)
@@ -54,16 +79,18 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
             WriteButton(control, v);
         }
         static void Flush(bool f) { if (f) InputSystem.Update(); }
-        static void DoClick(Vector2 p, int b, bool f) { Move(p); Btn(b, 1f); Flush(f); Btn(b, 0f); Flush(f); }
+        // WriteButton/Btn already force an update per transition (see above) — button
+        // presses no longer depend on a subsequent Flush() call for correctness.
+        static void DoClick(Vector2 p, int b) { Move(p); Btn(b, 1f); Btn(b, 0f); }
 #endif
 
         // ── Mouse Actions ──────────────────────────────────────────────────────────
         internal static object Click(ToolParams p)
         {
             var (pos, e) = Resolve(p); if (e != null) return e;
-            string bn = p.Get("button", "left"); bool fl = p.GetBool("flush", true);
+            string bn = p.Get("button", "left");
 #if UNITY_INPUT_SYSTEM
-            DoClick(pos.Value, BtnIndex(bn), fl);
+            DoClick(pos.Value, BtnIndex(bn));
             return new SuccessResponse($"Clicked ({pos.Value.x:F0}, {pos.Value.y:F0}).", new { x = pos.Value.x, y = pos.Value.y, button = bn });
 #else
             return new ErrorResponse("Legacy backend: click not supported. Enable com.unity.inputsystem.");
@@ -73,9 +100,9 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
         internal static object DoubleClick(ToolParams p)
         {
             var (pos, e) = Resolve(p); if (e != null) return e;
-            string bn = p.Get("button", "left"); bool fl = p.GetBool("flush", true);
+            string bn = p.Get("button", "left");
 #if UNITY_INPUT_SYSTEM
-            int b = BtnIndex(bn); DoClick(pos.Value, b, fl); DoClick(pos.Value, b, fl);
+            int b = BtnIndex(bn); DoClick(pos.Value, b); DoClick(pos.Value, b);
             return new SuccessResponse($"Double-clicked ({pos.Value.x:F0}, {pos.Value.y:F0}).", new { x = pos.Value.x, y = pos.Value.y, button = bn });
 #else
             return new ErrorResponse("Legacy backend: double-click not supported. Enable com.unity.inputsystem.");
@@ -98,10 +125,13 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
             var (fr, e1) = Resolve(p, "from_target"); if (e1 != null) return e1;
             var (to, e2) = Resolve(p, "to_target");   if (e2 != null) return e2;
 #if UNITY_INPUT_SYSTEM
-            bool fl = p.GetBool("flush", true);
-            Move(fr.Value); WriteButton(Mouse.current.leftButton, 1f); Flush(fl);
-            Move(to.Value); Flush(fl);
-            WriteButton(Mouse.current.leftButton, 0f); Flush(fl);
+            // Move() writes position immediately via InputState.Change; WriteButton()
+            // forces its own update per transition (see WriteButton), so each subsequent
+            // snapshot already observes the prior Move — no explicit flush needed here.
+            Move(fr.Value);
+            WriteButton(Mouse.current.leftButton, 1f);
+            Move(to.Value);
+            WriteButton(Mouse.current.leftButton, 0f);
             return new SuccessResponse($"Dragged ({fr.Value.x:F0},{fr.Value.y:F0}) → ({to.Value.x:F0},{to.Value.y:F0}).",
                 new { from_x = fr.Value.x, from_y = fr.Value.y, to_x = to.Value.x, to_y = to.Value.y });
 #else
@@ -145,12 +175,22 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
             string[] mods = p.GetStringArray("modifiers");
 #if UNITY_INPUT_SYSTEM
             if (!TryKey(r.Value, out var k)) return new ErrorResponse($"Unknown key '{r.Value}'.");
-            bool fl = p.GetBool("flush", true);
-            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) WriteButton(Keyboard.current[mk], 1f);
-            WriteButton(Keyboard.current[k], 1f); Flush(fl);
-            WriteButton(Keyboard.current[k], 0f);
-            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) WriteButton(Keyboard.current[mk], 0f);
-            Flush(fl);
+
+            // Modifiers + main key must go down in ONE event and come up in ONE event —
+            // see WriteButtons. Writing them as separate back-to-back events (the previous
+            // implementation) silently drops the modifier on the way down and leaves the
+            // main key stuck down on the way up, because each event only snapshots the
+            // state as of its own creation.
+            var down = new List<(ButtonControl control, float value)>();
+            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) down.Add((Keyboard.current[mk], 1f));
+            down.Add((Keyboard.current[k], 1f));
+            WriteButtons(Keyboard.current, down.ToArray());
+
+            var up = new List<(ButtonControl control, float value)>();
+            up.Add((Keyboard.current[k], 0f));
+            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) up.Add((Keyboard.current[mk], 0f));
+            WriteButtons(Keyboard.current, up.ToArray());
+
             return new SuccessResponse($"Combo [{string.Join("+", mods ?? Array.Empty<string>())}]+{r.Value}.", new { key = r.Value, modifiers = mods });
 #else
             return new ErrorResponse("Legacy backend: key combo not supported. Enable com.unity.inputsystem.");

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationActions.cs
@@ -12,7 +12,8 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
 {
     /// <summary>
     /// Mouse + keyboard input simulation actions.
-    /// Dual backend: New Input System (InputState.Change) + Legacy (ExecuteEvents).
+    /// Dual backend: New Input System (InputState.Change for byte-aligned controls,
+    /// event-queued writes via WriteButton for bitfield controls) + Legacy (ExecuteEvents).
     /// </summary>
     internal static class InputSimulationActions
     {
@@ -31,11 +32,26 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
         static int BtnIndex(string n) => n?.ToLowerInvariant() == "right" ? 1 : n?.ToLowerInvariant() == "middle" ? 2 : 0;
         static bool TryKey(string n, out Key k) => Enum.TryParse(n ?? "", true, out k);
         static void Move(Vector2 p) => InputState.Change(Mouse.current.position, p);
+
+        // Key/Button controls are bitfield-backed (packed sub-byte state) and cannot be
+        // written via InputState.Change — that overload only supports byte-aligned state
+        // memory and throws "Cannot change state of bitfield control ... using this method".
+        // The supported way to flip a bitfield control is to write the value into a fresh
+        // state event for the owning device, then queue that event (same pattern Unity's
+        // own OnScreenControl uses for on-screen buttons/keys).
+        static void WriteButton(UnityEngine.InputSystem.Controls.ButtonControl control, float value)
+        {
+            using (StateEvent.From(control.device, out var eventPtr))
+            {
+                control.WriteValueIntoEvent(value, eventPtr);
+                InputSystem.QueueEvent(eventPtr);
+            }
+        }
+
         static void Btn(int b, float v)
         {
-            if (b == 1)      InputState.Change(Mouse.current.rightButton,  v);
-            else if (b == 2) InputState.Change(Mouse.current.middleButton, v);
-            else             InputState.Change(Mouse.current.leftButton,   v);
+            var control = b == 1 ? Mouse.current.rightButton : b == 2 ? Mouse.current.middleButton : Mouse.current.leftButton;
+            WriteButton(control, v);
         }
         static void Flush(bool f) { if (f) InputSystem.Update(); }
         static void DoClick(Vector2 p, int b, bool f) { Move(p); Btn(b, 1f); Flush(f); Btn(b, 0f); Flush(f); }
@@ -83,9 +99,9 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
             var (to, e2) = Resolve(p, "to_target");   if (e2 != null) return e2;
 #if UNITY_INPUT_SYSTEM
             bool fl = p.GetBool("flush", true);
-            Move(fr.Value); InputState.Change(Mouse.current.leftButton, 1f); Flush(fl);
+            Move(fr.Value); WriteButton(Mouse.current.leftButton, 1f); Flush(fl);
             Move(to.Value); Flush(fl);
-            InputState.Change(Mouse.current.leftButton, 0f); Flush(fl);
+            WriteButton(Mouse.current.leftButton, 0f); Flush(fl);
             return new SuccessResponse($"Dragged ({fr.Value.x:F0},{fr.Value.y:F0}) → ({to.Value.x:F0},{to.Value.y:F0}).",
                 new { from_x = fr.Value.x, from_y = fr.Value.y, to_x = to.Value.x, to_y = to.Value.y });
 #else
@@ -114,8 +130,8 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
 #if UNITY_INPUT_SYSTEM
             if (!TryKey(r.Value, out var k)) return new ErrorResponse($"Unknown key '{r.Value}'. Use Key enum names (e.g. Space, A, Escape).");
             bool fl = p.GetBool("flush", true);
-            if (mode == "release") { InputState.Change(Keyboard.current[k], 0f); }
-            else { InputState.Change(Keyboard.current[k], 1f); Flush(fl); if (mode == "tap") InputState.Change(Keyboard.current[k], 0f); }
+            if (mode == "release") { WriteButton(Keyboard.current[k], 0f); }
+            else { WriteButton(Keyboard.current[k], 1f); Flush(fl); if (mode == "tap") WriteButton(Keyboard.current[k], 0f); }
             Flush(fl);
             return new SuccessResponse($"Key '{r.Value}' {mode}.", new { key = r.Value, mode });
 #else
@@ -130,10 +146,10 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
 #if UNITY_INPUT_SYSTEM
             if (!TryKey(r.Value, out var k)) return new ErrorResponse($"Unknown key '{r.Value}'.");
             bool fl = p.GetBool("flush", true);
-            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) InputState.Change(Keyboard.current[mk], 1f);
-            InputState.Change(Keyboard.current[k], 1f); Flush(fl);
-            InputState.Change(Keyboard.current[k], 0f);
-            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) InputState.Change(Keyboard.current[mk], 0f);
+            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) WriteButton(Keyboard.current[mk], 1f);
+            WriteButton(Keyboard.current[k], 1f); Flush(fl);
+            WriteButton(Keyboard.current[k], 0f);
+            if (mods != null) foreach (var m in mods) if (TryKey(m, out var mk)) WriteButton(Keyboard.current[mk], 0f);
             Flush(fl);
             return new SuccessResponse($"Combo [{string.Join("+", mods ?? Array.Empty<string>())}]+{r.Value}.", new { key = r.Value, modifiers = mods });
 #else

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationFocusGuard.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationFocusGuard.cs
@@ -1,38 +1,40 @@
 using System;
 using UnityEditor;
-#if UNITY_INPUT_SYSTEM
-using UnityEngine.InputSystem;
-#endif
 
 namespace MCPForUnity.Editor.Tools.InputSimulation
 {
     /// <summary>
     /// Simulated input only reaches the running game when the Game view is the input
-    /// target. Two independent problems can defeat that:
-    ///   1. The Editor is looking at the Scene view (or another window) instead of the
-    ///      Game view — simulated devices still update, but nothing in the game observes
-    ///      them because the Game view never processes the frame's input.
-    ///   2. The Input System's "Play Mode Input Behavior" setting can route device input
-    ///      away from the Game view depending on focus, so even a technically-successful
-    ///      write may not surface to gameplay code.
-    /// This helper surfaces (1) as a response warning instead of a silent false-positive
-    /// "success", and works around (2) for the duration of a simulated action.
+    /// target. Two independent things can defeat that:
+    ///   1. Unity itself doesn't have OS-level focus (the user is in an MCP client, Unity
+    ///      is in the background) — simulated devices still update, but nothing in the
+    ///      game observes them because the Game view never processes the frame's input.
+    ///   2. The Editor is looking at the Scene view (or another window) instead of the
+    ///      Game view, even while Unity itself is focused.
+    /// This helper surfaces either case as a response warning instead of a silent
+    /// false-positive "success".
     /// </summary>
     internal static class InputSimulationFocusGuard
     {
         /// <summary>
-        /// True if the currently focused Editor window is the Game view. Best-effort:
-        /// returns true (no warning) if the check itself fails, since a warning must never
-        /// be fabricated on top of an actual detection error.
+        /// True if Unity has OS-level focus AND the currently focused Editor window is
+        /// the Game view. Best-effort: a genuine detection failure (no focused-window
+        /// state available, or the internal GameView type can't be resolved) returns
+        /// true (no warning) — a warning must never be fabricated on top of an actual
+        /// detection error. A real "not focused" signal (Unity backgrounded, or a
+        /// different window focused) returns false so the warning fires.
         /// </summary>
         internal static bool IsGameViewFocused()
         {
             try
             {
+                if (!UnityEditorInternal.InternalEditorUtility.isApplicationActive) return false;
+
                 var focused = EditorWindow.focusedWindow;
-                if (focused == null) return false;
+                if (focused == null) return true;
                 var gameViewType = Type.GetType("UnityEditor.GameView,UnityEditor");
-                return gameViewType != null && focused.GetType() == gameViewType;
+                if (gameViewType == null) return true;
+                return focused.GetType() == gameViewType;
             }
             catch
             {
@@ -44,60 +46,5 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
             "Game view is not focused — simulated input was sent to the input devices but may not reach " +
             "the running game. Focus the Game view (or call manage_editor to bring it forward) before " +
             "relying on this result.";
-
-        /// <summary>
-        /// Forces all device input to the Game view for the lifetime of the returned scope,
-        /// then restores the previous setting. No-op (returns a no-op disposable) when the
-        /// Input System package isn't present or the setting can't be reached.
-        /// </summary>
-        internal static IDisposable ForceGameViewInput()
-        {
-#if UNITY_INPUT_SYSTEM
-            try
-            {
-                return new PlayModeInputScope();
-            }
-            catch
-            {
-                return NullScope.Instance;
-            }
-#else
-            return NullScope.Instance;
-#endif
-        }
-
-        private sealed class NullScope : IDisposable
-        {
-            internal static readonly NullScope Instance = new NullScope();
-            public void Dispose() { }
-        }
-
-#if UNITY_INPUT_SYSTEM
-        private sealed class PlayModeInputScope : IDisposable
-        {
-            private readonly InputSettings.EditorInputBehaviorInPlayMode _previous;
-            private readonly bool _applied;
-
-            internal PlayModeInputScope()
-            {
-                var settings = InputSystem.settings;
-                if (settings == null) { _applied = false; return; }
-                _previous = settings.editorInputBehaviorInPlayMode;
-                settings.editorInputBehaviorInPlayMode = InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView;
-                _applied = true;
-            }
-
-            public void Dispose()
-            {
-                if (!_applied) return;
-                try
-                {
-                    var settings = InputSystem.settings;
-                    if (settings != null) settings.editorInputBehaviorInPlayMode = _previous;
-                }
-                catch { /* best-effort restore */ }
-            }
-        }
-#endif
     }
 }

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationFocusGuard.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationFocusGuard.cs
@@ -1,0 +1,103 @@
+using System;
+using UnityEditor;
+#if UNITY_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace MCPForUnity.Editor.Tools.InputSimulation
+{
+    /// <summary>
+    /// Simulated input only reaches the running game when the Game view is the input
+    /// target. Two independent problems can defeat that:
+    ///   1. The Editor is looking at the Scene view (or another window) instead of the
+    ///      Game view — simulated devices still update, but nothing in the game observes
+    ///      them because the Game view never processes the frame's input.
+    ///   2. The Input System's "Play Mode Input Behavior" setting can route device input
+    ///      away from the Game view depending on focus, so even a technically-successful
+    ///      write may not surface to gameplay code.
+    /// This helper surfaces (1) as a response warning instead of a silent false-positive
+    /// "success", and works around (2) for the duration of a simulated action.
+    /// </summary>
+    internal static class InputSimulationFocusGuard
+    {
+        /// <summary>
+        /// True if the currently focused Editor window is the Game view. Best-effort:
+        /// returns true (no warning) if the check itself fails, since a warning must never
+        /// be fabricated on top of an actual detection error.
+        /// </summary>
+        internal static bool IsGameViewFocused()
+        {
+            try
+            {
+                var focused = EditorWindow.focusedWindow;
+                if (focused == null) return false;
+                var gameViewType = Type.GetType("UnityEditor.GameView,UnityEditor");
+                return gameViewType != null && focused.GetType() == gameViewType;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
+        internal const string FocusWarning =
+            "Game view is not focused — simulated input was sent to the input devices but may not reach " +
+            "the running game. Focus the Game view (or call manage_editor to bring it forward) before " +
+            "relying on this result.";
+
+        /// <summary>
+        /// Forces all device input to the Game view for the lifetime of the returned scope,
+        /// then restores the previous setting. No-op (returns a no-op disposable) when the
+        /// Input System package isn't present or the setting can't be reached.
+        /// </summary>
+        internal static IDisposable ForceGameViewInput()
+        {
+#if UNITY_INPUT_SYSTEM
+            try
+            {
+                return new PlayModeInputScope();
+            }
+            catch
+            {
+                return NullScope.Instance;
+            }
+#else
+            return NullScope.Instance;
+#endif
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            internal static readonly NullScope Instance = new NullScope();
+            public void Dispose() { }
+        }
+
+#if UNITY_INPUT_SYSTEM
+        private sealed class PlayModeInputScope : IDisposable
+        {
+            private readonly InputSettings.EditorInputBehaviorInPlayMode _previous;
+            private readonly bool _applied;
+
+            internal PlayModeInputScope()
+            {
+                var settings = InputSystem.settings;
+                if (settings == null) { _applied = false; return; }
+                _previous = settings.editorInputBehaviorInPlayMode;
+                settings.editorInputBehaviorInPlayMode = InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView;
+                _applied = true;
+            }
+
+            public void Dispose()
+            {
+                if (!_applied) return;
+                try
+                {
+                    var settings = InputSystem.settings;
+                    if (settings != null) settings.editorInputBehaviorInPlayMode = _previous;
+                }
+                catch { /* best-effort restore */ }
+            }
+        }
+#endif
+    }
+}

--- a/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationFocusGuard.cs.meta
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputSimulationFocusGuard.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80798be32ac745059973863d8e9a0d4e

--- a/MCPForUnity/Editor/Tools/ManageInputSimulation.cs
+++ b/MCPForUnity/Editor/Tools/ManageInputSimulation.cs
@@ -40,25 +40,12 @@ namespace MCPForUnity.Editor.Tools
 
             try
             {
-                object result;
-                if (isGameFacingAction)
-                {
-                    // Force all device input to the Game view for the duration of the
-                    // simulated action, then restore whatever the user had configured.
-                    using (InputSimulationFocusGuard.ForceGameViewInput())
-                    {
-                        result = Dispatch(action, p);
-                    }
+                object result = Dispatch(action, p);
 
-                    // A "success" that never reached the game is a false positive — surface
-                    // it as a warning instead of silently reporting plain success.
-                    if (result is SuccessResponse success && !InputSimulationFocusGuard.IsGameViewFocused())
-                        success.Warning = InputSimulationFocusGuard.FocusWarning;
-                }
-                else
-                {
-                    result = Dispatch(action, p);
-                }
+                // A "success" that never reached the game is a false positive — surface
+                // it as a warning instead of silently reporting plain success.
+                if (isGameFacingAction && result is SuccessResponse success && !InputSimulationFocusGuard.IsGameViewFocused())
+                    success.Warning = InputSimulationFocusGuard.FocusWarning;
 
                 return result;
             }

--- a/MCPForUnity/Editor/Tools/ManageInputSimulation.cs
+++ b/MCPForUnity/Editor/Tools/ManageInputSimulation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
 using MCPForUnity.Editor.Tools.InputSimulation;
 using Newtonsoft.Json.Linq;
@@ -14,6 +15,15 @@ namespace MCPForUnity.Editor.Tools
     [McpForUnityTool("manage_input_simulation", AutoRegister = true, Group = "testing")]
     public static class ManageInputSimulation
     {
+        // Actions that inject device state the running game is expected to observe.
+        // Discovery/sequence/status actions don't move a device, so they're exempt.
+        private static readonly HashSet<string> GameFacingActions = new HashSet<string>
+        {
+            "click", "double_click", "mouse_move", "drag", "scroll",
+            "key_press", "key_combo", "text_input",
+            "touch_tap", "touch_swipe", "touch_pinch",
+        };
+
         public static object HandleCommand(JObject @params)
         {
             if (@params == null) return new ErrorResponse("Parameters cannot be null.");
@@ -26,47 +36,70 @@ namespace MCPForUnity.Editor.Tools
             var actionResult = p.GetRequired("action");
             if (!actionResult.IsSuccess) return new ErrorResponse(actionResult.ErrorMessage);
             string action = actionResult.Value.ToLowerInvariant();
+            bool isGameFacingAction = GameFacingActions.Contains(action);
 
             try
             {
-                return action switch
+                object result;
+                if (isGameFacingAction)
                 {
-                    // Discovery (Phase 1)
-                    "discover"           => InputDiscovery.Discover(p),
-                    "get_element_bounds" => InputDiscovery.GetElementBounds(p),
+                    // Force all device input to the Game view for the duration of the
+                    // simulated action, then restore whatever the user had configured.
+                    using (InputSimulationFocusGuard.ForceGameViewInput())
+                    {
+                        result = Dispatch(action, p);
+                    }
 
-                    // Mouse actions (Phase 2)
-                    "click"              => InputSimulationActions.Click(p),
-                    "double_click"       => InputSimulationActions.DoubleClick(p),
-                    "mouse_move"         => InputSimulationActions.MouseMove(p),
-                    "drag"               => InputSimulationActions.Drag(p),
-                    "scroll"             => InputSimulationActions.Scroll(p),
+                    // A "success" that never reached the game is a false positive — surface
+                    // it as a warning instead of silently reporting plain success.
+                    if (result is SuccessResponse success && !InputSimulationFocusGuard.IsGameViewFocused())
+                        success.Warning = InputSimulationFocusGuard.FocusWarning;
+                }
+                else
+                {
+                    result = Dispatch(action, p);
+                }
 
-                    // Keyboard actions (Phase 2)
-                    "key_press"          => InputSimulationActions.KeyPress(p),
-                    "key_combo"          => InputSimulationActions.KeyCombo(p),
-                    "text_input"         => InputSimulationActions.TextInput(p),
-
-                    // Touch actions (Phase 3)
-                    "touch_tap"          => InputSimulationTouch.TouchTap(p),
-                    "touch_swipe"        => InputSimulationTouch.TouchSwipe(p),
-                    "touch_pinch"        => InputSimulationTouch.TouchPinch(p),
-
-                    // Sequence actions (Phase 3)
-                    "sequence"           => InputSimulationSequence.StartSequence(p),
-                    "status"             => InputSimulationSequence.GetStatus(p),
-
-                    _ => new ErrorResponse(
-                        $"Unknown action: '{action}'. Valid actions: discover, get_element_bounds, " +
-                        "click, double_click, mouse_move, drag, scroll, " +
-                        "key_press, key_combo, text_input, " +
-                        "touch_tap, touch_swipe, touch_pinch, sequence, status.")
-                };
+                return result;
             }
             catch (Exception e)
             {
                 return new ErrorResponse($"Internal error during '{action}': {e.Message}");
             }
         }
+
+        private static object Dispatch(string action, ToolParams p) => action switch
+        {
+            // Discovery (Phase 1)
+            "discover"           => InputDiscovery.Discover(p),
+            "get_element_bounds" => InputDiscovery.GetElementBounds(p),
+
+            // Mouse actions (Phase 2)
+            "click"              => InputSimulationActions.Click(p),
+            "double_click"       => InputSimulationActions.DoubleClick(p),
+            "mouse_move"         => InputSimulationActions.MouseMove(p),
+            "drag"               => InputSimulationActions.Drag(p),
+            "scroll"             => InputSimulationActions.Scroll(p),
+
+            // Keyboard actions (Phase 2)
+            "key_press"          => InputSimulationActions.KeyPress(p),
+            "key_combo"          => InputSimulationActions.KeyCombo(p),
+            "text_input"         => InputSimulationActions.TextInput(p),
+
+            // Touch actions (Phase 3)
+            "touch_tap"          => InputSimulationTouch.TouchTap(p),
+            "touch_swipe"        => InputSimulationTouch.TouchSwipe(p),
+            "touch_pinch"        => InputSimulationTouch.TouchPinch(p),
+
+            // Sequence actions (Phase 3)
+            "sequence"           => InputSimulationSequence.StartSequence(p),
+            "status"             => InputSimulationSequence.GetStatus(p),
+
+            _ => new ErrorResponse(
+                $"Unknown action: '{action}'. Valid actions: discover, get_element_bounds, " +
+                "click, double_click, mouse_move, drag, scroll, " +
+                "key_press, key_combo, text_input, " +
+                "touch_tap, touch_swipe, touch_pinch, sequence, status.")
+        };
     }
 }


### PR DESCRIPTION
Fixes #39

## Root cause

`Key` and `Button` controls in the Input System are bitfield-backed (packed
sub-byte state). `InputState.Change(control, value)` only supports
byte-aligned control state and throws:

```
Cannot change state of bitfield control 'Key:/Keyboard/space' using this method
Parameter name: control
```

This made `key_press`, `key_combo`, `click`, `double_click`, and `drag` (all
of which flip a Key/Button control) unusable — 100% failure rate on the
reported symptom.

## Fix

**Symptom 1 (bitfield write crash).** Added `InputSimulationActions.WriteButton`,
which writes the value into a `StateEvent.From(control.device)` buffer via
`control.WriteValueIntoEvent(...)` and queues it with `InputSystem.QueueEvent`.
This is the same low-level pattern Unity's own `OnScreenControl` (on-screen
buttons/keys) uses for exactly this class of control. Replaced every direct
`InputState.Change` call on a `Key`/`Button` control (mouse buttons in
`Click`/`DoubleClick`/`Drag`, keys in `KeyPress`/`KeyCombo`) with it. Mouse
position and scroll (not bitfield-backed) are untouched and still use
`InputState.Change`.

**Symptom 2 (touch executes but doesn't reach the game).** `ManageInputSimulation.HandleCommand`
now:
- Wraps every device-injecting action (click/double_click/mouse_move/drag/scroll/
  key_press/key_combo/text_input/touch_tap/touch_swipe/touch_pinch) in a scope that
  forces `InputSettings.editorInputBehaviorInPlayMode` to
  `AllDeviceInputAlwaysGoesToGameView` for the duration of the call, restoring the
  previous value afterward.
- If the Game view still isn't the focused Editor window when the action completes,
  attaches a `warning` field to the (still-successful) response instead of reporting
  plain, unqualified success. Added `SuccessResponse.Warning` (optional, mutable,
  `NullValueHandling.Ignore`) for this.

New file `InputSimulationFocusGuard.cs` holds the focus check and the
`IDisposable` play-mode-input-behavior scope; it's a no-op scope when the
Input System package isn't present.

## Tests

**Not added.** The EditMode test harness at
`TestProjects/UnityMCPTests/Assets/Tests/EditMode` does not have the Input
System package installed (`com.unity.inputsystem` is absent from
`TestProjects/UnityMCPTests/Packages/manifest.json`), and the test assembly
(`MCPForUnityTests.EditMode.asmdef`) doesn't reference `Unity.InputSystem`.
The `manage_input_simulation` code path is entirely gated behind
`#if UNITY_INPUT_SYSTEM` and is currently untested by this repo's own CI
project. Wiring that up (package manifest change + asmdef reference +
`InputTestFixture`-based test) is a reasonable follow-up but is more than I
could safely do blind — I have no Unity Editor available to verify the
package resolves or the test compiles/passes, and a bad manifest/asmdef edit
could break the existing EditMode suite for everyone. Flagging this
explicitly rather than inventing an unverified harness.

## Honesty note on verification

**I could not compile or run this in the Unity Editor** — no Editor instance
was available in this environment. The fix is by inspection against the
vendored Input System 1.x source (`StateEvent.From` / `WriteValueIntoEvent`
/ `QueueEvent` — confirmed these exact signatures exist in a local
`com.unity.inputsystem` package cache) and against Unity's own
`OnScreenControl.cs`, which uses the identical pattern for the identical
problem (writing to a bitfield-backed on-screen button/key). I'm confident in
the approach but this PR should get a real Play Mode smoke test
(`key_press`, `click`, `drag`) before merging.