### PR TITLE
fix(manage_dots): fix set_component enum writes and unmanaged component writes

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageDots.cs
+++ b/MCPForUnity/Editor/Tools/ManageDots.cs
@@ -542,20 +542,44 @@ namespace MCPForUnity.Editor.Tools
                     return new ErrorResponse($"Field '{fieldName}' not found on component '{componentName}'.");
 
                 // Parse the value to the correct type
-                object parsedValue = Convert.ChangeType(fieldValue, field.FieldType, System.Globalization.CultureInfo.InvariantCulture);
+                object parsedValue = field.FieldType.IsEnum
+                    ? ParseEnumFieldValue(field.FieldType, fieldValue)
+                    : Convert.ChangeType(fieldValue, field.FieldType, System.Globalization.CultureInfo.InvariantCulture);
                 field.SetValue(obj, parsedValue);
 
-                // SetComponentBoxed not available in public API — use SetComponentObject via reflection
-                var setMethod = typeof(EntityManager).GetMethod("SetComponentObject",
-                    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
-                    null, new[] { typeof(Entity), typeof(ComponentType), typeof(object) }, null);
-                if (setMethod != null)
+                if (!ct.Value.IsManagedComponent)
                 {
-                    setMethod.Invoke(em, new object[] { entity, ct.Value, obj });
+                    // Unmanaged IComponentData (struct) — SetComponentObject below asserts
+                    // componentType.IsManagedComponent internally (EntityDataAccess.SetComponentObject)
+                    // and throws ArgumentException for anything else. Write back through the
+                    // generic unmanaged EntityManager.SetComponentData<T> instead.
+                    var setDataMethod = typeof(EntityManager)
+                        .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                        .FirstOrDefault(m => m.Name == "SetComponentData"
+                            && m.IsGenericMethodDefinition
+                            && m.GetGenericArguments().Length == 1
+                            && m.GetParameters().Length == 2
+                            && m.GetParameters()[0].ParameterType == typeof(Entity));
+                    if (setDataMethod == null)
+                        return new ErrorResponse("SetComponentData is not available in this version of Unity Entities.");
+
+                    setDataMethod.MakeGenericMethod(type).Invoke(em, new object[] { entity, obj });
                 }
                 else
                 {
-                    return new ErrorResponse("SetComponent is not supported in this version of Unity Entities.");
+                    // Managed component (class-based IComponentData) — SetComponentBoxed is not
+                    // available in the public API, so use SetComponentObject via reflection.
+                    var setObjectMethod = typeof(EntityManager).GetMethod("SetComponentObject",
+                        BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                        null, new[] { typeof(Entity), typeof(ComponentType), typeof(object) }, null);
+                    if (setObjectMethod != null)
+                    {
+                        setObjectMethod.Invoke(em, new object[] { entity, ct.Value, obj });
+                    }
+                    else
+                    {
+                        return new ErrorResponse("SetComponent is not supported in this version of Unity Entities.");
+                    }
                 }
 
                 return new SuccessResponse(
@@ -570,7 +594,39 @@ namespace MCPForUnity.Editor.Tools
             }
             catch (Exception e)
             {
-                return new ErrorResponse($"Failed to set field: {e.Message}");
+                // Reflected MethodInfo.Invoke wraps the real failure in a TargetInvocationException;
+                // surface the InnerException so the caller sees the actual cause, not the wrapper.
+                var reported = e;
+                if (e is TargetInvocationException tie && tie.InnerException != null)
+                    reported = tie.InnerException;
+                return new ErrorResponse($"Failed to set field: {reported.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Parses a string value into an enum member of <paramref name="enumType"/>.
+        /// Accepts a numeric literal (honoring the enum's underlying integral type) or a
+        /// member name (case-insensitive, including comma-separated flag combinations).
+        /// </summary>
+        private static object ParseEnumFieldValue(Type enumType, string fieldValue)
+        {
+            var underlyingType = Enum.GetUnderlyingType(enumType);
+            if (long.TryParse(fieldValue, System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture, out var numeric))
+            {
+                var converted = Convert.ChangeType(numeric, underlyingType, System.Globalization.CultureInfo.InvariantCulture);
+                return Enum.ToObject(enumType, converted);
+            }
+
+            try
+            {
+                return Enum.Parse(enumType, fieldValue, ignoreCase: true);
+            }
+            catch (ArgumentException)
+            {
+                var names = string.Join(", ", Enum.GetNames(enumType));
+                throw new ArgumentException(
+                    $"Value '{fieldValue}' is not a valid member of enum '{enumType.Name}'. Valid values: {names}");
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `ManageDots.cs`'s `set_component` field-write path (same function, different stages -- fixing one alone still fails one line later, so both land together):

- **#68** -- `Convert.ChangeType` has no enum branch, so writing an enum field (by name or by number) throws `Invalid cast from System.String to <enum>`. Added `ParseEnumFieldValue`: `Enum.ToObject` for a numeric literal (honors the enum's underlying integral type), `Enum.Parse(ignoreCase: true)` for a member name (including comma-separated flag combinations), and the error lists valid member names via `Enum.GetNames` on failure.
- **#69** -- the write-back always used `SetComponentObject`, which is the **managed-component-only** path (`EntityDataAccess.SetComponentObject` asserts `componentType.IsManagedComponent` and throws `ArgumentException` otherwise -- confirmed against the Unity Entities source quoted in the issue). Every unmanaged `IComponentData` field write therefore threw `TargetInvocationException`, including a trivial no-op int write. Now dispatches on `ComponentType.IsManagedComponent`: unmanaged components write through the generic `EntityManager.SetComponentData<T>` (found via reflection, filtered by name/arity/first-param-type to avoid picking a decoy overload); managed components keep the existing `SetComponentObject` path.
- The `catch` block dropped `TargetInvocationException.InnerException`, reporting only the fixed, contentless `"Exception has been thrown by the target of an invocation."` Both write paths now unwrap `InnerException` so the real failure message reaches the caller.

Fixes #68
Fixes #69

## Verification

**This is C# inside a Unity Editor package (`#if UNITY_ENTITIES`) and cannot be compiled or run without a Unity Editor + the `com.unity.entities` package -- neither is available in this environment. I did not compile it against real Unity.Entities, and a reviewer with Unity open must verify it compiles and behaves correctly against the real API before merging.**

To get real evidence anyway, I extracted the exact reflection/dispatch code (`ApplyWrite`, `ParseEnumFieldValue`) into a standalone .NET 9 console harness against hand-written stand-ins for the Unity.Entities surface this code touches (`EntityManager.SetComponentData<T>` with a decoy overload to prove the reflection filter is precise, `EntityManager.SetComponentObject`, `ComponentType.IsManagedComponent` per the source quoted in #69, `TargetInvocationException` unwrapping). This proves the C# compiles under real Roslyn and that the control flow, generic-method reflection, and enum parsing behave as intended -- it does **not** prove the real `Unity.Entities` API matches the stand-in shapes.

```
PASS - enum parse by name (case-insensitive)
PASS - enum parse by numeric literal
PASS - enum parse numeric result is boxed as byte-backed enum
PASS - enum parse invalid name throws with valid-names list
PASS - flags enum comma-separated names
PASS - unmanaged write returns OK
PASS - unmanaged write invoked SetComponentData<T> (not SetComponentObject)
PASS - managed write returns OK
PASS - managed write invoked SetComponentObject (not SetComponentData<T>)
PASS - unmanaged write failure unwraps TargetInvocationException
PASS - unmanaged write failure message does NOT leak the TIE wrapper text
PASS - managed write failure unwraps TargetInvocationException

ALL CHECKS PASSED
```

### What a reviewer with Unity open should specifically check
- `ComponentType.IsManagedComponent` is public/accessible from `ManageDots.cs` in the target Entities version (I believe this holds across 1.x based on the source quoted in #69, but have not compiled against it).
- The `SetComponentData` reflection filter (name == `"SetComponentData"`, `IsGenericMethodDefinition`, 1 generic arg, 2 params, first param `Entity`) resolves to exactly one method on the real `EntityManager` and not, e.g., an `EntityQuery`-based overload.
- A real enum field write (both by name and by numeric value) and a real unmanaged struct field write against a live World/Entity.

Draft PR pending that verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)