### PR TITLE
fix(unity): guard refresh_unity + manage_editor play against Play-mode DOTS World loss

### DIFF
--- a/MCPForUnity/Editor/Services/RunInBackgroundPlayGuard.cs
+++ b/MCPForUnity/Editor/Services/RunInBackgroundPlayGuard.cs
@@ -1,0 +1,103 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace MCPForUnity.Editor.Services
+{
+    /// <summary>
+    /// Mitigates an unfocused-editor Play-mode stall (issue #62): with the
+    /// consuming project's Player Setting "Run In Background" disabled, an
+    /// editor window that never holds OS focus can silently stop advancing
+    /// the *player* loop while remaining fully MCP-responsive (the editor
+    /// loop keeps ticking). <c>manage_editor action=play</c> opts into this
+    /// guard by default; it sets <see cref="Application.runInBackground"/>
+    /// for the duration of the Play session and restores it on the first
+    /// <see cref="EditorApplication.playModeStateChanged"/> transition back
+    /// to Edit mode -- whichever path triggered it: our own "stop" action,
+    /// the user clicking Stop in the Editor, or a script-driven stop
+    /// elsewhere. Unity's own PlayMode test runner does the equivalent
+    /// set/restore around a test run
+    /// (<c>PreparePlayModeRunTask</c> / <c>RestoreProjectSettingsTask</c>).
+    ///
+    /// <para>
+    /// <see cref="Application.runInBackground"/> writes through to
+    /// <c>PlayerSettings.runInBackground</c>, which serializes into the
+    /// tracked <c>ProjectSettings/ProjectSettings.asset</c> -- so an aborted
+    /// restore leaves a diff behind. <see cref="SessionState"/> survives the
+    /// domain reload that entering/exiting Play mode can trigger ("Enter
+    /// Play Mode Settings" -> Reload Domain), so the original value and the
+    /// "we changed it" flag are recoverable across that reload.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Known, accepted gap:</b> this does NOT survive an editor quit or
+    /// crash that happens while the guard is still active (i.e. Play mode
+    /// never reached <see cref="PlayModeStateChange.EnteredEditMode"/>
+    /// before the process exited). <see cref="SessionState"/> is in-memory
+    /// only and is gone on the next launch, so there is nothing left to read
+    /// at startup that would tell a future session "restore
+    /// runInBackground". Closing that gap needs a project-local marker file
+    /// read on every editor startup (a larger, untested-here change) --
+    /// documented as a known limitation rather than silently risked.
+    /// </para>
+    /// </summary>
+    [InitializeOnLoad]
+    public static class RunInBackgroundPlayGuard
+    {
+        private const string SessionKeyDirty = "MCPForUnity.RunInBackgroundGuard.Dirty";
+        private const string SessionKeyOriginalValue = "MCPForUnity.RunInBackgroundGuard.OriginalValue";
+
+        static RunInBackgroundPlayGuard()
+        {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        /// <summary>
+        /// Call before setting <c>EditorApplication.isPlaying = true</c> from
+        /// the manage_editor "play" action. No-op when
+        /// <see cref="Application.runInBackground"/> is already true, or when
+        /// a previously-armed guard has not yet been restored (avoids
+        /// clobbering the recorded original value with an already-mutated
+        /// "current" value on a re-entrant/duplicate play request).
+        /// </summary>
+        public static void OnEnteringPlayMode()
+        {
+            if (SessionState.GetBool(SessionKeyDirty, false))
+            {
+                return;
+            }
+
+            bool original = Application.runInBackground;
+            if (original)
+            {
+                // Already backgrounded -- nothing to mitigate or restore later.
+                return;
+            }
+
+            SessionState.SetBool(SessionKeyOriginalValue, original);
+            SessionState.SetBool(SessionKeyDirty, true);
+            Application.runInBackground = true;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange change)
+        {
+            if (change != PlayModeStateChange.EnteredEditMode)
+            {
+                return;
+            }
+            Restore();
+        }
+
+        private static void Restore()
+        {
+            if (!SessionState.GetBool(SessionKeyDirty, false))
+            {
+                return;
+            }
+
+            bool original = SessionState.GetBool(SessionKeyOriginalValue, false);
+            Application.runInBackground = original;
+            SessionState.EraseBool(SessionKeyDirty);
+            SessionState.EraseBool(SessionKeyOriginalValue);
+        }
+    }
+}

--- a/MCPForUnity/Editor/Services/RunInBackgroundPlayGuard.cs.meta
+++ b/MCPForUnity/Editor/Services/RunInBackgroundPlayGuard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bdd41e1ec5d4012ac3ec89fa8c64ccc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MCPForUnity/Editor/Tools/ManageEditor.cs
+++ b/MCPForUnity/Editor/Tools/ManageEditor.cs
@@ -55,6 +55,18 @@ namespace MCPForUnity.Editor.Tools
                     {
                         if (!EditorApplication.isPlaying)
                         {
+                            // Mitigates issue #62: an unfocused editor with Player Settings
+                            // "Run In Background" disabled can silently stop advancing the
+                            // player loop while remaining fully MCP-responsive. Defaults on
+                            // because an unattended/unfocused editor is this fork's whole
+                            // premise; pass run_in_background=false to opt out (it writes
+                            // through to the tracked ProjectSettings.asset for the duration
+                            // of the Play session -- see RunInBackgroundPlayGuard for the
+                            // restore contract and its known editor-quit-mid-session gap).
+                            if (p.GetBool("run_in_background", true))
+                            {
+                                RunInBackgroundPlayGuard.OnEnteringPlayMode();
+                            }
                             EditorApplication.isPlaying = true;
                             return new SuccessResponse("Entered play mode.");
                         }

--- a/MCPForUnity/Editor/Tools/RefreshUnity.cs
+++ b/MCPForUnity/Editor/Tools/RefreshUnity.cs
@@ -24,6 +24,7 @@ namespace MCPForUnity.Editor.Tools
             string scope = @params?["scope"]?.ToString() ?? "all";
             string compile = @params?["compile"]?.ToString() ?? "none";
             bool waitForReady = ParamCoercion.CoerceBool(@params?["wait_for_ready"], false);
+            bool allowDuringPlay = ParamCoercion.CoerceBool(@params?["allow_during_play"], false);
 
             if (TestRunStatus.IsRunning)
             {
@@ -31,6 +32,29 @@ namespace MCPForUnity.Editor.Tools
                 {
                     reason = "tests_running",
                     retry_after_ms = 5000
+                });
+            }
+
+            // A refresh/compile triggered while Play mode is live forces a domain reload.
+            // On a DOTS project that reload permanently disposes the ECS Default World for
+            // the rest of the Play session -- nothing recreates it until Play is stopped and
+            // re-entered (Unity.Entities only rebuilds it via a BeforeSceneLoad bootstrap,
+            // which does not re-fire mid-Play), and any SubScene-baked content goes with it.
+            // The managed/DI side restarts and keeps rendering, so the failure surfaces later
+            // as an unrelated-looking null-world exception. Refuse by default; an explicit
+            // allow_during_play=true opts back in for callers who understand the consequence.
+            // Deliberately NOT auto-recreating the World here -- a rebuilt World would carry
+            // no baked SubScene content, trading a loud failure for a silent, wrong one.
+            if (EditorApplication.isPlaying && !allowDuringPlay)
+            {
+                return new ErrorResponse("play_mode_active", new
+                {
+                    reason = "play_mode_active",
+                    message = "refresh_unity was refused because Play mode is active. Refreshing/compiling " +
+                        "during Play triggers a domain reload that permanently disposes the DOTS Default World " +
+                        "for the rest of this Play session (nothing recreates it until Play is stopped and " +
+                        "re-entered) and drops any SubScene-baked content. Stop Play mode first, or pass " +
+                        "allow_during_play=true if you understand and accept this.",
                 });
             }
 


### PR DESCRIPTION
## Summary

C#-only. Companion Python PR for the `refresh_unity` param plumbing:
(opened separately, see below). **This PR is UNVERIFIED** -- this session
has no compiled Unity Editor available. Everything below is a static-review
change; see "What a Unity-side reviewer must check" before merging.

### Fixes #67 -- refresh_unity mid-Play domain reload destroys the DOTS Default World

`RefreshUnity.cs` forces `AssetDatabase.Refresh` / `CompilationPipeline.RequestScriptCompilation()`
unconditionally, including while Play mode is live. On a DOTS project the resulting domain
reload permanently disposes the ECS `Default World` for the rest of the Play session --
`Unity.Entities.Hybrid`'s only recreation path is a `[RuntimeInitializeOnLoadMethod(BeforeSceneLoad)]`
bootstrap, which does not re-fire mid-Play. VContainer's Mono-side container restarts and keeps
the game apparently running (HUD, screens, third-party SDKs), so the resulting null-world
exception surfaces later and reads as an unrelated DOTS/DI coexistence bug.

Added a guard mirroring the existing `TestRunStatus.IsRunning` early-return in the same method:
refuse when `EditorApplication.isPlaying` is true, naming the consequence in the error, unless
the caller passes `allow_during_play=true`. Deliberately does **not** attempt to auto-recreate
the World on the far side of a reload -- a rebuilt World would carry no baked SubScene content,
trading a loud failure for a silent, wrong one (explicitly called out as the wrong direction in
the issue).

### Mitigates #62 -- unfocused editor stalls the Play-mode player loop

With the consuming project's Player Setting "Run In Background" off, an editor window that
never holds OS focus can silently stop advancing the *player* loop while remaining fully
MCP-responsive (the *editor* loop keeps ticking -- confirmed by the issue's own
`PerformanceSessionRecorder` evidence: 25k editor updates/sec against 0 game fps). The existing
`EditorApplication.QueuePlayerLoopUpdate()` nudge (11 call sites) keeps the editor loop serviced
but does not revive a stalled player loop.

New `RunInBackgroundPlayGuard` (`MCPForUnity/Editor/Services/`): `manage_editor action=play` now
sets `Application.runInBackground = true` for the duration of the Play session (default on --
an unattended/unfocused editor is this fork's whole premise; `run_in_background=false` opts out)
and restores it on the first `EditorApplication.playModeStateChanged` transition back to
`EnteredEditMode`, whichever path triggered it (our own `stop` action, the user clicking Stop,
or a script-driven stop). This mirrors Unity's own PlayMode test runner
(`PreparePlayModeRunTask` / `RestoreProjectSettingsTask`), which the issue's own follow-up
comment cited as precedent.

**Known, disclosed gap** (flagged in the issue as a real cost to account for): `Application.runInBackground`
writes through to `PlayerSettings.runInBackground`, which serializes into the tracked
`ProjectSettings/ProjectSettings.asset`. `SessionState` (used here to record the original value
and a "dirty" flag) survives the domain reload that entering/exiting Play mode can trigger, so
the restore is robust across that. It does **not** survive an editor quit/crash while the guard
is still armed -- `SessionState` is in-memory-only and is gone on the next launch, so there is
nothing to read at startup that would trigger a restore. Closing that fully would need a
project-local marker file read on every editor startup; that's a larger, untested-here change,
so it's documented as a known limitation in the class doc-comment rather than silently risked.

## Skipped from this batch

- **#65** (pointer position write never lands) -- the reporter's own issue text says the
  buffer-attribution root cause (`InputState.Change` landing in the editor update-type's state
  buffer rather than the player's) is "a strong inference, not a direct observation" and asks
  for buffer-level confirmation before committing to a fix. Reading the actual `com.unity.inputsystem`
  source (`InputManager.defaultUpdateType`) shows the Editor-vs-Player buffer resolution depends
  on live runtime state (`m_CurrentUpdate`, `gameIsPlaying`, `gameHasFocus`) that only a live Play
  session can answer, and the reporter's own two-arm test already leaves the "Unity window
  focused" arm undelivered without a confirmed explanation. Rewriting `Move()` to route through
  the queued-`StateEvent` path would also change the semantics of every other call site
  (`MouseMove`, `Scroll`, `Drag`, `DoClick`) that currently depends on `Move()`'s immediate
  application via `InputState.Change`. Not attempted here -- needs a live Unity session to
  confirm the mechanism before a fix is safe to write blind.

## What a Unity-side reviewer must check (this session could not)

- `RefreshUnity.cs` compiles and the new early-return doesn't shadow any existing symbol.
- `ManageEditor.cs` + the new `RunInBackgroundPlayGuard.cs` compile; `[InitializeOnLoad]` static
  constructor actually re-subscribes `playModeStateChanged` after a domain reload as expected
  (this is the standard Unity idiom, but confirm in this specific fork).
- End-to-end: `manage_editor action=play` on an unfocused editor with `Run In Background`
  initially off -- confirm `Application.runInBackground` flips to `true`, restores to `false` on
  Stop, and `ProjectSettings.asset` shows no diff after a normal play/stop cycle.
- `refresh_unity` with `compile="request"` while Play mode is active now returns
  `play_mode_active` instead of triggering a reload -- confirm the World survives.
- The `RunInBackgroundPlayGuard.cs.meta` GUID (`4bdd41e1ec5d4012ac3ec89fa8c64ccc`) was
  hand-generated (no Unity Editor available to auto-generate it) -- confirm Unity accepts it and
  it doesn't collide with an existing asset.

## Testing

None -- this session cannot compile or run Unity. Do not treat as verified.