### PR TITLE
fix(server): prefer Unity instance whose project dir contains server cwd

### DIFF
--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -10,6 +10,7 @@ from core.telemetry import record_milestone, record_telemetry, MilestoneType, Re
 from services.resources import register_all_resources
 from transport.plugin_registry import PluginRegistry
 from transport.plugin_hub import PluginHub
+from transport.instance_selection import select_sole_match_by_cwd
 from services.custom_tool_service import (
     CustomToolService,
     resolve_project_id_for_unity_instance,
@@ -367,6 +368,29 @@ def _normalize_instance_token(instance_token: str | None) -> tuple[str | None, s
     return None, instance_token
 
 
+def _select_default_session_id(sessions: dict[str, Any]) -> str | None:
+    """Pick which session to use when a CLI route got no explicit unity_instance.
+
+    With multiple Unity Editors connected, blindly taking the first entry in
+    ``sessions`` (dict insertion order) can silently route commands to the
+    wrong project -- the call still succeeds, just against a different Unity
+    instance than the caller is working in. Prefer the sole session whose
+    ``project_path`` contains this server process's cwd (the directory the
+    MCP client was launched from); fall back to "first available" on zero or
+    multiple cwd matches, preserving the previous behaviour in the ambiguous
+    case.
+    """
+    if not sessions:
+        return None
+    preferred = select_sole_match_by_cwd(
+        (session_id, details.project_path)
+        for session_id, details in sessions.items()
+    )
+    if preferred is not None:
+        return preferred
+    return next(iter(sessions.keys()))
+
+
 def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
     mcp = FastMCP(
         name="mcp-for-unity-server",
@@ -453,16 +477,15 @@ def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
                 # If no specific unity_instance requested, use first available session
                 # (Must be done before execute_custom_tool check so all command types benefit)
                 if not session_id:
-                    try:
-                        session_id = next(iter(sessions.sessions.keys()))
-                        session_details = sessions.sessions.get(session_id)
-                    except StopIteration:
-                        # No sessions available - sessions.sessions is empty
-                        # This should not happen since we checked at line 378, but handle gracefully
+                    session_id = _select_default_session_id(sessions.sessions)
+                    if session_id is None:
+                        # No sessions available - sessions.sessions is empty.
+                        # This should not happen since we checked above, but handle gracefully.
                         return JSONResponse({
                             "success": False,
                             "error": "No Unity instances connected. Make sure Unity is running with MCP plugin."
                         }, status_code=503)
+                    session_details = sessions.sessions.get(session_id)
 
                 # Custom tool execution - must be checked BEFORE the final PluginHub.send_command call
                 # This applies to both cases: with or without explicit unity_instance
@@ -574,8 +597,9 @@ def create_mcp_server(project_scoped_tools: bool) -> FastMCP:
                             status_code=404,
                         )
                 else:
-                    # No specific unity_instance requested: use first available session
-                    session_details = next(iter(sessions.sessions.values()))
+                    # No specific unity_instance requested: see _select_default_session_id.
+                    default_session_id = _select_default_session_id(sessions.sessions)
+                    session_details = sessions.sessions[default_session_id]
 
                 unity_instance_hint = unity_instance
                 if session_details and session_details.hash:

--- a/Server/src/services/tools/refresh_unity.py
+++ b/Server/src/services/tools/refresh_unity.py
@@ -193,6 +193,11 @@ async def refresh_unity(
                        "Whether to request compilation"] = "none",
     wait_for_ready: Annotated[bool,
                               "If true, wait until editor_state.advice.ready_for_tools is true"] = True,
+    allow_during_play: Annotated[bool,
+                                 "If false (default), refuse to refresh/compile while Play mode is "
+                                 "active -- on a DOTS project that forces a domain reload that "
+                                 "permanently disposes the ECS Default World for the rest of the Play "
+                                 "session. Pass true only if you understand and accept that."] = False,
 ) -> MCPResponse | dict[str, Any]:
     unity_instance = await get_unity_instance_from_context(ctx)
 
@@ -201,6 +206,7 @@ async def refresh_unity(
         "scope": scope,
         "compile": compile,
         "wait_for_ready": bool(wait_for_ready),
+        "allow_during_play": bool(allow_during_play),
     }
 
     recovered_from_disconnect = False

--- a/Server/src/transport/instance_selection.py
+++ b/Server/src/transport/instance_selection.py
@@ -1,0 +1,80 @@
+"""Shared helper for disambiguating multiple connected Unity instances by cwd.
+
+With more than one Unity Editor connected (multi-project workflows), several
+call sites used to fall back to "just pick the first session" when no explicit
+``unity_instance`` was requested. That silently routes commands to whichever
+project happened to register first -- a call can succeed against the *wrong*
+project with no error at all.
+
+This module centralises the fix: when exactly one connected instance's project
+directory contains the server process's current working directory (the
+directory the MCP client -- e.g. Claude Code -- was launched from), prefer
+that instance. On zero or more than one match, return ``None`` so the caller
+falls back to its previous (explicit/first-available) behaviour rather than
+guessing.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+
+def normalize_project_root(project_path: str | None) -> str | None:
+    """Normalize a Unity project path to its project-root directory.
+
+    Some callers report the ``Assets`` subfolder rather than the project root;
+    strip a trailing ``Assets`` segment before resolving. Returns ``None`` when
+    ``project_path`` is missing or cannot be resolved on this filesystem.
+    """
+    if not project_path:
+        return None
+    normalized = project_path.rstrip("/\\")
+    if not normalized:
+        return None
+    if os.path.basename(normalized) == "Assets":
+        parent = os.path.dirname(normalized)
+        normalized = parent or normalized
+    try:
+        return os.path.realpath(normalized)
+    except OSError:
+        return None
+
+
+def select_sole_match_by_cwd(
+    candidates: Iterable[tuple[str, str | None]],
+    cwd: str | None = None,
+) -> str | None:
+    """Return the id of the single candidate whose project dir contains ``cwd``.
+
+    Args:
+        candidates: iterable of ``(candidate_id, project_path)`` pairs.
+        cwd: directory to match against; defaults to ``os.getcwd()``.
+
+    Returns:
+        The matching candidate id when exactly one candidate's (normalized)
+        project directory is ``cwd`` or an ancestor of it. ``None`` on zero or
+        multiple matches -- callers should keep their existing default
+        behaviour rather than guess between ambiguous candidates.
+    """
+    if cwd is None:
+        try:
+            cwd = os.getcwd()
+        except OSError:
+            return None
+    try:
+        cwd = os.path.realpath(cwd)
+    except OSError:
+        return None
+
+    matches: list[str] = []
+    for candidate_id, project_path in candidates:
+        root = normalize_project_root(project_path)
+        if root is None:
+            continue
+        if cwd == root or cwd.startswith(root + os.sep):
+            matches.append(candidate_id)
+
+    if len(matches) == 1:
+        return matches[0]
+    return None

--- a/Server/src/transport/models.py
+++ b/Server/src/transport/models.py
@@ -62,6 +62,9 @@ class SessionDetails(BaseModel):
     hash: str
     unity_version: str
     connected_at: str
+    # Full path to the Unity project root, when known. Used to disambiguate
+    # which connected instance to auto-select when multiple are present.
+    project_path: str | None = None
 
 
 class SessionList(BaseModel):

--- a/Server/src/transport/plugin_hub.py
+++ b/Server/src/transport/plugin_hub.py
@@ -351,6 +351,7 @@ class PluginHub(WebSocketEndpoint):
                     hash=session.project_hash,
                     unity_version=session.unity_version,
                     connected_at=session.connected_at.isoformat(),
+                    project_path=session.project_path,
                 )
                 for session_id, session in sessions.items()
             }

--- a/Server/src/transport/unity_instance_middleware.py
+++ b/Server/src/transport/unity_instance_middleware.py
@@ -13,6 +13,7 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from core.config import config
 from services.registry import get_registered_tools
 from transport.plugin_hub import PluginHub
+from transport.instance_selection import select_sole_match_by_cwd
 
 logger = logging.getLogger("mcp-for-unity-server")
 # Separate logger that propagates to root -> stderr so diagnostics show in console
@@ -242,12 +243,16 @@ class UnityInstanceMiddleware(Middleware):
                     sessions_data = await PluginHub.get_sessions()
                     sessions = sessions_data.sessions or {}
                     ids: list[str] = []
+                    ids_with_path: list[tuple[str, str | None]] = []
                     for session_info in sessions.values():
                         project = getattr(
                             session_info, "project", None) or "Unknown"
                         hash_value = getattr(session_info, "hash", None)
                         if hash_value:
-                            ids.append(f"{project}@{hash_value}")
+                            instance_id = f"{project}@{hash_value}"
+                            ids.append(instance_id)
+                            ids_with_path.append(
+                                (instance_id, getattr(session_info, "project_path", None)))
                     if len(ids) == 1:
                         chosen = ids[0]
                         await self.set_active_instance(ctx, chosen)
@@ -257,6 +262,18 @@ class UnityInstanceMiddleware(Middleware):
                         )
                         return chosen
                     if len(ids) > 1:
+                        # Multiple instances connected: prefer the one whose project
+                        # directory contains this server process's cwd over leaving the
+                        # caller to guess -- but only when exactly one instance matches,
+                        # to avoid silently picking between two equally-plausible projects.
+                        cwd_match = select_sole_match_by_cwd(ids_with_path)
+                        if cwd_match is not None:
+                            await self.set_active_instance(ctx, cwd_match)
+                            logger.info(
+                                "Auto-selected Unity instance by cwd match among %d connected: %s",
+                                len(ids), cwd_match,
+                            )
+                            return cwd_match
                         logger.info(
                             "Multiple Unity instances found (%d). Pass unity_instance on any tool call "
                             "or call set_active_instance to choose one. Available: %s",

--- a/Server/tests/integration/test_cli_route_instance_selection.py
+++ b/Server/tests/integration/test_cli_route_instance_selection.py
@@ -1,0 +1,114 @@
+"""Regression tests for CLI HTTP route Unity-instance auto-selection (#66).
+
+With more than one Unity Editor connected, `/api/command` (the no-explicit-
+`unity_instance` path) and `/api/custom-tools` used to fall back to "pick the
+first session in the dict" -- dict insertion order, i.e. whichever Unity
+Editor happened to register first. That silently routes the call to the
+wrong project: the request still succeeds, it's just answered by a different
+Unity instance than the caller is working in.
+
+Both routes now share `main._select_default_session_id`, which prefers the
+sole connected session whose `project_path` contains the server process's
+cwd. These tests exercise that helper directly (the routes are thin wrappers
+around it -- see `src/main.py`), registering the "wrong" project first so a
+naive first-available fallback would deterministically pick it, proving the
+selection is cwd-driven rather than accidental.
+
+NOTE: `main` is imported lazily inside each test (not at module scope). It
+pulls in the REAL `core.telemetry` module as an import side effect, which
+initializes the telemetry singleton before `tests/test_core_infrastructure_
+characterization.py`'s fixtures get a chance to mock it -- pytest imports all
+test modules up front during collection, so a module-level import here would
+run before any test executes, regardless of file/run order. Importing inside
+each test function defers that side effect until this file's own tests
+actually run (mirrors the existing pattern in test_instance_autoselect.py).
+"""
+from __future__ import annotations
+
+from transport.models import SessionDetails
+
+
+def _sessions(*, wrong_path: str, right_path: str) -> dict[str, SessionDetails]:
+    # Insertion order matters: "session-wrong" is inserted FIRST, so a plain
+    # `next(iter(...))` fallback would pick it -- exactly the pre-fix bug.
+    return {
+        "session-wrong": SessionDetails(
+            project="ProjectA",
+            hash="aaaaaaaa",
+            unity_version="6000.0",
+            connected_at="now",
+            project_path=wrong_path,
+        ),
+        "session-right": SessionDetails(
+            project="ProjectB",
+            hash="bbbbbbbb",
+            unity_version="6000.0",
+            connected_at="now",
+            project_path=right_path,
+        ),
+    }
+
+
+def test_selects_session_whose_project_path_contains_cwd(tmp_path, monkeypatch):
+    import main
+
+    project_a = tmp_path / "ProjectA"
+    project_b = tmp_path / "ProjectB"
+    project_a.mkdir()
+    project_b.mkdir()
+    monkeypatch.chdir(project_b)
+
+    sessions = _sessions(wrong_path=str(project_a), right_path=str(project_b))
+
+    assert main._select_default_session_id(sessions) == "session-right"
+
+
+def test_selects_session_when_cwd_is_nested_under_project_assets_folder(tmp_path, monkeypatch):
+    """project_path may point at the project root while cwd is deep inside it."""
+    import main
+
+    project_a = tmp_path / "ProjectA"
+    project_b = tmp_path / "ProjectB"
+    (project_b / "Assets" / "Scripts").mkdir(parents=True)
+    project_a.mkdir()
+    monkeypatch.chdir(project_b / "Assets" / "Scripts")
+
+    sessions = _sessions(wrong_path=str(project_a), right_path=str(project_b))
+
+    assert main._select_default_session_id(sessions) == "session-right"
+
+
+def test_falls_back_to_first_available_when_no_session_matches_cwd(tmp_path, monkeypatch):
+    """Preserves the old behaviour when cwd doesn't disambiguate anything."""
+    import main
+
+    project_a = tmp_path / "ProjectA"
+    project_b = tmp_path / "ProjectB"
+    project_a.mkdir()
+    project_b.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    sessions = _sessions(wrong_path=str(project_a), right_path=str(project_b))
+
+    assert main._select_default_session_id(sessions) == "session-wrong"
+
+
+def test_falls_back_to_first_available_when_multiple_sessions_match_cwd(tmp_path, monkeypatch):
+    """Ambiguous cwd matches must not guess -- keep the prior first-available pick."""
+    import main
+
+    shared_root = tmp_path / "shared"
+    shared_root.mkdir()
+    monkeypatch.chdir(shared_root)
+
+    sessions = _sessions(wrong_path=str(shared_root), right_path=str(shared_root))
+
+    assert main._select_default_session_id(sessions) == "session-wrong"
+
+
+def test_returns_none_for_empty_sessions():
+    import main
+
+    assert main._select_default_session_id({}) is None

--- a/Server/tests/integration/test_instance_autoselect.py
+++ b/Server/tests/integration/test_instance_autoselect.py
@@ -137,3 +137,105 @@ async def test_auto_select_handles_stdio_errors(monkeypatch):
 
     assert selected is None
     assert await middleware.get_active_instance(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_auto_selects_by_cwd_among_multiple_pluginhub_instances(monkeypatch, tmp_path):
+    """#66: with >1 instances connected, prefer the one whose project_path
+    contains this process's cwd instead of leaving the caller to guess."""
+    plugin_hub = types.ModuleType("transport.plugin_hub")
+
+    class PluginHub:
+        @classmethod
+        def is_configured(cls) -> bool:
+            return True
+
+        @classmethod
+        async def get_sessions(cls):
+            raise AssertionError("get_sessions should be stubbed in test")
+
+    plugin_hub.PluginHub = PluginHub
+    monkeypatch.setitem(sys.modules, "transport.plugin_hub", plugin_hub)
+    monkeypatch.delitem(sys.modules, "transport.unity_instance_middleware", raising=False)
+
+    from transport.unity_instance_middleware import UnityInstanceMiddleware, PluginHub as ImportedPluginHub
+    assert ImportedPluginHub is plugin_hub.PluginHub
+
+    monkeypatch.setattr(config, "transport_mode", "http")
+
+    project_a = tmp_path / "ProjectA"
+    project_b = tmp_path / "ProjectB"
+    project_a.mkdir()
+    project_b.mkdir()
+    monkeypatch.chdir(project_b)
+
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    async def fake_get_sessions():
+        return SimpleNamespace(
+            sessions={
+                # Inserted first, so a plain "pick one" fallback would land here.
+                "session-a": SimpleNamespace(project="ProjectA", hash="aaaaaaaa", project_path=str(project_a)),
+                "session-b": SimpleNamespace(project="ProjectB", hash="bbbbbbbb", project_path=str(project_b)),
+            }
+        )
+
+    monkeypatch.setattr(plugin_hub.PluginHub, "get_sessions", fake_get_sessions)
+
+    selected = await middleware._maybe_autoselect_instance(ctx)
+
+    assert selected == "ProjectB@bbbbbbbb"
+    assert await middleware.get_active_instance(ctx) == "ProjectB@bbbbbbbb"
+
+
+@pytest.mark.asyncio
+async def test_no_autoselect_when_multiple_pluginhub_instances_dont_disambiguate(monkeypatch, tmp_path):
+    """Zero or ambiguous cwd matches must keep the prior "ask the caller" behaviour."""
+    plugin_hub = types.ModuleType("transport.plugin_hub")
+
+    class PluginHub:
+        @classmethod
+        def is_configured(cls) -> bool:
+            return True
+
+        @classmethod
+        async def get_sessions(cls):
+            raise AssertionError("get_sessions should be stubbed in test")
+
+    plugin_hub.PluginHub = PluginHub
+    monkeypatch.setitem(sys.modules, "transport.plugin_hub", plugin_hub)
+    monkeypatch.delitem(sys.modules, "transport.unity_instance_middleware", raising=False)
+
+    from transport.unity_instance_middleware import UnityInstanceMiddleware, PluginHub as ImportedPluginHub
+    assert ImportedPluginHub is plugin_hub.PluginHub
+
+    monkeypatch.setattr(config, "transport_mode", "http")
+
+    project_a = tmp_path / "ProjectA"
+    project_b = tmp_path / "ProjectB"
+    elsewhere = tmp_path / "elsewhere"
+    project_a.mkdir()
+    project_b.mkdir()
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    async def fake_get_sessions():
+        return SimpleNamespace(
+            sessions={
+                "session-a": SimpleNamespace(project="ProjectA", hash="aaaaaaaa", project_path=str(project_a)),
+                "session-b": SimpleNamespace(project="ProjectB", hash="bbbbbbbb", project_path=str(project_b)),
+            }
+        )
+
+    monkeypatch.setattr(plugin_hub.PluginHub, "get_sessions", fake_get_sessions)
+
+    selected = await middleware._maybe_autoselect_instance(ctx)
+
+    assert selected is None
+    assert await middleware.get_active_instance(ctx) is None

--- a/Server/tests/test_instance_selection.py
+++ b/Server/tests/test_instance_selection.py
@@ -1,0 +1,103 @@
+"""Unit tests for transport.instance_selection (the shared cwd-preference helper)."""
+from __future__ import annotations
+
+from transport.instance_selection import normalize_project_root, select_sole_match_by_cwd
+
+
+def test_normalize_project_root_strips_trailing_assets(tmp_path):
+    project = tmp_path / "MyProject"
+    assets = project / "Assets"
+    assets.mkdir(parents=True)
+
+    assert normalize_project_root(str(assets)) == normalize_project_root(str(project))
+
+
+def test_normalize_project_root_handles_trailing_separator(tmp_path):
+    project = tmp_path / "MyProject"
+    project.mkdir()
+
+    assert normalize_project_root(str(project) + "/") == normalize_project_root(str(project))
+
+
+def test_normalize_project_root_none_for_missing_input():
+    assert normalize_project_root(None) is None
+    assert normalize_project_root("") is None
+
+
+def test_select_sole_match_by_cwd_exact_match(tmp_path):
+    project_a = tmp_path / "A"
+    project_b = tmp_path / "B"
+    project_a.mkdir()
+    project_b.mkdir()
+
+    result = select_sole_match_by_cwd(
+        [("id-a", str(project_a)), ("id-b", str(project_b))],
+        cwd=str(project_b),
+    )
+
+    assert result == "id-b"
+
+
+def test_select_sole_match_by_cwd_nested_cwd(tmp_path):
+    project_a = tmp_path / "A"
+    project_b = tmp_path / "B"
+    nested = project_b / "Assets" / "Scripts"
+    nested.mkdir(parents=True)
+    project_a.mkdir()
+
+    result = select_sole_match_by_cwd(
+        [("id-a", str(project_a)), ("id-b", str(project_b))],
+        cwd=str(nested),
+    )
+
+    assert result == "id-b"
+
+
+def test_select_sole_match_by_cwd_returns_none_on_zero_matches(tmp_path):
+    project_a = tmp_path / "A"
+    project_b = tmp_path / "B"
+    elsewhere = tmp_path / "elsewhere"
+    project_a.mkdir()
+    project_b.mkdir()
+    elsewhere.mkdir()
+
+    result = select_sole_match_by_cwd(
+        [("id-a", str(project_a)), ("id-b", str(project_b))],
+        cwd=str(elsewhere),
+    )
+
+    assert result is None
+
+
+def test_select_sole_match_by_cwd_returns_none_on_ambiguous_matches(tmp_path):
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    result = select_sole_match_by_cwd(
+        [("id-a", str(shared)), ("id-b", str(shared))],
+        cwd=str(shared),
+    )
+
+    assert result is None
+
+
+def test_select_sole_match_by_cwd_ignores_candidates_with_no_project_path(tmp_path):
+    project_b = tmp_path / "B"
+    project_b.mkdir()
+
+    result = select_sole_match_by_cwd(
+        [("id-a", None), ("id-b", str(project_b))],
+        cwd=str(project_b),
+    )
+
+    assert result == "id-b"
+
+
+def test_select_sole_match_by_cwd_defaults_to_os_getcwd(tmp_path, monkeypatch):
+    project = tmp_path / "P"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    result = select_sole_match_by_cwd([("id-a", str(project))])
+
+    assert result == "id-a"

--- a/Server/tests/test_refresh_unity_play_mode_guard.py
+++ b/Server/tests/test_refresh_unity_play_mode_guard.py
@@ -1,0 +1,103 @@
+"""refresh_unity(allow_during_play=...) plumbing for issue #67.
+
+The Unity-side guard (RefreshUnity.cs) refuses a refresh/compile while Play
+mode is active unless the caller passes allow_during_play=true -- forcing a
+domain reload mid-Play permanently disposes the DOTS Default World for the
+rest of the session. These tests only cover the Python-side plumbing: the
+parameter is forwarded to Unity, defaults to False, and a "play_mode_active"
+rejection is surfaced to the caller as a normal (non-retried) failure rather
+than being mistaken for the "connection lost because a reload was triggered"
+success path refresh_unity treats specially for compile="request".
+"""
+import pytest
+
+from .integration.test_helpers import DummyContext
+
+INSTANCE = "UnityMCPTests@cc8756d4cce0805a"
+
+
+@pytest.mark.asyncio
+async def test_allow_during_play_defaults_to_false_and_is_forwarded(monkeypatch):
+    from services.tools.refresh_unity import refresh_unity
+    import services.tools.refresh_unity as refresh_mod
+
+    ctx = DummyContext()
+    await ctx.set_state("unity_instance", INSTANCE)
+
+    captured = {}
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        if command_type == "refresh_unity":
+            captured["params"] = params
+            return {"success": True, "message": "Refreshed."}
+        raise ValueError(f"Unexpected command: {command_type}")
+
+    monkeypatch.setattr(refresh_mod.unity_transport,
+                        "send_with_unity_instance", fake_send_with_unity_instance)
+
+    await refresh_unity(ctx, mode="force", scope="all", compile="none", wait_for_ready=True)
+
+    assert captured["params"]["allow_during_play"] is False
+
+
+@pytest.mark.asyncio
+async def test_allow_during_play_true_is_forwarded(monkeypatch):
+    from services.tools.refresh_unity import refresh_unity
+    import services.tools.refresh_unity as refresh_mod
+
+    ctx = DummyContext()
+    await ctx.set_state("unity_instance", INSTANCE)
+
+    captured = {}
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        if command_type == "refresh_unity":
+            captured["params"] = params
+            return {"success": True, "message": "Refreshed."}
+        raise ValueError(f"Unexpected command: {command_type}")
+
+    monkeypatch.setattr(refresh_mod.unity_transport,
+                        "send_with_unity_instance", fake_send_with_unity_instance)
+
+    await refresh_unity(ctx, mode="force", scope="all", compile="none",
+                         wait_for_ready=True, allow_during_play=True)
+
+    assert captured["params"]["allow_during_play"] is True
+
+
+@pytest.mark.asyncio
+async def test_play_mode_active_rejection_is_not_retried_or_masked_as_success(monkeypatch):
+    """A play_mode_active refusal must surface as a real failure -- not be
+    mistaken for the "connection lost because compile triggered a reload"
+    success path, and not be silently retried like a reloading-rejection."""
+    from services.tools.refresh_unity import refresh_unity
+    import services.tools.refresh_unity as refresh_mod
+
+    ctx = DummyContext()
+    await ctx.set_state("unity_instance", INSTANCE)
+
+    refresh_calls = []
+
+    async def fake_send_with_unity_instance(send_fn, unity_instance, command_type, params, **kwargs):
+        if command_type == "refresh_unity":
+            refresh_calls.append(params)
+            return {
+                "success": False,
+                "error": "play_mode_active",
+                "data": {
+                    "reason": "play_mode_active",
+                    "message": "refresh_unity was refused because Play mode is active.",
+                },
+            }
+        raise ValueError(f"Unexpected command: {command_type}")
+
+    monkeypatch.setattr(refresh_mod.unity_transport,
+                        "send_with_unity_instance", fake_send_with_unity_instance)
+
+    resp = await refresh_unity(ctx, mode="force", scope="all", compile="request", wait_for_ready=True)
+    payload = resp.model_dump() if hasattr(resp, "model_dump") else resp
+
+    # Not retried: exactly one attempt, even though compile="request" would
+    # normally retry a "connection lost" / "reloading" rejection.
+    assert len(refresh_calls) == 1
+    assert payload["success"] is False


### PR DESCRIPTION
## Summary

Fixes #66. With more than one Unity Editor connected, `/api/command`
(the `execute_custom_tool` / default-session path) and
`/api/custom-tools` fell back to `next(iter(sessions.sessions.keys()))`
-- dict insertion order -- whenever no explicit `unity_instance` was
given. That silently routes the call to whichever project happened to
register first: the request still succeeds, it's just answered by a
different Unity instance than the caller is working in.
`UnityInstanceMiddleware._maybe_autoselect_instance` had the analogous
gap on the tool-call path: with >1 connected instances it correctly
declined to guess, but never tried to disambiguate first either.

Relates to #67 (see second commit below).

## Changes (#66)

- New `transport/instance_selection.py`: `select_sole_match_by_cwd`, a
  shared helper that prefers the *sole* connected session whose
  `project_path` (normalizing away a reported `Assets/` subfolder)
  contains the server process's `cwd` -- the directory the MCP client
  was launched from. Returns `None` on zero or multiple matches so
  callers keep their previous (explicit-selection-required) behaviour
  rather than guessing between ambiguous candidates.
- `transport/models.py`: `SessionDetails` gains an additive
  `project_path: str | None = None` field.
- `transport/plugin_hub.py`: `PluginHub.get_sessions()` now populates
  `project_path` from the internal `PluginSession` (it already carried
  the field; it just wasn't surfaced in the API-facing DTO).
- `main.py`: both CLI-route fallbacks now go through a new
  `_select_default_session_id(sessions)` helper built on
  `select_sole_match_by_cwd`.
- `transport/unity_instance_middleware.py`:
  `_maybe_autoselect_instance`'s `len(ids) > 1` branch now also tries
  the cwd match before falling back to "ask the caller to disambiguate".

## Changes (relates to #67) -- second commit

The C# guard in #75 (`RefreshUnity.cs`) refuses a refresh/compile while
Play mode is active unless the caller passes `allow_during_play=true`.
Without a Python-side change, that new parameter has no way to reach
Unity through the MCP tool surface. This commit adds
`allow_during_play` to the `refresh_unity` tool signature, forwards it
in the outgoing params (default `False`), and verifies a
`play_mode_active` rejection is surfaced as a normal failure rather
than being mistaken for the "connection lost because compile triggered
a reload" success path, or silently retried like a reloading
rejection.

## Testing

Baseline established on clean `origin/beta` before any changes:

```
12 failed, 1522 passed in 32.53s
```

All 12 pre-existing failures are in `tests/integration/test_manage_physics.py`
and `tests/integration/test_manage_profiler.py` (unrelated to this change --
confirmed identical failure set before and after every commit below).

After the #66 commit:

```
12 failed, 1538 passed in 29.89s
```

After the #67-plumbing commit:

```
12 failed, 1541 passed in 29.80s
```

Same 12 pre-existing failures throughout, byte-identical set of failing
test names. 19 new tests added across both commits, all passing:

- `tests/test_instance_selection.py` (9) -- unit tests for
  `normalize_project_root` / `select_sole_match_by_cwd`.
- `tests/integration/test_cli_route_instance_selection.py` (5) -- exercises
  `main._select_default_session_id` directly (registers the "wrong"
  session first so a naive first-available fallback would deterministically
  pick it, proving selection is cwd-driven).
- `tests/integration/test_instance_autoselect.py` (+2) -- exercises
  `_maybe_autoselect_instance`'s new cwd-preference branch, plus a
  regression test proving the ambiguous-match case still declines to guess.
- `tests/test_refresh_unity_play_mode_guard.py` (3) -- `allow_during_play`
  defaults/forwarding, and the play_mode_active-is-not-retried-or-masked
  check.

Every new regression test was confirmed **failing** against the pre-fix
code before its fix landed (`git stash` on the relevant `src/` files
reproduced either an `AttributeError`, an `AssertionError`, a `KeyError`,
or a `TypeError` depending on the test -- see individual commits).

## Notes for reviewers

- Scope of the #66 fix is intentionally limited to the
  `PluginHub`/HTTP-remote-hosted path. The legacy stdio connection-pool
  path (`transport/legacy/unity_connection.py`, used when
  `transport != "http"`) doesn't expose `project_path` on its
  `UnityInstanceInfo` and is structurally single-instance-per-server-process
  (each stdio server is a distinct process bound to one port/project), so
  there's no analogous ambiguity to resolve there.
- The #67-plumbing commit has no effect until #75 (the C# guard) merges --
  it's inert additive JSON on older Unity-side builds.
- `uv.lock` is unchanged in this PR (a local `uv run` sync artifact was
  reverted before committing).