### PR TITLE
fix(render-pipeline): guard Volume API behind UNITY_RENDER_PIPELINES_CORE

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageRenderPipeline.cs
+++ b/MCPForUnity/Editor/Tools/ManageRenderPipeline.cs
@@ -121,6 +121,7 @@ namespace MCPForUnity.Editor.Tools
         #endregion
 
         #region Volume Operations
+#if UNITY_RENDER_PIPELINES_CORE
 
         private static object ListVolumes(ToolParams p)
         {
@@ -290,6 +291,21 @@ namespace MCPForUnity.Editor.Tools
             return new ErrorResponse($"Override '{overrideTypeResult.Value}' not found on volume '{go.name}'.");
         }
 
+#else
+
+        private static object ListVolumes(ToolParams p) =>
+            VolumeSystemUnavailable("list_volumes");
+
+        private static object GetVolume(ToolParams p) =>
+            VolumeSystemUnavailable("get_volume");
+
+        private static object SetVolumeOverride(ToolParams p) =>
+            VolumeSystemUnavailable("set_volume_override");
+
+        private static object ToggleVolumeOverride(ToolParams p) =>
+            VolumeSystemUnavailable("toggle_volume_override");
+
+#endif
         #endregion
 
         #region Renderer Features & Post Processing
@@ -353,6 +369,7 @@ namespace MCPForUnity.Editor.Tools
             });
         }
 
+#if UNITY_RENDER_PIPELINES_CORE
         private static object ListPostProcessing()
         {
             var volumes = UnityEngine.Object.FindObjectsByType<Volume>(FindObjectsSortMode.InstanceID);
@@ -380,10 +397,25 @@ namespace MCPForUnity.Editor.Tools
             });
         }
 
+#else
+
+        private static object ListPostProcessing() =>
+            VolumeSystemUnavailable("list_post_processing");
+
+#endif
         #endregion
 
         #region Helpers
 
+        private static object VolumeSystemUnavailable(string action)
+        {
+            return new ErrorResponse(
+                $"Action '{action}' requires the Volume system from com.unity.render-pipelines.core, " +
+                "which is not installed in this project (Built-in Render Pipeline). " +
+                "Install an SRP (URP/HDRP) or com.unity.render-pipelines.core to use this action.");
+        }
+
+#if UNITY_RENDER_PIPELINES_CORE
         private static void SetVolumeParamValue(VolumeParameter param, string valueStr)
         {
             var paramType = param.GetType();
@@ -405,6 +437,7 @@ namespace MCPForUnity.Editor.Tools
             }
         }
 
+#endif
         #endregion
     }
 }


### PR DESCRIPTION
## Problem

`MCPForUnity.Editor` fails to compile in any project on the **Built-in Render Pipeline** (no SRP package installed):

```
Library\PackageCache\com.coplaydev.unity-mcp@fb462725cb18\Editor\Tools\ManageRenderPipeline.cs(387,49):
error CS0246: The type or namespace name 'VolumeParameter' could not be found
```

`ManageRenderPipeline.cs` references `UnityEngine.Rendering.Volume` and `VolumeParameter` as **hard types**. Both live in `Unity.RenderPipelines.Core.Runtime` (`com.unity.render-pipelines.core`). When that package is absent the asmdef reference is dropped, the types do not exist, and the **entire editor assembly** fails — taking every unrelated MCP tool down with it.

Hit on Unity `6000.3.10f1`, package `9.7.2-beta.9`, a WebGL project with zero `com.unity.render-pipelines.*` entries in `manifest.json`. The same code is present on `CoplayDev/main`, so this is inherited upstream, not fork-specific. Projects pinned to `9.4.7` are unaffected because `Tools/Graphics` and `ManageRenderPipeline.cs` did not exist yet.

## Why this file only

`MCPForUnity.Editor.asmdef` already declares the `UNITY_RENDER_PIPELINES_CORE` versionDefine — the intent to gate was there — but **no source file ever used the symbol**.

Every sibling resolves SRP types through reflection and degrades at runtime:

| File | SRP access | Compiles without core? |
|---|---|---|
| `Tools/Graphics/GraphicsHelpers.cs` | `Type.GetType("UnityEngine.Rendering.Volume, Unity.RenderPipelines.Core.Runtime")` | yes |
| `Tools/Graphics/VolumeOps.cs` | delegates to `GraphicsHelpers` | yes |
| `Tools/Graphics/RendererFeatureOps.cs` | `Type.GetType(...)` for URP types | yes |
| `Tools/ManageRenderPipeline.cs` | **hard `using UnityEngine.Rendering;` + `Volume` / `VolumeParameter`** | **no** |

`ManageRenderPipeline.cs` is the sole file taking a compile-time dependency.

## Change

Additive only — 33 lines, no deletions. `#if UNITY_RENDER_PIPELINES_CORE` around:

- the four Volume actions (`ListVolumes`, `GetVolume`, `SetVolumeOverride`, `ToggleVolumeOverride`)
- `ListPostProcessing` (uses `FindObjectsByType<Volume>`)
- the `SetVolumeParamValue(VolumeParameter, string)` helper

The `#else` branch keeps **every action reachable** and returns an explicit `ErrorResponse` naming the missing package, rather than letting the action vanish:

> Action 'list_volumes' requires the Volume system from com.unity.render-pipelines.core, which is not installed in this project (Built-in Render Pipeline). Install an SRP (URP/HDRP) or com.unity.render-pipelines.core to use this action.

`get_pipeline_info`, `get_render_pipeline_asset`, and `list_renderer_features` were already reflection-based and are untouched.

## Verification

Both preprocessor branches were expanded and checked mechanically:

| Branch | Braces | `VolumeParameter` refs | `FindObjectsByType<Volume>` |
|---|---|---|---|
| `UNITY_RENDER_PIPELINES_CORE` defined | 56 / 56 balanced | 4 (unchanged from original) | 2 (unchanged) |
| not defined | 26 / 26 balanced | **0** | **0** |

Behavior with the package present is byte-for-byte unchanged — the guarded branch retains the original reference counts.

`using UnityEngine.Rendering;` is deliberately left unguarded: that namespace also ships in `UnityEngine.CoreModule`, so the directive resolves either way.

## Suggested follow-up (not in this PR)

Converting the Volume region to the `GraphicsHelpers` reflection pattern would let these actions work on Built-in RP instead of erroring, and would remove the duplication with `VolumeOps.cs`. That is a larger refactor and deliberately out of scope here.