### PR TITLE
fix(transport): refuse to auto-select the sole Unity instance when it belongs to another project

### DIFF
--- a/Server/src/core/config.py
+++ b/Server/src/core/config.py
@@ -21,6 +21,12 @@ class ServerConfig:
     # HTTP transport behaviour
     http_remote_hosted: bool = False
 
+    # Auto-selection behaviour: when the sole connected Unity instance belongs to
+    # a project that shares no ancestry with the server's cwd, refuse to select it
+    # rather than silently driving the wrong Editor (#61). Set True to restore the
+    # legacy "select whatever is registered" behaviour.
+    allow_cross_project_autoselect: bool = False
+
     # API key authentication (required when http_remote_hosted=True)
     api_key_validation_url: str | None = None  # POST endpoint to validate keys
     api_key_login_url: str | None = None       # URL for users to get/manage keys

--- a/Server/src/main.py
+++ b/Server/src/main.py
@@ -828,6 +828,11 @@ Examples:
         or os.environ.get("UNITY_MCP_HTTP_REMOTE_HOSTED", "").lower() in ("true", "1", "yes", "on")
     )
 
+    config.allow_cross_project_autoselect = (
+        os.environ.get("UNITY_MCP_ALLOW_CROSS_PROJECT_AUTOSELECT", "").lower()
+        in ("true", "1", "yes", "on")
+    )
+
     # API key authentication configuration
     config.api_key_validation_url = (
         args.api_key_validation_url

--- a/Server/src/transport/instance_selection.py
+++ b/Server/src/transport/instance_selection.py
@@ -78,3 +78,50 @@ def select_sole_match_by_cwd(
     if len(matches) == 1:
         return matches[0]
     return None
+
+
+class CrossProjectAutoSelectError(RuntimeError):
+    """Raised when the sole connected instance belongs to an unrelated project.
+
+    Auto-selecting in that situation is the #61 footgun: the call succeeds, it
+    is just answered by a Unity Editor the caller never meant to touch. Carrying
+    a dedicated type (rather than a bare ``ValueError``) keeps the refusal from
+    being swallowed by the broad "auto-select probe failed" handlers around the
+    discovery calls, which deliberately degrade to "no instance" on transport
+    errors.
+    """
+
+
+def is_project_unrelated_to_cwd(project_path: str | None, cwd: str | None = None) -> bool:
+    """Report whether ``project_path`` provably shares no ancestry with ``cwd``.
+
+    "Related" is deliberately wider than :func:`select_sole_match_by_cwd`'s
+    containment test: a client is routinely launched from a monorepo root that
+    *contains* the Unity project, so an ancestor cwd counts as related too. Only
+    genuinely disjoint paths -- neither one an ancestor of the other -- are
+    reported unrelated.
+
+    Returns ``False`` whenever the answer cannot be established (missing or
+    unresolvable ``project_path``, unreadable cwd), so an unknown path never
+    blocks a selection that the previous behaviour would have made.
+    """
+    root = normalize_project_root(project_path)
+    if root is None:
+        return False
+    if cwd is None:
+        try:
+            cwd = os.getcwd()
+        except OSError:
+            return False
+    try:
+        cwd = os.path.realpath(cwd)
+    except OSError:
+        return False
+
+    if cwd == root:
+        return False
+    if cwd.startswith(root + os.sep):
+        return False  # cwd sits inside the project
+    if root.startswith(cwd + os.sep):
+        return False  # the project sits inside cwd (monorepo / parent-dir launch)
+    return True

--- a/Server/src/transport/unity_instance_middleware.py
+++ b/Server/src/transport/unity_instance_middleware.py
@@ -6,6 +6,7 @@ into the request-scoped state, allowing tools to access it via ctx.get_state("un
 """
 from threading import RLock
 import logging
+import os
 import time
 
 from fastmcp.server.middleware import Middleware, MiddlewareContext
@@ -13,7 +14,12 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 from core.config import config
 from services.registry import get_registered_tools
 from transport.plugin_hub import PluginHub
-from transport.instance_selection import select_sole_match_by_cwd
+from transport.instance_selection import (
+    CrossProjectAutoSelectError,
+    is_project_unrelated_to_cwd,
+    normalize_project_root,
+    select_sole_match_by_cwd,
+)
 
 logger = logging.getLogger("mcp-for-unity-server")
 # Separate logger that propagates to root -> stderr so diagnostics show in console
@@ -225,6 +231,33 @@ class UnityInstanceMiddleware(Middleware):
             "Read mcpforunity://instances for current sessions."
         )
 
+    @staticmethod
+    def _reject_cross_project_autoselect(
+        instance_id: str, project_path: str | None
+    ) -> None:
+        """Refuse to auto-select the sole instance when it is another project's.
+
+        A single registered instance used to be selected unconditionally, so a
+        project whose own Editor bridge never came up had its tool calls answered
+        by whatever unrelated Editor happened to be listening -- successfully, and
+        with no warning (#61). Fail loudly instead, naming both paths so the caller
+        can tell at a glance which Editor is missing.
+        """
+        if config.allow_cross_project_autoselect:
+            return
+        if not is_project_unrelated_to_cwd(project_path):
+            return
+        raise CrossProjectAutoSelectError(
+            f"Refusing to auto-select '{instance_id}': it is the only connected "
+            f"Unity instance, but its project ({normalize_project_root(project_path)}) "
+            f"is unrelated to this session's working directory ({os.getcwd()}). "
+            "The Editor for this project is most likely not running or its bridge "
+            "failed to start. Pass unity_instance (or call set_active_instance) to "
+            "target it deliberately, read mcpforunity://instances for current "
+            "sessions, or set UNITY_MCP_ALLOW_CROSS_PROJECT_AUTOSELECT=1 to restore "
+            "the previous behaviour."
+        )
+
     async def _maybe_autoselect_instance(self, ctx) -> str | None:
         """
         Auto-select the sole Unity instance when no active instance is set.
@@ -255,6 +288,8 @@ class UnityInstanceMiddleware(Middleware):
                                 (instance_id, getattr(session_info, "project_path", None)))
                     if len(ids) == 1:
                         chosen = ids[0]
+                        self._reject_cross_project_autoselect(
+                            chosen, ids_with_path[0][1])
                         await self.set_active_instance(ctx, chosen)
                         logger.info(
                             "Auto-selected sole Unity instance via PluginHub: %s",
@@ -286,7 +321,7 @@ class UnityInstanceMiddleware(Middleware):
                         exc_info=True,
                     )
                 except Exception as exc:
-                    if isinstance(exc, (SystemExit, KeyboardInterrupt)):
+                    if isinstance(exc, (SystemExit, KeyboardInterrupt, CrossProjectAutoSelectError)):
                         raise
                     logger.debug(
                         "PluginHub auto-select probe failed with unexpected error (%s); falling back to stdio",
@@ -301,10 +336,16 @@ class UnityInstanceMiddleware(Middleware):
 
                     pool = get_unity_connection_pool()
                     instances = pool.discover_all_instances(force_refresh=True)
-                    ids = [getattr(inst, "id", None) for inst in instances]
-                    ids = [inst_id for inst_id in ids if inst_id]
+                    ids_with_path = [
+                        (getattr(inst, "id", None), getattr(inst, "path", None))
+                        for inst in instances
+                    ]
+                    ids_with_path = [pair for pair in ids_with_path if pair[0]]
+                    ids = [inst_id for inst_id, _ in ids_with_path]
                     if len(ids) == 1:
                         chosen = ids[0]
+                        self._reject_cross_project_autoselect(
+                            chosen, ids_with_path[0][1])
                         await self.set_active_instance(ctx, chosen)
                         logger.info(
                             "Auto-selected sole Unity instance via stdio discovery: %s",
@@ -324,7 +365,7 @@ class UnityInstanceMiddleware(Middleware):
                         exc_info=True,
                     )
                 except Exception as exc:
-                    if isinstance(exc, (SystemExit, KeyboardInterrupt)):
+                    if isinstance(exc, (SystemExit, KeyboardInterrupt, CrossProjectAutoSelectError)):
                         raise
                     logger.debug(
                         "Stdio auto-select probe failed with unexpected error (%s)",
@@ -332,7 +373,7 @@ class UnityInstanceMiddleware(Middleware):
                         exc_info=True,
                     )
         except Exception as exc:
-            if isinstance(exc, (SystemExit, KeyboardInterrupt)):
+            if isinstance(exc, (SystemExit, KeyboardInterrupt, CrossProjectAutoSelectError)):
                 raise
             logger.debug(
                 "Auto-select path encountered an unexpected error (%s)",

--- a/Server/tests/integration/test_instance_autoselect.py
+++ b/Server/tests/integration/test_instance_autoselect.py
@@ -239,3 +239,167 @@ async def test_no_autoselect_when_multiple_pluginhub_instances_dont_disambiguate
 
     assert selected is None
     assert await middleware.get_active_instance(ctx) is None
+
+
+def _single_session_plugin_hub(monkeypatch, *, project_path):
+    """Install a PluginHub stub reporting exactly one session at ``project_path``."""
+    plugin_hub = types.ModuleType("transport.plugin_hub")
+
+    class PluginHub:
+        @classmethod
+        def is_configured(cls) -> bool:
+            return True
+
+        @classmethod
+        async def get_sessions(cls):
+            return SimpleNamespace(
+                sessions={
+                    "session-a": SimpleNamespace(
+                        project="ProjectA",
+                        hash="aaaaaaaa",
+                        project_path=project_path,
+                    ),
+                }
+            )
+
+    plugin_hub.PluginHub = PluginHub
+    monkeypatch.setitem(sys.modules, "transport.plugin_hub", plugin_hub)
+    monkeypatch.delitem(
+        sys.modules, "transport.unity_instance_middleware", raising=False)
+    monkeypatch.setattr(config, "transport_mode", "http")
+    monkeypatch.setattr(config, "allow_cross_project_autoselect", False)
+
+
+@pytest.mark.asyncio
+async def test_refuses_sole_pluginhub_instance_from_an_unrelated_project(monkeypatch, tmp_path):
+    """#61: one registered instance is not a licence to drive it.
+
+    The reporting project's Editor bridge failed to compile, so the only session
+    on the hub belonged to a different project -- and every tool call was answered
+    by it, successfully and silently. Refuse instead, naming both paths.
+    """
+    project_a = tmp_path / "ProjectA"
+    elsewhere = tmp_path / "ProjectB"
+    project_a.mkdir()
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    _single_session_plugin_hub(monkeypatch, project_path=str(project_a))
+    from transport.unity_instance_middleware import (
+        UnityInstanceMiddleware,
+        CrossProjectAutoSelectError,
+    )
+
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    with pytest.raises(CrossProjectAutoSelectError) as excinfo:
+        await middleware._maybe_autoselect_instance(ctx)
+
+    message = str(excinfo.value)
+    assert str(project_a) in message
+    assert str(elsewhere) in message
+    # The refusal must not leave a half-applied selection behind.
+    assert await middleware.get_active_instance(ctx) is None
+
+
+@pytest.mark.asyncio
+async def test_selects_sole_pluginhub_instance_when_cwd_is_inside_it(monkeypatch, tmp_path):
+    project_a = tmp_path / "ProjectA"
+    (project_a / "Assets").mkdir(parents=True)
+    monkeypatch.chdir(project_a / "Assets")
+
+    _single_session_plugin_hub(monkeypatch, project_path=str(project_a))
+    from transport.unity_instance_middleware import UnityInstanceMiddleware
+
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    assert await middleware._maybe_autoselect_instance(ctx) == "ProjectA@aaaaaaaa"
+
+
+@pytest.mark.asyncio
+async def test_selects_sole_pluginhub_instance_when_cwd_contains_it(monkeypatch, tmp_path):
+    """Monorepo launch: the client runs from a root that holds the Unity project."""
+    repo = tmp_path / "repo"
+    project_a = repo / "ProjectA"
+    project_a.mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    _single_session_plugin_hub(monkeypatch, project_path=str(project_a))
+    from transport.unity_instance_middleware import UnityInstanceMiddleware
+
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    assert await middleware._maybe_autoselect_instance(ctx) == "ProjectA@aaaaaaaa"
+
+
+@pytest.mark.asyncio
+async def test_opt_out_restores_legacy_cross_project_autoselect(monkeypatch, tmp_path):
+    project_a = tmp_path / "ProjectA"
+    elsewhere = tmp_path / "ProjectB"
+    project_a.mkdir()
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    _single_session_plugin_hub(monkeypatch, project_path=str(project_a))
+    monkeypatch.setattr(config, "allow_cross_project_autoselect", True)
+    from transport.unity_instance_middleware import UnityInstanceMiddleware
+
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    assert await middleware._maybe_autoselect_instance(ctx) == "ProjectA@aaaaaaaa"
+
+
+@pytest.mark.asyncio
+async def test_refuses_sole_stdio_instance_from_an_unrelated_project(monkeypatch, tmp_path):
+    """The stdio discovery path reports the Assets folder; it needs the same guard."""
+    project_a = tmp_path / "ProjectA"
+    elsewhere = tmp_path / "ProjectB"
+    (project_a / "Assets").mkdir(parents=True)
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    plugin_hub = types.ModuleType("transport.plugin_hub")
+
+    class PluginHub:
+        @classmethod
+        def is_configured(cls) -> bool:
+            return False
+
+    plugin_hub.PluginHub = PluginHub
+    monkeypatch.setitem(sys.modules, "transport.plugin_hub", plugin_hub)
+    monkeypatch.delitem(
+        sys.modules, "transport.unity_instance_middleware", raising=False)
+    monkeypatch.setattr(config, "transport_mode", "stdio")
+    monkeypatch.setattr(config, "allow_cross_project_autoselect", False)
+
+    class PoolStub:
+        def discover_all_instances(self, force_refresh=False):
+            return [SimpleNamespace(
+                id="ProjectA@cc8756d4", path=str(project_a / "Assets"))]
+
+    unity_connection = types.ModuleType("transport.legacy.unity_connection")
+    unity_connection.get_unity_connection_pool = lambda: PoolStub()
+    monkeypatch.setitem(
+        sys.modules, "transport.legacy.unity_connection", unity_connection)
+
+    from transport.unity_instance_middleware import (
+        UnityInstanceMiddleware,
+        CrossProjectAutoSelectError,
+    )
+
+    middleware = UnityInstanceMiddleware()
+    ctx = DummyContext()
+    ctx.client_id = "client-1"
+
+    with pytest.raises(CrossProjectAutoSelectError):
+        await middleware._maybe_autoselect_instance(ctx)
+
+    assert await middleware.get_active_instance(ctx) is None

--- a/Server/tests/test_instance_selection.py
+++ b/Server/tests/test_instance_selection.py
@@ -1,7 +1,11 @@
 """Unit tests for transport.instance_selection (the shared cwd-preference helper)."""
 from __future__ import annotations
 
-from transport.instance_selection import normalize_project_root, select_sole_match_by_cwd
+from transport.instance_selection import (
+    is_project_unrelated_to_cwd,
+    normalize_project_root,
+    select_sole_match_by_cwd,
+)
 
 
 def test_normalize_project_root_strips_trailing_assets(tmp_path):
@@ -101,3 +105,79 @@ def test_select_sole_match_by_cwd_defaults_to_os_getcwd(tmp_path, monkeypatch):
     result = select_sole_match_by_cwd([("id-a", str(project))])
 
     assert result == "id-a"
+
+
+# --- is_project_unrelated_to_cwd (#61) -------------------------------------
+#
+# These pin the REFUSAL state, not just the pass state: the guard exists to say
+# "no" to a disjoint project, so a version that can never return True would be
+# decoration. Every "related" case below is a launch position we must NOT break.
+
+
+def test_unrelated_when_project_and_cwd_are_disjoint(tmp_path):
+    project = tmp_path / "ProjectA"
+    elsewhere = tmp_path / "ProjectB"
+    project.mkdir()
+    elsewhere.mkdir()
+
+    assert is_project_unrelated_to_cwd(str(project), cwd=str(elsewhere)) is True
+
+
+def test_related_when_cwd_is_the_project_root(tmp_path):
+    project = tmp_path / "ProjectA"
+    project.mkdir()
+
+    assert is_project_unrelated_to_cwd(str(project), cwd=str(project)) is False
+
+
+def test_related_when_cwd_is_inside_the_project(tmp_path):
+    nested = tmp_path / "ProjectA" / "Assets" / "Scripts"
+    nested.mkdir(parents=True)
+
+    assert is_project_unrelated_to_cwd(
+        str(tmp_path / "ProjectA"), cwd=str(nested)) is False
+
+
+def test_related_when_project_is_inside_cwd(tmp_path):
+    """Monorepo / parent-dir launch: the client's cwd contains the Unity project."""
+    project = tmp_path / "repo" / "UnityProject"
+    project.mkdir(parents=True)
+
+    assert is_project_unrelated_to_cwd(
+        str(project), cwd=str(tmp_path / "repo")) is False
+
+
+def test_related_when_project_path_reports_the_assets_folder(tmp_path):
+    """stdio discovery reports the Assets folder, not the project root."""
+    project = tmp_path / "repo" / "UnityProject"
+    assets = project / "Assets"
+    assets.mkdir(parents=True)
+
+    assert is_project_unrelated_to_cwd(
+        str(assets), cwd=str(tmp_path / "repo")) is False
+
+
+def test_not_unrelated_when_project_path_is_unknown(tmp_path):
+    """Undeterminable must never block a selection the old code would have made."""
+    assert is_project_unrelated_to_cwd(None, cwd=str(tmp_path)) is False
+    assert is_project_unrelated_to_cwd("", cwd=str(tmp_path)) is False
+
+
+def test_sibling_prefix_paths_are_unrelated(tmp_path):
+    """/work/Game must not count as containing /work/GameTools (string-prefix trap)."""
+    project = tmp_path / "GameTools"
+    cwd = tmp_path / "Game"
+    project.mkdir()
+    cwd.mkdir()
+
+    assert is_project_unrelated_to_cwd(str(project), cwd=str(cwd)) is True
+
+
+def test_defaults_to_os_getcwd(tmp_path, monkeypatch):
+    project = tmp_path / "ProjectA"
+    elsewhere = tmp_path / "ProjectB"
+    project.mkdir()
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    assert is_project_unrelated_to_cwd(str(project)) is True


### PR DESCRIPTION
## What

When exactly one Unity instance is registered, `_maybe_autoselect_instance` selected it unconditionally. This PR refuses that selection when the instance's project shares no ancestry with the server session's cwd, raising a dedicated `CrossProjectAutoSelectError` that names both paths.

## Why

This is ask 3 of #61 — the report's most serious symptom:

> `manage_packages` / `refresh_unity` calls intended for project A were accepted and executed against project B, with no error and no warning. The only tell was `manage_packages ping` reporting a `unity_version` that did not match the target project's `ProjectVersion.txt`.

The failure is *silent success*: the reporting project's Editor bridge failed to compile, so it registered nothing, and the sole remaining instance — an unrelated project's Editor — answered everything.

The cwd guard added by #66 (`select_sole_match_by_cwd`) never covered this. It is invoked only in the `len(ids) > 1` branch at `unity_instance_middleware.py:269`, which is exactly *not* this scenario. Verified on `origin/beta` @ `b0fe829`: the `len(ids) == 1` branch went straight to `set_active_instance` with no path check on either the PluginHub or the stdio discovery path.

## Scope chosen, and why this option

Three options were on the table for "refuse a cross-project instance":

| Option | Rejected because |
|---|---|
| Require `set_active_instance` whenever no instance is active | Breaks every solo user working inside their project — the common happy path — for a defect that only occurs cross-project. |
| Refuse unless cwd is *contained by* the project root (reuse `select_sole_match_by_cwd` as-is) | Breaks the monorepo / parent-directory launch, where the client runs from a root that *holds* the Unity project. Large blast radius, unrelated to the defect. |
| **Refuse only on provably disjoint paths** ← chosen | Smallest blast radius that still fully closes the reported defect. Every legitimate launch position (inside the project, at its root, above it) still auto-selects. |

Two further deliberate choices:

- **An unknown `project_path` is never treated as unrelated.** `is_project_unrelated_to_cwd` returns `False` on any undeterminable input, so missing information can never block a selection the previous code would have made. This is what keeps the pre-existing `test_auto_selects_single_instance_via_pluginhub` (a session with no `project_path` at all) green.
- **A dedicated exception type, not a `ValueError`.** Both discovery calls sit inside broad `except Exception` "probe failed" handlers that deliberately degrade to *no instance* on transport errors — a `ValueError` would have been swallowed there and the refusal would have silently become "no auto-select", losing the diagnostic. `CrossProjectAutoSelectError` is re-raised alongside `SystemExit`/`KeyboardInterrupt` in the three handlers inside `_maybe_autoselect_instance`.

`on_call_tool` / `on_read_resource` propagate the refusal so the call fails loudly; `on_list_tools` already swallows injection failures, so tool listing keeps working.

Opt out with `UNITY_MCP_ALLOW_CROSS_PROJECT_AUTOSELECT=1` (`config.allow_cross_project_autoselect`) for a deliberate cross-project setup.

## Evidence

**The guard can go red.** Neutralising the check (`if config.allow_cross_project_autoselect:` → `if True:`) and re-running:

```
FAILED tests/integration/test_instance_autoselect.py::test_refuses_sole_pluginhub_instance_from_an_unrelated_project
FAILED tests/integration/test_instance_autoselect.py::test_refuses_sole_stdio_instance_from_an_unrelated_project
E       Failed: DID NOT RAISE CrossProjectAutoSelectError
2 failed, 8 passed
```

The other 8 stayed green, so those two tests are detecting the guard specifically, not incidental behaviour. Restored, all 10 pass.

The new unit tests pin the **refusal** state as well as the pass state — every "related" case is a launch position that must not break (cwd inside the project, cwd at the root, project inside cwd, an `Assets`-folder `project_path` from stdio discovery, and the string-prefix trap where `/work/Game` must not read as containing `/work/GameTools`).

**Full suite:** `1554 passed, 12 failed`. All 12 failures are pre-existing and unrelated — `tests/integration/test_manage_physics.py` (7) and `test_manage_profiler.py` (5). Confirmed by reverting every change in this PR and re-running those two files on pristine `beta`: **the same 12 fail identically**, `12 failed, 4 passed`.

Selection-related tests specifically: `32 passed` (`test_instance_selection.py`, `test_instance_autoselect.py`, `test_cli_route_instance_selection.py`).

## What remains on #61

This closes ask 3 only; the issue should stay open. The other two asks are environment-blocked, not deferrable to code review — verified against `origin/beta` rather than assumed:

- **Ask 1 (compile on 6000.5.x)** — the `ManageAsset.cs` CS0619 arm **is** fixed: `ManageAsset.cs:1148` now reads `while (asset.IsLoadingAssetPreviewCompat())`, shimmed behind `UNITY_6000_5_OR_NEWER` in `UnityObjectIdCompat.cs:82-93` (#64, merged). The `ManageInputSimulation.cs` CS0103/CS0165 arm is **not** explained by the optional-dependency theory in the issue comments: `git diff f6ffa19a..beta` over `ManageInputSimulation.cs` and `InputSimulation/` is **empty** — byte-identical to the version that failed — and `InputSimulationFocusGuard.cs` contains **no** `#if` directives at all, then or now, using only `UnityEditor`/`UnityEditorInternal` APIs. It was never gated behind `UNITY_INPUT_SYSTEM`. Clearing this arm needs a real 6000.5.x editor and the full `Logs/Editor.log` error list from a clean single-copy checkout. Worth testing the reporter's own "Also worth flagging" note first: `manifest.json` pointing at `file:com.coplaydev.unity-mcp-pkg` while the submodule sits at `Packages/com.coplaydev.unity-mcp` means two copies were present, and a stale one predating `InputSimulationFocusGuard.cs` would produce exactly CS0103 there.
- **Ask 2 (optional-dependency gating)** — `MCPForUnity.Editor.asmdef` is also byte-identical to the reported commit and still lists `Unity.Entities` / `Unity.InputSystem` / `Newtonsoft.Json` unconditionally under `references`. Needs a bare URP project with neither `com.unity.inputsystem` nor `com.unity.entities` to establish whether Unity errors or merely warns before a fix shape can be chosen. (One correction to the report: `Unity.RenderPipelines.HighDefinition.Runtime` appears in no MCPForUnity asmdef on `beta` — only in the vendored `TestProjects/AssetStoreUploads` asmdef.)
- **No CI gate covers 6000.5.** `tools/unity-versions.json` carries a `$coverageGap` field stating the `UNITY_6000_5_OR_NEWER` / `UNITY_6000_6_OR_NEWER` branches are unexercised because GameCI has published no image; the matrix is 2021.3.45f2 / 2022.3.62f1 / 6000.0.75f1 / 6000.4.8f1. That standing TODO is why this class of regression reached a consumer instead of a gate.

## Note on the base branch

Opened against `beta`, the repo's default branch. `origin/main` is the stale upstream release line (735 commits behind); the issue and all evidence were verified against `beta`.

Refs #61


t1k-claim: The1Studio/unity-mcp#61
