### PR TITLE
fix(tools): unblock beta release gate — stale physics/profiler tests + missing transport guard

### DIFF
--- a/Server/src/services/tools/manage_physics.py
+++ b/Server/src/services/tools/manage_physics.py
@@ -256,7 +256,10 @@ async def manage_physics(
         if val is not None:
             params_dict[key] = val
 
-    result = await send_with_unity_instance(
-        async_send_command_with_retry, unity_instance, "manage_physics", params_dict
-    )
+    try:
+        result = await send_with_unity_instance(
+            async_send_command_with_retry, unity_instance, "manage_physics", params_dict
+        )
+    except Exception as e:
+        return {"success": False, "message": f"Python error managing physics: {str(e)}"}
     return result if isinstance(result, dict) else {"success": False, "message": str(result)}

--- a/Server/src/services/tools/manage_profiler.py
+++ b/Server/src/services/tools/manage_profiler.py
@@ -100,7 +100,10 @@ async def manage_profiler(
         if val is not None:
             params_dict[key] = val
 
-    result = await send_with_unity_instance(
-        async_send_command_with_retry, unity_instance, "manage_profiler", params_dict
-    )
+    try:
+        result = await send_with_unity_instance(
+            async_send_command_with_retry, unity_instance, "manage_profiler", params_dict
+        )
+    except Exception as e:
+        return {"success": False, "message": f"Python error managing profiler: {str(e)}"}
     return result if isinstance(result, dict) else {"success": False, "message": str(result)}

--- a/Server/tests/integration/test_manage_physics.py
+++ b/Server/tests/integration/test_manage_physics.py
@@ -66,7 +66,7 @@ async def test_raycast_all_params(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_overlap_sphere_params(monkeypatch):
-    """overlap_sphere sends center, radius, layer_mask."""
+    """overlap with shape=sphere sends position, size, layer_mask."""
     captured = {}
     monkeypatch.setattr(
         physics_mod, "async_send_command_with_retry",
@@ -74,18 +74,20 @@ async def test_overlap_sphere_params(monkeypatch):
     )
 
     resp = await physics_mod.manage_physics(
-        ctx=DummyContext(), action="overlap_sphere",
-        center="0,0,0", radius=10.0, layer_mask=-1,
+        ctx=DummyContext(), action="overlap",
+        shape="sphere", position=[0.0, 0.0, 0.0], size=10.0, layer_mask="-1",
     )
 
     assert resp["success"] is True
-    assert captured["params"]["center"] == "0,0,0"
-    assert captured["params"]["radius"] == 10.0
+    assert captured["params"]["action"] == "overlap"
+    assert captured["params"]["shape"] == "sphere"
+    assert captured["params"]["position"] == [0.0, 0.0, 0.0]
+    assert captured["params"]["size"] == 10.0
 
 
 @pytest.mark.asyncio
 async def test_overlap_box_params(monkeypatch):
-    """overlap_box sends center, half_extents."""
+    """overlap with shape=box sends position and half-extent size."""
     captured = {}
     monkeypatch.setattr(
         physics_mod, "async_send_command_with_retry",
@@ -93,17 +95,18 @@ async def test_overlap_box_params(monkeypatch):
     )
 
     resp = await physics_mod.manage_physics(
-        ctx=DummyContext(), action="overlap_box",
-        center="0,0,0", half_extents="5,5,5",
+        ctx=DummyContext(), action="overlap",
+        shape="box", position=[0.0, 0.0, 0.0], size=[5.0, 5.0, 5.0],
     )
 
     assert resp["success"] is True
-    assert captured["params"]["half_extents"] == "5,5,5"
+    assert captured["params"]["shape"] == "box"
+    assert captured["params"]["size"] == [5.0, 5.0, 5.0]
 
 
 @pytest.mark.asyncio
-async def test_list_rigidbodies(monkeypatch):
-    """list_rigidbodies sends page_size."""
+async def test_validate_pagination_params(monkeypatch):
+    """validate sends page_size and cursor."""
     captured = {}
     monkeypatch.setattr(
         physics_mod, "async_send_command_with_retry",
@@ -111,11 +114,12 @@ async def test_list_rigidbodies(monkeypatch):
     )
 
     resp = await physics_mod.manage_physics(
-        ctx=DummyContext(), action="list_rigidbodies", page_size=20,
+        ctx=DummyContext(), action="validate", page_size=20, cursor=40,
     )
 
     assert resp["success"] is True
     assert captured["params"]["page_size"] == 20
+    assert captured["params"]["cursor"] == 40
 
 
 @pytest.mark.asyncio
@@ -139,8 +143,8 @@ async def test_get_rigidbody(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_set_rigidbody(monkeypatch):
-    """set_rigidbody sends target and properties."""
+async def test_configure_rigidbody(monkeypatch):
+    """configure_rigidbody sends target and properties."""
     captured = {}
     monkeypatch.setattr(
         physics_mod, "async_send_command_with_retry",
@@ -148,17 +152,18 @@ async def test_set_rigidbody(monkeypatch):
     )
 
     resp = await physics_mod.manage_physics(
-        ctx=DummyContext(), action="set_rigidbody",
-        target="Player", properties='{"mass": 5.0}',
+        ctx=DummyContext(), action="configure_rigidbody",
+        target="Player", properties={"mass": 5.0},
     )
 
     assert resp["success"] is True
-    assert captured["params"]["properties"] == '{"mass": 5.0}'
+    assert captured["params"]["action"] == "configure_rigidbody"
+    assert captured["params"]["properties"] == {"mass": 5.0}
 
 
 @pytest.mark.asyncio
-async def test_get_physics_settings(monkeypatch):
-    """get_physics_settings routes correctly with no extra params."""
+async def test_get_settings(monkeypatch):
+    """get_settings routes correctly with no extra params."""
     captured = {}
     monkeypatch.setattr(
         physics_mod, "async_send_command_with_retry",
@@ -166,7 +171,7 @@ async def test_get_physics_settings(monkeypatch):
     )
 
     resp = await physics_mod.manage_physics(
-        ctx=DummyContext(), action="get_physics_settings",
+        ctx=DummyContext(), action="get_settings",
     )
 
     assert resp["success"] is True
@@ -183,7 +188,7 @@ async def test_none_params_stripped(monkeypatch):
     )
 
     await physics_mod.manage_physics(
-        ctx=DummyContext(), action="list_colliders",
+        ctx=DummyContext(), action="ping",
     )
 
     assert set(captured["params"].keys()) == {"action"}

--- a/Server/tests/integration/test_manage_profiler.py
+++ b/Server/tests/integration/test_manage_profiler.py
@@ -32,41 +32,56 @@ async def test_get_counters(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_list_categories(monkeypatch):
+async def test_profiler_status(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", _fake_send_factory(captured))
+    resp = await profiler_mod.manage_profiler(ctx=DummyContext(), action="profiler_status")
+    assert resp["success"] is True
+    assert captured["cmd"] == "manage_profiler"
+    assert captured["params"]["action"] == "profiler_status"
+
+
+@pytest.mark.asyncio
+async def test_profiler_start_recording(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", _fake_send_factory(captured))
+    resp = await profiler_mod.manage_profiler(
+        ctx=DummyContext(), action="profiler_start",
+        log_file="/tmp/profile.raw", enable_callstacks=True,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["log_file"] == "/tmp/profile.raw"
+    assert captured["params"]["enable_callstacks"] is True
+
+
+@pytest.mark.asyncio
+async def test_frame_debugger_get_events_pagination(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", _fake_send_factory(captured))
+    resp = await profiler_mod.manage_profiler(
+        ctx=DummyContext(), action="frame_debugger_get_events", page_size=20, cursor=40,
+    )
+    assert resp["success"] is True
+    assert captured["params"]["page_size"] == 20
+    assert captured["params"]["cursor"] == 40
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_rejected(monkeypatch):
+    """An action outside ALL_ACTIONS is rejected before the transport is touched."""
     captured = {}
     monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", _fake_send_factory(captured))
     resp = await profiler_mod.manage_profiler(ctx=DummyContext(), action="list_categories")
-    assert resp["success"] is True
-    assert captured["cmd"] == "manage_profiler"
-
-
-@pytest.mark.asyncio
-async def test_start_recording(monkeypatch):
-    captured = {}
-    monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", _fake_send_factory(captured))
-    resp = await profiler_mod.manage_profiler(
-        ctx=DummyContext(), action="start_recording", path="/tmp/profile.raw",
-    )
-    assert resp["success"] is True
-    assert captured["params"]["path"] == "/tmp/profile.raw"
-
-
-@pytest.mark.asyncio
-async def test_get_frame_data(monkeypatch):
-    captured = {}
-    monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", _fake_send_factory(captured))
-    resp = await profiler_mod.manage_profiler(
-        ctx=DummyContext(), action="get_frame_data", count=20,
-    )
-    assert resp["success"] is True
-    assert captured["params"]["count"] == 20
+    assert resp["success"] is False
+    assert "Unknown action 'list_categories'" in resp["message"]
+    assert "params" not in captured
 
 
 @pytest.mark.asyncio
 async def test_none_params_stripped(monkeypatch):
     captured = {}
     monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", _fake_send_factory(captured))
-    await profiler_mod.manage_profiler(ctx=DummyContext(), action="list_categories")
+    await profiler_mod.manage_profiler(ctx=DummyContext(), action="ping")
     assert set(captured["params"].keys()) == {"action"}
 
 
@@ -75,6 +90,6 @@ async def test_python_exception_caught(monkeypatch):
     async def raising_send(cmd, params, **kwargs):
         raise ConnectionError("Unity not connected")
     monkeypatch.setattr(profiler_mod, "async_send_command_with_retry", raising_send)
-    resp = await profiler_mod.manage_profiler(ctx=DummyContext(), action="list_categories")
+    resp = await profiler_mod.manage_profiler(ctx=DummyContext(), action="ping")
     assert resp["success"] is False
     assert "Unity not connected" in resp["message"]


### PR DESCRIPTION
Fixes #76

## What was wrong

The Beta Release gate is permanently red on `beta`. Reproduced at `986b7728`:

```
$ cd Server && uv run --with pytest --with pytest-asyncio pytest tests/ -q
12 failed, 1554 passed in 32.28s
```

Exactly the 12 failures the issue names, nothing else. `.github/workflows/python-tests.yml:54` runs `pytest tests/` with no marker deselect and no path exclusion, so `tests/integration/` runs unconditionally and these 12 do gate the release.

## Cause 1 (10 of 12) — stale tests, not a functional regression

`manage_physics` was deliberately consolidated: `overlap_sphere`/`overlap_box` became a single `overlap` taking `shape` + `position` + `size`; `center` was dropped from the signature (it survives only as `explosion_position`); `list_rigidbodies`/`set_rigidbody`/`get_physics_settings` became `get_rigidbody`/`configure_rigidbody`/`get_settings`. `manage_profiler`'s action set is `ping`, `profiler_*`, `get_*`, `memory_*`, `frame_debugger_*` — there is no `list_categories`, `start_recording` or `get_frame_data`, and no `count` param.

The tools are right and the tests were never updated. Rewritten against the current signatures (`manage_physics.py:11-33`, `manage_profiler.py:12-29`). Where a stale action had no successor, the test keeps its original purpose rather than duplicating an existing one — `test_list_rigidbodies` (which existed to cover `page_size` routing) became `test_validate_pagination_params`, and profiler's `test_list_categories` became `test_profiler_status`.

## Cause 2 (2 of 12) — a real product gap the issue did not identify

The issue and its triage both concluded "no product code changes". That is wrong, and the run proves it. After fixing every stale action name, two tests still failed:

```
$ pytest tests/integration/test_manage_physics.py tests/integration/test_manage_profiler.py -q
2 failed, 15 passed
FAILED test_manage_physics.py::test_python_exception_caught
FAILED test_manage_profiler.py::test_python_exception_caught
E   ConnectionError: Unity not connected
```

`test_python_exception_caught` in the physics file already used a *valid* action (`raycast`), so the "invalid action short-circuits before the transport" explanation never applied to it. The real cause: `manage_physics` and `manage_profiler` are the only tools that do not wrap their `send_with_unity_instance` call in a `try`/`except`. A transport exception escapes the tool instead of being returned as `{"success": False, ...}` — inconsistent with every sibling tool (`manage_navigation.py` is the reference shape).

Added the same guard to both. The two tests now pass because the behaviour they assert exists, not because they were weakened.

## What I verified

- Red before: `12 failed, 1554 passed` at `986b7728`.
- Red for the right reason after the test-drift fix alone: `2 failed, 15 passed` — the two exception tests, proving the guard is load-bearing and not cosmetic.
- Green after: **`1567 passed, 0 failed`** (1554 + 12 fixed + 1 new `test_unknown_action_rejected`, which pins the unknown-action rejection path the old profiler tests were accidentally exercising).

## What I deliberately did not do

No `-m "not integration"`, no pytest marker deselect, no connectivity skip. The issue's cause 3 (`ConnectionError: Unity not connected` means CI reached for a live editor) is a misreading — that string is raised by the test's own monkeypatched `raising_send`. No test in this set needs an editor, and suppressing them would hide the signature drift instead of fixing it.

Base is `beta`, not `main`: `origin/HEAD -> origin/beta`, and `main` is 736 commits behind with 0 unique commits.