### PR TITLE
fix(components): accept Vector2/Vector3/Color and friends in component_properties writes

### DIFF
--- a/MCPForUnity/Editor/Helpers/ComponentOps.cs
+++ b/MCPForUnity/Editor/Helpers/ComponentOps.cs
@@ -650,6 +650,92 @@ namespace MCPForUnity.Editor.Helpers
                     case SerializedPropertyType.Enum:
                         return SetEnum(prop, value, out error);
 
+                    // Vector/struct leaves. Mirrors the switch in ManageScriptableObject
+                    // (TrySetSerializedProperty) so the two write paths accept the same value
+                    // forms — both the array [x, y] and the object {"x": 0, "y": 0} shape that
+                    // VectorParsing handles. Without these, a RectTransform's m_AnchorMin /
+                    // m_AnchorMax / m_SizeDelta / m_Pivot (all SerializedPropertyType.Vector2)
+                    // fell through to the default and were rejected outright. See issue #79.
+                    case SerializedPropertyType.Vector2:
+                        var v2 = VectorParsing.ParseVector2(value);
+                        if (v2 == null)
+                        {
+                            error = "Expected Vector2 (array or object).";
+                            return false;
+                        }
+                        prop.vector2Value = v2.Value;
+                        return true;
+
+                    case SerializedPropertyType.Vector3:
+                        var v3 = VectorParsing.ParseVector3(value);
+                        if (v3 == null)
+                        {
+                            error = "Expected Vector3 (array or object).";
+                            return false;
+                        }
+                        prop.vector3Value = v3.Value;
+                        return true;
+
+                    case SerializedPropertyType.Vector4:
+                        var v4 = VectorParsing.ParseVector4(value);
+                        if (v4 == null)
+                        {
+                            error = "Expected Vector4 (array or object).";
+                            return false;
+                        }
+                        prop.vector4Value = v4.Value;
+                        return true;
+
+                    case SerializedPropertyType.Quaternion:
+                        var quat = VectorParsing.ParseQuaternion(value);
+                        if (quat == null)
+                        {
+                            error = "Expected Quaternion (array [x,y,z] euler, [x,y,z,w], or object).";
+                            return false;
+                        }
+                        prop.quaternionValue = quat.Value;
+                        return true;
+
+                    case SerializedPropertyType.Color:
+                        var col = VectorParsing.ParseColor(value);
+                        if (col == null)
+                        {
+                            error = "Expected Color (array or object).";
+                            return false;
+                        }
+                        prop.colorValue = col.Value;
+                        return true;
+
+                    case SerializedPropertyType.Rect:
+                        var rect = VectorParsing.ParseRect(value);
+                        if (rect == null)
+                        {
+                            error = "Expected Rect (array [x,y,width,height] or object).";
+                            return false;
+                        }
+                        prop.rectValue = rect.Value;
+                        return true;
+
+                    case SerializedPropertyType.Bounds:
+                        var bounds = VectorParsing.ParseBounds(value);
+                        if (bounds == null)
+                        {
+                            error = "Expected Bounds (object with center and size).";
+                            return false;
+                        }
+                        prop.boundsValue = bounds.Value;
+                        return true;
+
+                    case SerializedPropertyType.AnimationCurve:
+                        var curve = VectorParsing.ParseAnimationCurve(value);
+                        if (curve == null)
+                        {
+                            error = "Expected AnimationCurve (object with 'keys' or array of keyframes).";
+                            return false;
+                        }
+                        prop.animationCurveValue = curve;
+                        return true;
+
                     default:
                         error = $"Unsupported SerializedPropertyType: {prop.propertyType} at '{prop.propertyPath}'.";
                         return false;

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ComponentOpsVectorPropertyTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ComponentOpsVectorPropertyTests.cs
@@ -1,0 +1,110 @@
+using NUnit.Framework;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+using MCPForUnity.Editor.Helpers;
+
+namespace MCPForUnityTests.Editor.Tools
+{
+    /// <summary>
+    /// Regression tests for issue #79: ComponentOps.SetProperty rejected every
+    /// vector-family SerializedProperty with "Unsupported SerializedPropertyType",
+    /// so manage_prefabs modify_contents could not write a RectTransform's
+    /// m_AnchorMin / m_AnchorMax / m_SizeDelta / m_Pivot in either the object
+    /// {"x":0,"y":0} or the array [0,0] form.
+    ///
+    /// These names take the SerializedProperty path rather than reflection:
+    /// ParamCoercion.NormalizePropertyName("m_AnchorMin") yields "mAnchormin",
+    /// which matches no RectTransform member, and RectTransform's fields are
+    /// native so no serialized backing field is found either.
+    /// </summary>
+    public class ComponentOpsVectorPropertyTests
+    {
+        private GameObject go;
+        private RectTransform rect;
+
+        [SetUp]
+        public void SetUp()
+        {
+            go = new GameObject("VectorPropertyTarget", typeof(RectTransform));
+            rect = go.GetComponent<RectTransform>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (go != null)
+                Object.DestroyImmediate(go);
+        }
+
+        [Test]
+        public void SetProperty_Vector2_ObjectForm_RoundTrips()
+        {
+            var value = new JObject { ["x"] = 0.25f, ["y"] = 0.75f };
+
+            bool ok = ComponentOps.SetProperty(rect, "m_AnchorMin", value, out string error);
+
+            Assert.IsTrue(ok, $"Expected the Vector2 object form to be accepted, got: {error}");
+            Assert.IsNull(error);
+            Assert.AreEqual(new Vector2(0.25f, 0.75f), rect.anchorMin);
+        }
+
+        [Test]
+        public void SetProperty_Vector2_ArrayForm_RoundTrips()
+        {
+            var value = new JArray { 1f, 1f };
+
+            bool ok = ComponentOps.SetProperty(rect, "m_AnchorMax", value, out string error);
+
+            Assert.IsTrue(ok, $"Expected the Vector2 array form to be accepted, got: {error}");
+            Assert.AreEqual(new Vector2(1f, 1f), rect.anchorMax);
+        }
+
+        [Test]
+        public void SetProperty_Vector2_SizeDeltaAndPivot_RoundTrip()
+        {
+            Assert.IsTrue(
+                ComponentOps.SetProperty(rect, "m_SizeDelta", new JObject { ["x"] = 100f, ["y"] = 50f }, out string sizeError),
+                $"m_SizeDelta rejected: {sizeError}");
+            Assert.IsTrue(
+                ComponentOps.SetProperty(rect, "m_Pivot", new JArray { 0.5f, 0.5f }, out string pivotError),
+                $"m_Pivot rejected: {pivotError}");
+
+            Assert.AreEqual(new Vector2(100f, 50f), rect.sizeDelta);
+            Assert.AreEqual(new Vector2(0.5f, 0.5f), rect.pivot);
+        }
+
+        /// <summary>
+        /// The dotted-path form documented as the workaround in issue #79 resolves to a
+        /// Float leaf. It worked before the fix and must keep working after it.
+        /// </summary>
+        [Test]
+        public void SetProperty_DottedFloatPath_StillWorks()
+        {
+            bool ok = ComponentOps.SetProperty(rect, "m_AnchorMin.x", new JValue(0.4f), out string error);
+
+            Assert.IsTrue(ok, $"Dotted-path float write regressed: {error}");
+            Assert.AreEqual(0.4f, rect.anchorMin.x, 0.0001f);
+        }
+
+        /// <summary>
+        /// Pins the FAILURE state: an unparsable payload for a supported vector type must
+        /// still be rejected with a type-specific error, never silently written as a zeroed
+        /// default. Without this, the fix above could "pass" by accepting anything.
+        /// </summary>
+        [Test]
+        public void SetProperty_Vector2_UnparsableValue_IsRejected()
+        {
+            Vector2 before = rect.anchorMin;
+
+            bool ok = ComponentOps.SetProperty(rect, "m_AnchorMin", new JValue("not-a-vector"), out string error);
+
+            Assert.IsFalse(ok, "An unparsable Vector2 payload must be rejected.");
+            Assert.IsNotNull(error);
+            Assert.IsFalse(
+                error.Contains("Unsupported SerializedPropertyType"),
+                $"Vector2 must no longer be reported as an unsupported type. Got: {error}");
+            Assert.AreEqual(before, rect.anchorMin, "A rejected write must not mutate the property.");
+        }
+
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ComponentOpsVectorPropertyTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ComponentOpsVectorPropertyTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8900fb92d7ff45e18ed0625ee69a8785
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #79

## The defect

`ComponentOps.SetSerializedPropertyRecursive`'s leaf-type switch handled exactly five types — Integer, Boolean, Float, String, Enum. Everything else fell to:

```csharp
default:
    error = $"Unsupported SerializedPropertyType: {prop.propertyType} at '{prop.propertyPath}'.";
```

which is the verbatim string the reporter saw. There was no Vector2 case, so `manage_prefabs modify_contents` could not write a RectTransform's `m_AnchorMin` / `m_AnchorMax` / `m_SizeDelta` / `m_Pivot` in either the object `{"x":0,"y":0}` or the array `[0,0]` form.

## Why those names never reach the reflection path

I traced this rather than assuming it, because `RectTransform.anchorMin` is a perfectly writable public property and the write "should" have succeeded before ever reaching the SerializedProperty switch:

- `ParamCoercion.NormalizePropertyName("m_AnchorMin")` splits on `_` and produces **`"mAnchormin"`**, not `anchorMin` — so neither `GetProperty("m_AnchorMin")` nor `GetProperty("mAnchormin")` matches, even case-insensitively.
- `RectTransform`'s storage is native, so `FindSerializedFieldInHierarchy` finds no managed backing field either.

Reflection therefore fails outright and `SetProperty` falls through to `SetViaSerializedProperty`, where `FindProperty("m_AnchorMin")` returns a `SerializedPropertyType.Vector2` and the switch rejects it. The same trace explains the reporter's dotted-path workaround: `m_AnchorMin.x` resolves to a Float leaf, which the switch already handled.

## The fix

Added the missing vector/struct leaf cases, mirroring the switch `ManageScriptableObject.TrySetSerializedProperty` already implements for the identical job, so the two write paths **converge** on one set of accepted value forms rather than drifting apart: `Vector2`, `Vector3`, `Vector4`, `Quaternion`, `Color`, `Rect`, `Bounds`, `AnimationCurve` — each delegating to the existing `VectorParsing` helper (same namespace, no new import needed).

The `default:` arm is deliberately left in place so a genuinely unsupported type still errors loudly.

`Vector2Int` / `Vector3Int` are **not** included: `VectorParsing` has no integer parser, and adding one would mean inventing rounding semantics that `ManageScriptableObject` does not have — reintroducing the divergence this change exists to remove.

## Test

New EditMode test `ComponentOpsVectorPropertyTests` (headless, no live editor needed):

- `m_AnchorMin` via `{"x":0.25,"y":0.75}` and `m_AnchorMax` via `[1,1]` round-trip.
- `m_SizeDelta` and `m_Pivot` round-trip, covering both forms again.
- The dotted-path float form `m_AnchorMin.x` still works — it was the only thing that worked before, so a regression there would be silent.
- **Pins the failure state:** an unparsable payload (`"not-a-vector"`) is still rejected, the error is no longer `Unsupported SerializedPropertyType`, and the property is left unmutated. Without this the fix could "pass" by accepting anything, and a check that cannot go red is decoration.

## Verification status — read this before merging

**The EditMode test did not run in CI.** `unity-tests` reports a passing `Test in editmode on Unity 6000.0.75f1` in about 8 seconds; the log shows `UNITY_LICENSE:` empty and `Unity license secrets missing; skipping Unity tests.` The job exits clean so the status check still appears. Every Unity EditMode check on this repo is currently a no-op — a green that would look identical if the whole suite were failing.

What I could verify without an editor: the changed `ComponentOps.cs` and the new test file both parse clean under Roslyn (`csc` from the dotnet SDK, compiled standalone) — zero `CS1xxx` syntax diagnostics; the only errors are `CS0246`/`CS0518` missing-Unity-assembly errors, as expected. That proves the syntax, not the behaviour. A maintainer with a licensed editor should run `ComponentOpsVectorPropertyTests` before trusting this.

## Note on the docs check

`Check docs reference is fresh` is red on this PR. It is red on `beta` itself and has been for at least the last five merges (`8fd6821f`, `aa3847e8`, `f6ffa19a`, `1aa68fea`, `69f53224`) — ~26 generated-only tool docs that were never committed. Nothing in this diff touches a tool signature, and none of the drifting files are ones I changed. Out of scope here; worth its own issue.

Base is `beta`, not `main`: `origin/HEAD -> origin/beta`, and `main` is 736 commits behind with 0 unique commits.
