### PR TITLE
fix(run_tests): reject a test filter that matched 0 tests instead of reporting Passed

### DIFF
--- a/MCPForUnity/Editor/Services/TestJobManager.cs
+++ b/MCPForUnity/Editor/Services/TestJobManager.cs
@@ -31,6 +31,10 @@ namespace MCPForUnity.Editor.Services
         public long StartedUnixMs { get; set; }
         public long? FinishedUnixMs { get; set; }
         public long LastUpdateUnixMs { get; set; }
+        // True when the job was started with a test_names/group_names/category_names/assembly_names
+        // filter. Combined with TotalTests == 0, this distinguishes "filter matched nothing" (a caller
+        // bug) from "project genuinely has zero tests" (TotalTests == 0 with FilterRequested == false).
+        public bool FilterRequested { get; set; }
         public int? TotalTests { get; set; }
         public int CompletedTests { get; set; }
         public string CurrentTestFullName { get; set; }
@@ -133,6 +137,7 @@ namespace MCPForUnity.Editor.Services
             public long started_unix_ms { get; set; }
             public long? finished_unix_ms { get; set; }
             public long last_update_unix_ms { get; set; }
+            public bool filter_requested { get; set; }
             public int? total_tests { get; set; }
             public int completed_tests { get; set; }
             public string current_test_full_name { get; set; }
@@ -196,6 +201,7 @@ namespace MCPForUnity.Editor.Services
                             StartedUnixMs = pj.started_unix_ms,
                             FinishedUnixMs = pj.finished_unix_ms,
                             LastUpdateUnixMs = pj.last_update_unix_ms,
+                            FilterRequested = pj.filter_requested,
                             TotalTests = pj.total_tests,
                             CompletedTests = pj.completed_tests,
                             CurrentTestFullName = pj.current_test_full_name,
@@ -270,6 +276,7 @@ namespace MCPForUnity.Editor.Services
                             started_unix_ms = j.StartedUnixMs,
                             finished_unix_ms = j.FinishedUnixMs,
                             last_update_unix_ms = j.LastUpdateUnixMs,
+                            filter_requested = j.FilterRequested,
                             total_tests = j.TotalTests,
                             completed_tests = j.CompletedTests,
                             current_test_full_name = j.CurrentTestFullName,
@@ -299,6 +306,19 @@ namespace MCPForUnity.Editor.Services
             }
         }
 
+        private static bool HasFilter(TestFilterOptions filterOptions)
+        {
+            if (filterOptions == null)
+            {
+                return false;
+            }
+
+            return (filterOptions.TestNames != null && filterOptions.TestNames.Length > 0)
+                || (filterOptions.GroupNames != null && filterOptions.GroupNames.Length > 0)
+                || (filterOptions.CategoryNames != null && filterOptions.CategoryNames.Length > 0)
+                || (filterOptions.AssemblyNames != null && filterOptions.AssemblyNames.Length > 0);
+        }
+
         public static string StartJob(TestMode mode, TestFilterOptions filterOptions = null, long initTimeoutMs = 0)
         {
             // Clamp to valid range: non-positive values mean "use default", cap at 10 minutes
@@ -317,6 +337,7 @@ namespace MCPForUnity.Editor.Services
                 StartedUnixMs = started,
                 FinishedUnixMs = null,
                 LastUpdateUnixMs = started,
+                FilterRequested = HasFilter(filterOptions),
                 TotalTests = null,
                 CompletedTests = 0,
                 CurrentTestFullName = null,
@@ -552,6 +573,11 @@ namespace MCPForUnity.Editor.Services
                 started_unix_ms = job.StartedUnixMs,
                 finished_unix_ms = job.FinishedUnixMs,
                 last_update_unix_ms = job.LastUpdateUnixMs,
+                // Lets callers detect "filter matched nothing" without re-deriving it from progress.total:
+                // a job started with a test_names/group_names/category_names/assembly_names filter whose
+                // discovered_tests is 0 ran nothing, even though NUnit reports that as a "Passed" result.
+                filter_requested = job.FilterRequested,
+                discovered_tests = job.TotalTests,
                 progress = new
                 {
                     completed = job.CompletedTests,

--- a/Server/src/services/tools/run_tests.py
+++ b/Server/src/services/tools/run_tests.py
@@ -134,6 +134,10 @@ class GetTestJobData(BaseModel):
     started_unix_ms: int | None = None
     finished_unix_ms: int | None = None
     last_update_unix_ms: int | None = None
+    # True when run_tests was called with a test_names/group_names/category_names/assembly_names filter.
+    filter_requested: bool | None = None
+    # Number of tests Unity's Test Runner actually discovered/selected for this run (post-filter).
+    discovered_tests: int | None = None
     progress: TestJobProgress | None = None
     error: str | None = None
     result: RunTestsResult | None = None
@@ -141,6 +145,46 @@ class GetTestJobData(BaseModel):
 
 class GetTestJobResponse(MCPResponse):
     data: GetTestJobData | None = None
+
+
+def _reject_zero_match_filter(response: dict[str, Any]) -> dict[str, Any]:
+    """Turn a "Passed" result with 0 discovered tests into an explicit error.
+
+    A test_names/group_names/category_names/assembly_names filter that matches no
+    tests still reports resultState "Passed" (NUnit has nothing to fail). Silently
+    returning that as success hides a caller bug (typo'd test name, stale filter) --
+    see #37. Only rewrite terminal jobs that were actually filtered; a genuinely
+    empty EditMode/PlayMode suite run without a filter is left alone.
+    """
+    if not isinstance(response, dict) or not response.get("success", True):
+        return response
+
+    data = response.get("data")
+    if not isinstance(data, dict):
+        return response
+
+    if data.get("status") not in ("succeeded", "failed"):
+        return response
+
+    if not data.get("filter_requested"):
+        return response
+
+    if (data.get("discovered_tests") or 0) != 0:
+        return response
+
+    summary = ((data.get("result") or {}).get("summary")) or {}
+    if summary.get("total", 0) != 0:
+        return response
+
+    return {
+        "success": False,
+        "error": (
+            "Test filter matched 0 tests. test_names/group_names/category_names/"
+            "assembly_names did not match any test Unity discovered for this run -- "
+            "check for typos or a stale filter."
+        ),
+        "data": data,
+    }
 
 
 @mcp_for_unity_tool(
@@ -278,6 +322,9 @@ async def get_test_job(
             data = response.get("data", {})
             status = data.get("status", "")
             if status in ("succeeded", "failed", "cancelled"):
+                response = _reject_zero_match_filter(response)
+                if not response.get("success", True):
+                    return MCPResponse(**response)
                 return GetTestJobResponse(**response)
 
             # Detect progress and reset exponential backoff
@@ -350,4 +397,7 @@ async def get_test_job(
             _background_tasks.add(task)
             task.add_done_callback(_background_tasks.discard)
 
+    response = _reject_zero_match_filter(response)
+    if not response.get("success", True):
+        return MCPResponse(**response)
     return GetTestJobResponse(**response)

--- a/Server/tests/integration/test_run_tests_async.py
+++ b/Server/tests/integration/test_run_tests_async.py
@@ -114,3 +114,105 @@ async def test_get_test_job_forwards_job_id(monkeypatch):
     assert resp.success is True
     assert resp.data is not None
     assert resp.data.job_id == "job-1"
+
+
+def _zero_match_job_response(status="succeeded"):
+    return {
+        "success": True,
+        "data": {
+            "job_id": "job-zero",
+            "status": status,
+            "mode": "EditMode",
+            "filter_requested": True,
+            "discovered_tests": 0,
+            "progress": {"completed": 0, "total": 0},
+            "result": {
+                "mode": "EditMode",
+                "summary": {
+                    "total": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "durationSeconds": 0.01,
+                    "resultState": "Passed",
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_test_job_rejects_zero_match_filter(monkeypatch):
+    """#37: a test_names/group_names/... filter that matches nothing must not report Passed."""
+    from services.tools.run_tests import get_test_job
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return _zero_match_job_response()
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await get_test_job(DummyContext(), job_id="job-zero")
+    assert resp.success is False
+    assert "0 tests" in resp.error
+    assert resp.data["discovered_tests"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_test_job_rejects_zero_match_filter_via_wait_timeout(monkeypatch):
+    """Same guard applies on the server-side polling path (wait_timeout)."""
+    from services.tools.run_tests import get_test_job
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return _zero_match_job_response()
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await get_test_job(DummyContext(), job_id="job-zero", wait_timeout=5)
+    assert resp.success is False
+    assert "0 tests" in resp.error
+
+
+@pytest.mark.asyncio
+async def test_get_test_job_allows_zero_match_when_no_filter_requested(monkeypatch):
+    """A genuinely empty suite (no filter applied) must still report success normally."""
+    from services.tools.run_tests import get_test_job
+
+    payload = _zero_match_job_response()
+    payload["data"]["filter_requested"] = False
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return payload
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await get_test_job(DummyContext(), job_id="job-zero")
+    assert resp.success is True
+    assert resp.data.discovered_tests == 0
+
+
+@pytest.mark.asyncio
+async def test_get_test_job_allows_filter_with_matched_tests(monkeypatch):
+    """A filter that matched real tests must not be affected by the zero-match guard."""
+    from services.tools.run_tests import get_test_job
+
+    payload = _zero_match_job_response()
+    payload["data"]["discovered_tests"] = 3
+    payload["data"]["result"]["summary"]["total"] = 3
+    payload["data"]["result"]["summary"]["passed"] = 3
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return payload
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await get_test_job(DummyContext(), job_id="job-zero")
+    assert resp.success is True
+    assert resp.data.discovered_tests == 3


### PR DESCRIPTION
## Summary

`run_tests`/`get_test_job` reported `resultState: "Passed"` (with `total: 0`) whenever a `test_names`/`group_names`/`category_names`/`assembly_names` filter matched no tests -- NUnit has nothing to fail, so a typo'd or stale filter silently looked green. A silently-green suite is worse than a red one.

Repro path: `Server/src/services/tools/run_tests.py:75-80` built `RunTestsSummary` with no cross-check between `total == 0` and `resultState`. `RunTests.cs:79-91` forwarded the filter to `TestJobManager.StartJob` without recording whether a filter was even applied, and `TestJobManager.cs:547-571` returned `progress.total` from Test Runner's discovery with nothing distinguishing "filter matched nothing" from "project genuinely has zero tests."

## Changes

- `MCPForUnity/Editor/Services/TestJobManager.cs`: `TestJob` now tracks `FilterRequested` (set in `StartJob` from whether any filter list is non-empty, persisted across domain reloads via `PersistedJob`). `ToSerializable` exposes `filter_requested` and `discovered_tests` (`job.TotalTests`) at the top level of the job payload.
- `Server/src/services/tools/run_tests.py`: `GetTestJobData` gains `filter_requested`/`discovered_tests`. New `_reject_zero_match_filter` guard rewrites a terminal (`succeeded`/`failed`) job response into an explicit `success: False` error when a filter was requested and both `discovered_tests` and the final `summary.total` are 0. Applied at both `get_test_job` return sites (server-side `wait_timeout` poll loop and the immediate no-wait path). A genuinely empty, *unfiltered* suite is left untouched.
- `Server/tests/integration/test_run_tests_async.py`: 4 new tests -- zero-match rejected (immediate path), zero-match rejected (`wait_timeout` poll path), unfiltered zero-match left as success, filtered-with-matches left as success.

## Verification

```
cd Server && PYTHONPATH="$PWD:$PWD/src" uv run --with pytest --with pytest-asyncio pytest tests/ -q
```

Before: `12 failed, 1513 passed` (pre-existing drift in `test_manage_physics.py`/`test_manage_profiler.py`, unrelated to this change -- also failing on `beta`).
After: `12 failed, 1517 passed` -- same 12 pre-existing failures, 4 new tests pass.

The C# side (`TestJobManager.cs`) is **unverified against a live Unity Editor** -- I could not run Unity in this environment. The change is additive (one new bool field + two new payload keys) and mirrors existing patterns in the same file (`PersistedJob` round-trip, `ToSerializable` top-level fields), but please give it a real test run before merge.

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jjTpvdtG5uceDtNQQVwba