### PR TITLE
fix(manage_asset): route AssetPreview.IsLoadingAssetPreview through EntityId compat shim

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageAsset.cs
+++ b/MCPForUnity/Editor/Tools/ManageAsset.cs
@@ -1143,10 +1143,9 @@ namespace MCPForUnity.Editor.Tools
                 return (preview, false);
             }
 
-            int instanceId = asset.GetInstanceIDCompat();
             DateTime deadline = DateTime.UtcNow.AddSeconds(PreviewLoadTimeoutSeconds);
 
-            while (AssetPreview.IsLoadingAssetPreview(instanceId))
+            while (asset.IsLoadingAssetPreviewCompat())
             {
                 if (DateTime.UtcNow >= deadline)
                 {

--- a/MCPForUnity/Runtime/Helpers/UnityCompatShims.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityCompatShims.cs
@@ -9,7 +9,8 @@ namespace MCPForUnity.Runtime.Helpers
     ///
     /// Active shims (deprecated_since → removed_in):
     ///   • <see cref="UnityFindObjectsCompat"/> — Object.FindObjectsOfType → FindObjectsByType (2023.1)
-    ///   • <see cref="UnityObjectIdCompat"/>    — InstanceID ↔ EntityId (6000.3 → 6000.6 CS0619)
+    ///   • <see cref="UnityObjectIdCompat"/>    — InstanceID ↔ EntityId, incl. AssetPreview.IsLoadingAssetPreview
+    ///                                            (6000.3 → 6000.6 CS0619)
     ///   • <see cref="UnityPhysicsCompat"/>     — Physics{,2D}.autoSyncTransforms (6000.0),
     ///                                            Physics{,2D}.autoSimulation → simulationMode (2022.2)
     ///   • <see cref="UnityAssembliesCompat"/>  — AppDomain.GetAssemblies →

--- a/MCPForUnity/Runtime/Helpers/UnityObjectIdCompat.cs
+++ b/MCPForUnity/Runtime/Helpers/UnityObjectIdCompat.cs
@@ -70,6 +70,28 @@ namespace MCPForUnity.Runtime.Helpers
             return EditorUtility.InstanceIDToObject(instanceId);
 #endif
         }
+
+        /// <summary>
+        /// Returns whether Unity is still generating an asset preview for <paramref name="obj"/>.
+        ///   Pre-6.5 : AssetPreview.IsLoadingAssetPreview(int)
+        ///   6.5+    : AssetPreview.IsLoadingAssetPreview(EntityId) — the int overload is
+        ///             obsolete-as-error (CS0619) as of 6000.5.
+        /// Takes the Object directly (rather than a previously-computed int handle) to avoid
+        /// routing through the lossy int truncation in <see cref="GetInstanceIDCompat"/>.
+        /// </summary>
+        public static bool IsLoadingAssetPreviewCompat(this Object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+#if UNITY_6000_5_OR_NEWER
+            return AssetPreview.IsLoadingAssetPreview(obj.GetEntityId());
+#else
+            return AssetPreview.IsLoadingAssetPreview(obj.GetInstanceID());
+#endif
+        }
 #endif
     }
 }


### PR DESCRIPTION
## Summary
- `AssetPreview.IsLoadingAssetPreview(int)` is obsolete-as-error (`CS0619`) on Unity 6000.5+; the non-obsolete overload takes an `EntityId`. Commit 42794329 (#60) added the `WaitForAssetPreviewAsync` editor-tick polling loop without routing the call through the existing InstanceID↔EntityId compat-shim family, breaking the 6000.5 compile for any consumer.
- Adds `IsLoadingAssetPreviewCompat` to `UnityObjectIdCompat.cs`, following the file's established pattern (`UNITY_6000_5_OR_NEWER` static dispatch, Editor-only, extension method on `UnityEngine.Object`). Takes the `Object` directly rather than a previously-computed `int` handle, avoiding the lossy int-truncation that `GetInstanceIDCompat`'s own docs warn about.
- Updates the shim catalog comment in `UnityCompatShims.cs`.

## Test plan
- [x] Cleared Unity console, forced a recompile (`refresh_unity(force, all, compile=request)`) on Unity 6000.5.6f1 — zero `CS0619` (or any other CS/BC/EA/DC) errors; console shows only pre-existing, unrelated third-party editor-load noise.
- [x] Cross-checked `Logs/Editor.log`: the `CS0619` at `ManageAsset.cs(1149,20)` recorded before this fix does not recur in any compile after it.
- [x] Confirmed no other call site in the pulled-in commit range hits a newly-obsolete Unity 6.5 API — a full assembly compile surfaces every error in the assembly in one pass, and this compile is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)