### PR TITLE
fix(manage_asset): wait across editor ticks for generate_preview instead of giving up immediately

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageAsset.cs
+++ b/MCPForUnity/Editor/Tools/ManageAsset.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -44,7 +45,7 @@ namespace MCPForUnity.Editor.Tools
             "get_components",
         };
 
-        public static object HandleCommand(JObject @params)
+        public static async Task<object> HandleCommand(JObject @params)
         {
             string action = @params["action"]?.ToString()?.ToLowerInvariant();
             if (string.IsNullOrEmpty(action))
@@ -99,12 +100,12 @@ namespace MCPForUnity.Editor.Tools
                     case "rename":
                         return MoveOrRenameAsset(path, @params["destination"]?.ToString());
                     case "search":
-                        return SearchAssets(@params);
+                        return await SearchAssets(@params).ConfigureAwait(true);
                     case "get_info":
-                        return GetAssetInfo(
+                        return await GetAssetInfo(
                             path,
                             @params["generatePreview"]?.ToObject<bool>() ?? false
-                        );
+                        ).ConfigureAwait(true);
                     case "create_folder": // Added specific action for clarity
                         return CreateFolder(path);
                     case "get_components":
@@ -625,7 +626,7 @@ namespace MCPForUnity.Editor.Tools
             }
         }
 
-        private static object SearchAssets(JObject @params)
+        private static async Task<object> SearchAssets(JObject @params)
         {
             string searchPattern = @params["searchPattern"]?.ToString();
             string filterType = @params["filterType"]?.ToString();
@@ -706,7 +707,9 @@ namespace MCPForUnity.Editor.Tools
                     }
 
                     totalFound++; // Count matching assets before pagination
-                    results.Add(GetAssetData(assetPath, generatePreview));
+                    results.Add(generatePreview
+                        ? await GetAssetDataAsync(assetPath).ConfigureAwait(true)
+                        : GetAssetData(assetPath));
                 }
 
                 // Apply pagination
@@ -730,7 +733,7 @@ namespace MCPForUnity.Editor.Tools
             }
         }
 
-        private static object GetAssetInfo(string path, bool generatePreview)
+        private static async Task<object> GetAssetInfo(string path, bool generatePreview)
         {
             if (string.IsNullOrEmpty(path))
                 return new ErrorResponse("'path' is required for get_info.");
@@ -740,10 +743,10 @@ namespace MCPForUnity.Editor.Tools
 
             try
             {
-                return new SuccessResponse(
-                    "Asset info retrieved.",
-                    GetAssetData(fullPath, generatePreview)
-                );
+                object data = generatePreview
+                    ? await GetAssetDataAsync(fullPath).ConfigureAwait(true)
+                    : GetAssetData(fullPath);
+                return new SuccessResponse("Asset info retrieved.", data);
             }
             catch (Exception e)
             {
@@ -1028,24 +1031,44 @@ namespace MCPForUnity.Editor.Tools
 
         // --- Data Serialization ---
 
+        // Bounded wait for AssetPreview.GetAssetPreview to finish an in-flight generation (#36).
+        // Unity's own Asset Store Tools package (TestProjects/AssetStoreUploads/.../NativePreviewGenerator.cs)
+        // uses the same technique -- yielding across real EditorApplication.update ticks -- because preview
+        // generation for non-trivial types (prefabs/models) is driven by that same update loop and never
+        // advances while this call stack blocks it (e.g. via Thread.Sleep).
+        private const double PreviewLoadTimeoutSeconds = 3.0;
+
         /// <summary>
-        /// Creates a serializable representation of an asset.
+        /// Creates a serializable representation of an asset (no preview).
         /// </summary>
-        private static object GetAssetData(string path, bool generatePreview = false)
+        private static object GetAssetData(string path)
         {
             if (string.IsNullOrEmpty(path) || !AssetExists(path))
                 return null;
 
-            string guid = AssetDatabase.AssetPathToGUID(path);
+            UnityEngine.Object asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path);
+            return BuildAssetDataRecord(path, asset, previewBase64: null, previewWidth: 0, previewHeight: 0);
+        }
+
+        /// <summary>
+        /// Creates a serializable representation of an asset, including a generated preview thumbnail.
+        /// Waits up to <see cref="PreviewLoadTimeoutSeconds"/> across editor ticks for Unity to finish
+        /// generating the preview before giving up.
+        /// </summary>
+        private static async Task<object> GetAssetDataAsync(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !AssetExists(path))
+                return null;
+
             Type assetType = AssetDatabase.GetMainAssetTypeAtPath(path);
             UnityEngine.Object asset = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path);
             string previewBase64 = null;
             int previewWidth = 0;
             int previewHeight = 0;
 
-            if (generatePreview && asset != null)
+            if (asset != null)
             {
-                Texture2D preview = AssetPreview.GetAssetPreview(asset);
+                var (preview, timedOut) = await WaitForAssetPreviewAsync(asset).ConfigureAwait(true);
 
                 if (preview != null)
                 {
@@ -1089,6 +1112,12 @@ namespace MCPForUnity.Editor.Tools
                         // Texture2D staticPreview = AssetPreview.GetMiniThumbnail(asset);
                     }
                 }
+                else if (timedOut)
+                {
+                    McpLog.Warn(
+                        $"Timed out after {PreviewLoadTimeoutSeconds:0.#}s waiting for asset preview for {path} (Type: {assetType?.Name}). Unity may still be generating it; retry get_info/search with generatePreview later."
+                    );
+                }
                 else
                 {
                     McpLog.Warn(
@@ -1096,6 +1125,68 @@ namespace MCPForUnity.Editor.Tools
                     );
                 }
             }
+
+            return BuildAssetDataRecord(path, asset, previewBase64, previewWidth, previewHeight);
+        }
+
+        /// <summary>
+        /// Polls <see cref="AssetPreview.GetAssetPreview"/> across editor ticks until a texture is
+        /// produced, Unity reports it is no longer loading one, or <see cref="PreviewLoadTimeoutSeconds"/>
+        /// elapses. Returns the last-seen preview (possibly null) and whether the wait timed out while
+        /// Unity was still reporting the preview as loading.
+        /// </summary>
+        private static async Task<(Texture2D preview, bool timedOut)> WaitForAssetPreviewAsync(UnityEngine.Object asset)
+        {
+            Texture2D preview = AssetPreview.GetAssetPreview(asset);
+            if (preview != null)
+            {
+                return (preview, false);
+            }
+
+            int instanceId = asset.GetInstanceIDCompat();
+            DateTime deadline = DateTime.UtcNow.AddSeconds(PreviewLoadTimeoutSeconds);
+
+            while (AssetPreview.IsLoadingAssetPreview(instanceId))
+            {
+                if (DateTime.UtcNow >= deadline)
+                {
+                    return (AssetPreview.GetAssetPreview(asset), true);
+                }
+
+                await WaitForNextEditorTickAsync().ConfigureAwait(true);
+
+                preview = AssetPreview.GetAssetPreview(asset);
+                if (preview != null)
+                {
+                    return (preview, false);
+                }
+            }
+
+            // Not (or no longer) loading, yet no preview was ever produced: unsupported type or a
+            // failed generation, not a timeout.
+            return (AssetPreview.GetAssetPreview(asset), false);
+        }
+
+        private static Task WaitForNextEditorTickAsync()
+        {
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            void Tick()
+            {
+                EditorApplication.update -= Tick;
+                tcs.TrySetResult(true);
+            }
+
+            EditorApplication.update += Tick;
+            // Nudge Unity to pump once in case update is throttled (mirrors RefreshUnity.cs).
+            try { EditorApplication.QueuePlayerLoopUpdate(); } catch { }
+            return tcs.Task;
+        }
+
+        private static object BuildAssetDataRecord(string path, UnityEngine.Object asset, string previewBase64, int previewWidth, int previewHeight)
+        {
+            string guid = AssetDatabase.AssetPathToGUID(path);
+            Type assetType = AssetDatabase.GetMainAssetTypeAtPath(path);
 
             return new
             {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/MCPToolParameterTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/MCPToolParameterTests.cs
@@ -85,7 +85,7 @@ namespace MCPForUnityTests.Editor.Tools
                 ["assetType"] = "Material",
                 ["properties"] = new JObject { ["shader"] = "Universal Render Pipeline/Lit", ["color"] = new JArray(0, 0, 1, 1) }
             };
-            var createMatRes = ManageAsset.HandleCommand(createMat);
+            var createMatRes = ManageAsset.HandleCommand(createMat).GetAwaiter().GetResult();
             var createMatObj = createMatRes as JObject ?? JObject.FromObject(createMatRes);
             Assert.IsTrue(createMatObj.Value<bool>("success"), createMatObj.ToString());
 
@@ -186,7 +186,7 @@ namespace MCPForUnityTests.Editor.Tools
                     ["assetType"] = "Material",
                     ["properties"] = "{\"shader\":\"Universal Render Pipeline/Lit\",\"color\":[1,0,0,1]}"
                 };
-                var createRaw = ManageAsset.HandleCommand(createParams);
+                var createRaw = ManageAsset.HandleCommand(createParams).GetAwaiter().GetResult();
                 var createResult = createRaw as JObject ?? JObject.FromObject(createRaw);
                 Assert.IsTrue(createResult.Value<bool>("success"), $"Test 1 failed: {createResult}");
                 var mat = AssetDatabase.LoadAssetAtPath<Material>(matPath);
@@ -205,7 +205,7 @@ namespace MCPForUnityTests.Editor.Tools
                     ["path"] = matPath,
                     ["properties"] = "{\"color\":[0,0.5,1,1],\"metallic\":0.6}"
                 };
-                var modifyRaw1 = ManageAsset.HandleCommand(modify1);
+                var modifyRaw1 = ManageAsset.HandleCommand(modify1).GetAwaiter().GetResult();
                 var modifyResult1 = modifyRaw1 as JObject ?? JObject.FromObject(modifyRaw1);
                 Assert.IsTrue(modifyResult1.Value<bool>("success"), $"Test 2 failed: {modifyResult1}");
                 mat = AssetDatabase.LoadAssetAtPath<Material>(matPath);
@@ -226,7 +226,7 @@ namespace MCPForUnityTests.Editor.Tools
                         ["float"] = new JObject { ["name"] = "_Metallic", ["value"] = 0.1 }
                     }
                 };
-                var modifyRaw2 = ManageAsset.HandleCommand(modify2);
+                var modifyRaw2 = ManageAsset.HandleCommand(modify2).GetAwaiter().GetResult();
                 var modifyResult2 = modifyRaw2 as JObject ?? JObject.FromObject(modifyRaw2);
                 Assert.IsTrue(modifyResult2.Value<bool>("success"), $"Test 3 failed: {modifyResult2}");
                 mat = AssetDatabase.LoadAssetAtPath<Material>(matPath);
@@ -239,7 +239,7 @@ namespace MCPForUnityTests.Editor.Tools
                     ["path"] = matPath,
                     ["properties"] = "{\"_BaseMap\":\"" + texPath + "\"}"
                 };
-                var modifyRaw3 = ManageAsset.HandleCommand(modify3);
+                var modifyRaw3 = ManageAsset.HandleCommand(modify3).GetAwaiter().GetResult();
                 var modifyResult3 = modifyRaw3 as JObject ?? JObject.FromObject(modifyRaw3);
                 Assert.IsTrue(modifyResult3.Value<bool>("success"), $"Test 4 failed: {modifyResult3}");
 
@@ -253,7 +253,7 @@ namespace MCPForUnityTests.Editor.Tools
                         ["texture"] = new JObject { ["name"] = "_MainTex", ["path"] = texPath }
                     }
                 };
-                var modifyRaw4 = ManageAsset.HandleCommand(modify4);
+                var modifyRaw4 = ManageAsset.HandleCommand(modify4).GetAwaiter().GetResult();
                 var modifyResult4 = modifyRaw4 as JObject ?? JObject.FromObject(modifyRaw4);
                 Assert.IsTrue(modifyResult4.Value<bool>("success"), $"Test 5 failed: {modifyResult4}");
 
@@ -293,7 +293,7 @@ namespace MCPForUnityTests.Editor.Tools
                         ["_BaseColor"] = new JArray(0.2, 0.8, 0.3, 1)
                     }
                 };
-                var modifyRaw5 = ManageAsset.HandleCommand(modify5);
+                var modifyRaw5 = ManageAsset.HandleCommand(modify5).GetAwaiter().GetResult();
                 var modifyResult5 = modifyRaw5 as JObject ?? JObject.FromObject(modifyRaw5);
                 Assert.IsTrue(modifyResult5.Value<bool>("success"), $"Test 7 failed: {modifyResult5}");
                 mat = AssetDatabase.LoadAssetAtPath<Material>(matPath);
@@ -312,7 +312,7 @@ namespace MCPForUnityTests.Editor.Tools
                     ["properties"] = "{\"invalid\": json, \"missing\": quotes}"
                 };
                 LogAssert.Expect(LogType.Warning, new Regex("(failed to parse)|(Could not parse 'properties' JSON string)", RegexOptions.IgnoreCase));
-                var invalidRaw = ManageAsset.HandleCommand(invalidJson);
+                var invalidRaw = ManageAsset.HandleCommand(invalidJson).GetAwaiter().GetResult();
                 var invalidResult = invalidRaw as JObject ?? JObject.FromObject(invalidRaw);
                 Assert.IsNotNull(invalidResult, "Test 8: Should return a result");
 
@@ -323,7 +323,7 @@ namespace MCPForUnityTests.Editor.Tools
                     ["path"] = matPath,
                     ["properties"] = "{\"shader\":\"Standard\",\"color\":[1,1,0,1]}"
                 };
-                var modifyRaw6 = ManageAsset.HandleCommand(modify6);
+                var modifyRaw6 = ManageAsset.HandleCommand(modify6).GetAwaiter().GetResult();
                 var modifyResult6 = modifyRaw6 as JObject ?? JObject.FromObject(modifyRaw6);
                 Assert.IsTrue(modifyResult6.Value<bool>("success"), $"Test 9 failed: {modifyResult6}");
                 mat = AssetDatabase.LoadAssetAtPath<Material>(matPath);
@@ -345,7 +345,7 @@ namespace MCPForUnityTests.Editor.Tools
                         ["albedo"] = texPath
                     }
                 };
-                var modifyRaw7 = ManageAsset.HandleCommand(modify7);
+                var modifyRaw7 = ManageAsset.HandleCommand(modify7).GetAwaiter().GetResult();
                 var modifyResult7 = modifyRaw7 as JObject ?? JObject.FromObject(modifyRaw7);
                 Assert.IsTrue(modifyResult7.Value<bool>("success"), $"Test 10 failed: {modifyResult7}");
                 mat = AssetDatabase.LoadAssetAtPath<Material>(matPath);

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/MaterialDirectPropertiesTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/MaterialDirectPropertiesTests.cs
@@ -113,7 +113,7 @@ namespace MCPForUnityTests.Editor.Tools
                     ["_Glossiness"] = 0.25f
                 }
             };
-            var createRes = ToJObject(ManageAsset.HandleCommand(createParams));
+            var createRes = ToJObject(ManageAsset.HandleCommand(createParams).GetAwaiter().GetResult());
             Assert.IsTrue(createRes.Value<bool>("success"), createRes.ToString());
 
             // Modify with aliases and textures
@@ -130,7 +130,7 @@ namespace MCPForUnityTests.Editor.Tools
                     ["_OcclusionMap"] = _occlusionMapPath
                 }
             };
-            var modifyRes = ToJObject(ManageAsset.HandleCommand(modifyParams));
+            var modifyRes = ToJObject(ManageAsset.HandleCommand(modifyParams).GetAwaiter().GetResult());
             Assert.IsTrue(modifyRes.Value<bool>("success"), modifyRes.ToString());
 
             var mat = AssetDatabase.LoadAssetAtPath<Material>(_matPath);

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/MaterialParameterToolTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/MaterialParameterToolTests.cs
@@ -91,7 +91,7 @@ namespace MCPForUnityTests.Editor.Tools
                 }
             };
 
-            var result = ToJObject(ManageAsset.HandleCommand(createParams));
+            var result = ToJObject(ManageAsset.HandleCommand(createParams).GetAwaiter().GetResult());
             Assert.IsTrue(result.Value<bool>("success"), result.Value<string>("error"));
 
             var mat = AssetDatabase.LoadAssetAtPath<Material>(_matPath);


### PR DESCRIPTION
## Summary

`manage_asset get_info`/`search` with `generatePreview=true` intermittently returned `previewBase64: null` (#36, "Shape 2" of the reported bug) because `GetAssetData` called `AssetPreview.GetAssetPreview(asset)` exactly once at `ManageAsset.cs:1048` with no `AssetPreview.IsLoadingAssetPreview` check and no retry. For non-trivial asset types (prefabs, models) Unity's `AssetPreview` API kicks off asynchronous generation and returns `null` on the first call by design -- callers are expected to poll until it resolves.

I confirmed this is the correct fix shape by finding Unity's own Asset Store Tools package vendored in this repo (`TestProjects/AssetStoreUploads/Packages/com.unity.asset-store-tools/Editor/Previews/Scripts/Generators/NativePreviewGenerator.cs`), which does exactly this: polls `AssetPreview.IsLoadingAssetPreview` while yielding across real `EditorApplication.update` ticks (`WaitForEndOfFrame`, using `Task.Yield()` + an `update` callback). A blocking `Thread.Sleep` retry loop would **not** work here -- preview generation for non-trivial types is itself driven by the `EditorApplication.update` loop, which can't advance while the calling thread is blocked on it.

## Changes

- `MCPForUnity/Editor/Tools/ManageAsset.cs`:
  - `GetAssetData(path)` stays fully synchronous (no preview) -- used by all 8 existing non-preview call sites, unchanged behavior.
  - New `GetAssetDataAsync(path)` (used only by `get_info`/`search` when `generatePreview=true`) awaits `WaitForAssetPreviewAsync`, which polls `IsLoadingAssetPreview` across real editor ticks for up to 3s, re-querying `GetAssetPreview` each tick.
  - `WaitForNextEditorTickAsync` mirrors the established `TaskCompletionSource` + `EditorApplication.update` pattern already used in `RefreshUnity.cs`.
  - The warning log now distinguishes "timed out while still loading" from "unsupported/failed" (previously a single generic message).
  - `HandleCommand` becomes `async Task<object>` -- `CommandRegistry` auto-detects and dispatches `Task`-returning handlers via reflection (same mechanism `RefreshUnity.cs` already relies on); only the `search`/`get_info` switch cases actually `await`, every other action still returns synchronously inside the async method.
  - Extracted the common asset-record-shape construction into `BuildAssetDataRecord` (used by both the sync and async paths) rather than duplicating it.
- `TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/{MCPToolParameterTests,MaterialDirectPropertiesTests,MaterialParameterToolTests}.cs`: updated the 14 direct `ManageAsset.HandleCommand(...)` call sites for the new `Task<object>` return type via `.GetAwaiter().GetResult()`. None of these tests exercise `search`/`get_info`+`generatePreview` (verified by grep), so the awaited `Task` is always already-completed when `HandleCommand` returns along their code paths -- no deadlock risk from blocking synchronously on it.

## Scope

**Does NOT address Shape 1** (corrupted PNG data -- a non-null but invalid `previewBase64`). That needs a live editor plus a disk-hash comparison to isolate whether the RT-format-under-linear/URP layer or the base64 transport layer is at fault, which I can't do without a running Unity Editor. Left open.

## Verification

I do not have a live Unity Editor in this environment, so **the C# change is unverified against a real Editor** -- please give it a real test run (`get_info`/`search` with `generatePreview=true` against a prefab whose preview isn't yet cached) before merging. What I could verify:

- Read-through of the new async control flow against `RefreshUnity.cs`'s existing, working async pattern in this same file tree.
- Confirmed via `CommandRegistry.cs` (`typeof(Task).IsAssignableFrom(method.ReturnType)`) that `Task<object> HandleCommand` is the documented, reflection-detected async dispatch path.
- Confirmed (grep) the only 3 EditMode test files that call `ManageAsset.HandleCommand` directly, and that none of them touch `generatePreview`/`search`, before mechanically updating their call sites for the new signature.
- Python suite is unaffected by this change (pure C#): `cd Server && PYTHONPATH="$PWD:$PWD/src" uv run --with pytest --with pytest-asyncio pytest tests/ -q` -> `12 failed, 1513 passed`, same pre-existing failures as `beta` (`test_manage_physics.py`/`test_manage_profiler.py`, unrelated).

Partially addresses #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016jjTpvdtG5uceDtNQQVwba