### PR TITLE
fix(run_tests): guard empty/partial response envelopes and init-timeout misreport

### DIFF
--- a/Server/src/services/tools/run_tests.py
+++ b/Server/src/services/tools/run_tests.py
@@ -147,6 +147,38 @@ class GetTestJobResponse(MCPResponse):
     data: GetTestJobData | None = None
 
 
+def _envelope_failure(response: Any) -> MCPResponse | None:
+    """Validate a raw Unity transport response before it's splatted into a strict
+    pydantic model (MCPResponse / RunTestsStartResponse / GetTestJobResponse all
+    require "success" with no default).
+
+    A non-dict response, or a dict missing "success" entirely (observed: Unity
+    returning an empty {} for a run that had actually started -- see #63), used
+    to sail past `.get("success", True)`'s permissive default and detonate as an
+    uncaught pydantic ValidationError instead of a clean MCPResponse(success=False).
+
+    Returns the MCPResponse to return immediately, or None when the envelope is
+    well-formed and the caller should proceed with its own response handling.
+    """
+    if not isinstance(response, dict):
+        return MCPResponse(success=False, error=str(response))
+    if "success" not in response:
+        return MCPResponse(
+            success=False,
+            error="empty_response_from_unity",
+            message=(
+                "Unity's response was missing or malformed. The underlying job may "
+                "still be running (e.g. a busy/reload race) -- check for an "
+                "in-progress job before retrying, rather than assuming it never started."
+            ),
+            data=response or None,
+            hint="retry",
+        )
+    if not response["success"]:
+        return MCPResponse(**response)
+    return None
+
+
 def _reject_zero_match_filter(response: dict[str, Any]) -> dict[str, Any]:
     """Turn a "Passed" result with 0 discovered tests into an explicit error.
 
@@ -169,7 +201,12 @@ def _reject_zero_match_filter(response: dict[str, Any]) -> dict[str, Any]:
     if not data.get("filter_requested"):
         return response
 
-    if (data.get("discovered_tests") or 0) != 0:
+    # discovered_tests is None (not 0) when the run never got past initialization --
+    # e.g. TestJobManager's init-timeout auto-fail, which sets data["status"] == "failed"
+    # without ever setting TotalTests. Collapsing that None to 0 here would misreport a
+    # genuine startup timeout as "filter matched 0 tests", masking the real cause.
+    discovered_tests = data.get("discovered_tests")
+    if discovered_tests is None or discovered_tests != 0:
         return response
 
     summary = ((data.get("result") or {}).get("summary")) or {}
@@ -257,11 +294,24 @@ async def run_tests(
         params,
     )
 
-    if isinstance(response, dict):
-        if not response.get("success", True):
-            return MCPResponse(**response)
-        return RunTestsStartResponse(**response)
-    return MCPResponse(success=False, error=str(response))
+    if (guard := _envelope_failure(response)) is not None:
+        return guard
+
+    # response["success"] is True and well-formed past this point, but the data
+    # payload can still be present-and-empty (e.g. {"success": true} with no
+    # "data"). get_test_job hard-requires job_id with no recovery path, so catch
+    # that here rather than let RunTestsStartResponse(**response) either raise on
+    # the missing required field or silently construct a job the caller can never
+    # poll for.
+    data = response.get("data")
+    if not isinstance(data, dict) or not data.get("job_id"):
+        return MCPResponse(
+            success=False,
+            error="Unity returned an incomplete run_tests response (missing job_id); "
+                  "the test run may not have started. Check the Unity console.",
+            data=response or None,
+        )
+    return RunTestsStartResponse(**response)
 
 
 @mcp_for_unity_tool(
@@ -312,11 +362,8 @@ async def get_test_job(
         while True:
             response = await _fetch_status()
 
-            if not isinstance(response, dict):
-                return MCPResponse(success=False, error=str(response))
-
-            if not response.get("success", True):
-                return MCPResponse(**response)
+            if (guard := _envelope_failure(response)) is not None:
+                return guard
 
             # Check if tests are done
             data = response.get("data", {})
@@ -370,10 +417,8 @@ async def get_test_job(
     
     # No wait_timeout - return immediately (original behavior)
     response = await _fetch_status()
-    if not isinstance(response, dict):
-        return MCPResponse(success=False, error=str(response))
-    if not response.get("success", True):
-        return MCPResponse(**response)
+    if (guard := _envelope_failure(response)) is not None:
+        return guard
 
     # Fire-and-forget nudge check: even without wait_timeout, clients may poll
     # externally. Check if Unity needs a nudge on every call so stalls get

--- a/Server/tests/integration/test_run_tests_async.py
+++ b/Server/tests/integration/test_run_tests_async.py
@@ -216,3 +216,116 @@ async def test_get_test_job_allows_filter_with_matched_tests(monkeypatch):
     resp = await get_test_job(DummyContext(), job_id="job-zero")
     assert resp.success is True
     assert resp.data.discovered_tests == 3
+
+
+@pytest.mark.asyncio
+async def test_run_tests_rejects_empty_response(monkeypatch):
+    """#63: an empty dict (no "success" key at all) must not be handed straight to
+    RunTestsStartResponse -- .get("success", True) would default it to success and
+    detonate as an uncaught pydantic ValidationError on construction. The shared
+    _envelope_failure guard must catch the missing "success" key before that."""
+    from services.tools.run_tests import run_tests
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return {}
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await run_tests(DummyContext(), mode="EditMode")
+    assert resp.success is False
+    assert resp.error == "empty_response_from_unity"
+
+
+@pytest.mark.asyncio
+async def test_run_tests_rejects_response_missing_job_id(monkeypatch):
+    """#63: a "data" payload with no job_id must still fail cleanly, not construct a
+    RunTestsStartResponse the caller can never poll (get_test_job requires job_id)."""
+    from services.tools.run_tests import run_tests
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return {"success": True, "data": {"status": "running"}}
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await run_tests(DummyContext(), mode="EditMode")
+    assert resp.success is False
+    assert "job_id" in resp.error
+
+
+def _init_timeout_job_response(status="failed"):
+    """A job that never got past initialization: TestJobManager's init-timeout
+    auto-fail sets status/error but never sets TotalTests, so discovered_tests is
+    JSON null -- not 0."""
+    return {
+        "success": True,
+        "data": {
+            "job_id": "job-timeout",
+            "status": status,
+            "mode": "PlayMode",
+            "filter_requested": True,
+            "discovered_tests": None,
+            "progress": {"completed": 0, "total": None},
+            "error": "Test job failed to initialize (tests did not start within timeout)",
+            "result": None,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_test_job_preserves_init_timeout_error(monkeypatch):
+    """#70: an init-timeout auto-fail (discovered_tests=None) must surface its real
+    error, not get rewritten by the zero-match-filter guard into a misleading
+    "filter matched 0 tests" message -- the filter was never even evaluated."""
+    from services.tools.run_tests import get_test_job
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return _init_timeout_job_response()
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await get_test_job(DummyContext(), job_id="job-timeout")
+    assert resp.success is True
+    assert resp.data.status == "failed"
+    assert "did not start within timeout" in resp.data.error
+    assert "0 tests" not in (resp.data.error or "")
+
+
+@pytest.mark.asyncio
+async def test_get_test_job_rejects_empty_response(monkeypatch):
+    """#63: get_test_job's non-wait_timeout path shares the same _envelope_failure
+    guard as run_tests -- an empty {} must not reach GetTestJobResponse(**{})."""
+    from services.tools.run_tests import get_test_job
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return {}
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await get_test_job(DummyContext(), job_id="job-lost")
+    assert resp.success is False
+    assert resp.error == "empty_response_from_unity"
+
+
+@pytest.mark.asyncio
+async def test_get_test_job_rejects_empty_response_via_wait_timeout(monkeypatch):
+    """#63: same guard on the server-side polling path (wait_timeout)."""
+    from services.tools.run_tests import get_test_job
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        return {}
+
+    import services.tools.run_tests as mod
+    monkeypatch.setattr(
+        mod.unity_transport, "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await get_test_job(DummyContext(), job_id="job-lost", wait_timeout=5)
+    assert resp.success is False
+    assert resp.error == "empty_response_from_unity"


### PR DESCRIPTION
## Summary

Fixes #63 and #70 in `Server/src/services/tools/run_tests.py`.

**#63** -- `MCPResponse` (and its subclasses `RunTestsStartResponse`, `GetTestJobResponse`) require `success: bool` with no default. `response.get("success", True)` treated a response dict missing `"success"` entirely as truthy and handed it straight to the model constructor. The filed issue documents this happening in the wild: Unity returned an empty `{}` for a `run_tests` call that had **actually started** (confirmed by a subsequent `tests_running` busy response) -- so the caller got an uncaught `pydantic.ValidationError` for a live run, `job_id` was lost, and `get_test_job` hard-requires `job_id` with no recovery path.

Added a shared `_envelope_failure(response)` guard used at **every** response-handling call site in both `run_tests` and `get_test_job` (including the `wait_timeout` server-side polling loop, which the original bug report also flagged for the same treatment): it explicitly returns `MCPResponse(success=False, error="empty_response_from_unity", ...)` whenever `"success"` is absent from the response, before any strict model gets a chance to raise. `run_tests` additionally checks that a well-formed `success: true` envelope still carries `data.job_id`, since a caller can never recover a job it can't name.

**#70** -- `TestJobManager`'s init-timeout auto-fail (`TestJobManager.cs:525-530`) sets `job.Error` but never sets `TotalTests` (the run never got past initialization), so `discovered_tests` comes back as JSON `null`. The existing zero-match-filter guard (`_reject_zero_match_filter`, from #37) collapsed that `null` to `0` via `(data.get("discovered_tests") or 0) != 0`, so a job that never started was misreported as `"Test filter matched 0 tests"` -- pointing diagnosis at the filter instead of the real timeout. Now distinguishes `None` (never discovered) from a genuine `0` (discovered and matched nothing) explicitly.

Note: the team-lead brief that scoped this work cited the root cause for #70 at `MCPForUnity/Editor/Tools/TestJobManager.cs:528-530` (correct path is actually `MCPForUnity/Editor/Services/TestJobManager.cs`) as the fix location. I verified that citation describes the *symptom's origin* correctly (the C# init-timeout path really does leave `TotalTests`/`discovered_tests` as `null`), but the actual place that **misinterprets** that `null` as `0` is the Python `_reject_zero_match_filter` in this file -- there is no `TotalTests == 0` executable check anywhere in the C# file, only in a doc comment. The fix therefore lands entirely in Python, consistent with this PR being scoped to the Python/`run_tests.py` changes only.

Fixes #63
Fixes #70

## Verification

Ran the real test suite with `uv` (Python 3.10 per the project's pinned version, pytest via `uv run`).

Targeted file, before my fix (confirms the 3 new regression tests actually catch the bugs -- `git stash` back to unmodified `origin/beta`):
```
FAILED tests/integration/test_run_tests_async.py::test_run_tests_rejects_empty_response
  pydantic_core._pydantic_core.ValidationError: 1 validation error for RunTestsStartResponse
  success
    Field required [type=missing, input_value={}, input_type=dict]
FAILED tests/integration/test_run_tests_async.py::test_run_tests_rejects_response_missing_job_id
  pydantic_core._pydantic_core.ValidationError: 1 validation error for RunTestsStartResponse
  data.job_id
    Field required [type=missing, input_value={'status': 'running'}, input_type=dict]
FAILED tests/integration/test_run_tests_async.py::test_get_test_job_preserves_init_timeout_error
  AssertionError: assert False is True
   +  where False = MCPResponse(..., error='Test filter matched 0 tests. ...').success
```

Targeted file, after my fix -- all 15 pass (10 pre-existing + 5 new regression tests, covering both `run_tests` and `get_test_job`, both the wait_timeout and non-wait_timeout paths):
```
============================== 15 passed in 0.18s ==============================
```

Full suite (`uv run pytest tests/ --tb=no -q`), before vs. after my change, same clone:
```
before: 12 failed, 1517 passed
after:  12 failed, 1522 passed
```
The 12 failures are pre-existing on unmodified `origin/beta` (`test_manage_physics.py`, `test_manage_profiler.py` -- unrelated to this change; verified identical failure set both before and after). +5 passed matches exactly the 5 new regression tests added. Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)