### PR TITLE
fix(prefabs): stop an open prefab stage silently wiping modify_contents work

### DIFF
--- a/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
+++ b/MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs
@@ -593,8 +593,11 @@ namespace MCPForUnity.Editor.Tools.Prefabs
         #region Headless Prefab Editing
 
         /// <summary>
-        /// Modifies a prefab's contents directly without opening the prefab stage.
+        /// Modifies a prefab's contents without opening the prefab stage itself.
         /// This is ideal for automated/agentic workflows as it avoids UI, dirty flags, and dialogs.
+        /// If a prefab stage is ALREADY open on the same asset, the modifications are applied to
+        /// that stage's contents root rather than to a second isolated copy — otherwise the
+        /// stage's later save would silently overwrite them (issue #77).
         /// </summary>
         private static object ModifyContents(JObject @params)
         {
@@ -610,8 +613,20 @@ namespace MCPForUnity.Editor.Tools.Prefabs
                 return new ErrorResponse($"Invalid prefab path '{prefabPath}'. Path traversal sequences are not allowed.");
             }
 
-            // Load prefab contents in isolated context (no UI)
-            GameObject prefabContents = PrefabUtility.LoadPrefabContents(sanitizedPath);
+            // If a prefab stage is already open on this same asset, that stage's in-memory copy
+            // is authoritative: whatever it holds gets written over the file when it is saved or
+            // closed. Loading a second isolated copy here and saving it would be silently undone
+            // by that later write — the data loss reported in issue #77. Edit the stage's own
+            // root instead, so exactly one in-memory copy of the asset ever exists.
+            PrefabStage openStage = PrefabStageUtility.GetCurrentPrefabStage();
+            bool editingOpenStage = openStage != null
+                && openStage.prefabContentsRoot != null
+                && string.Equals(openStage.assetPath, sanitizedPath, StringComparison.OrdinalIgnoreCase);
+
+            GameObject prefabContents = editingOpenStage
+                ? openStage.prefabContentsRoot
+                : PrefabUtility.LoadPrefabContents(sanitizedPath);
+
             if (prefabContents == null)
             {
                 return new ErrorResponse($"Failed to load prefab contents from '{sanitizedPath}'.");
@@ -645,23 +660,36 @@ namespace MCPForUnity.Editor.Tools.Prefabs
                         {
                             prefabPath = sanitizedPath,
                             targetName = targetGo.name,
-                            modified = false
+                            modified = false,
+                            editedOpenPrefabStage = editingOpenStage
                         }
                     );
                 }
 
-                // Save the prefab
-                bool success;
-                PrefabUtility.SaveAsPrefabAsset(prefabContents, sanitizedPath, out success);
-
-                if (!success)
+                // Save the prefab. When editing the open stage, route through TrySavePrefabStage
+                // so the stage's dirty flag is cleared too — otherwise a later close would treat
+                // the stage as unsaved and could write a stale copy back over what we just saved.
+                if (editingOpenStage)
                 {
-                    return new ErrorResponse($"Failed to save prefab asset at '{sanitizedPath}'.");
+                    if (!TrySavePrefabStage(openStage, out _, out string stageSaveError))
+                    {
+                        return new ErrorResponse(stageSaveError);
+                    }
+                }
+                else
+                {
+                    bool success;
+                    PrefabUtility.SaveAsPrefabAsset(prefabContents, sanitizedPath, out success);
+
+                    if (!success)
+                    {
+                        return new ErrorResponse($"Failed to save prefab asset at '{sanitizedPath}'.");
+                    }
+
+                    AssetDatabase.Refresh();
                 }
 
-                AssetDatabase.Refresh();
-
-                McpLog.Info($"[ManagePrefabs] Successfully modified and saved prefab '{sanitizedPath}' (headless).");
+                McpLog.Info($"[ManagePrefabs] Successfully modified and saved prefab '{sanitizedPath}' ({(editingOpenStage ? "open prefab stage" : "headless")}).");
 
                 return new SuccessResponse(
                     $"Prefab '{sanitizedPath}' modified and saved successfully.",
@@ -670,6 +698,7 @@ namespace MCPForUnity.Editor.Tools.Prefabs
                         prefabPath = sanitizedPath,
                         targetName = targetGo.name,
                         modified = modifyResult.modified,
+                        editedOpenPrefabStage = editingOpenStage,
                         transform = new
                         {
                             position = new { x = targetGo.transform.localPosition.x, y = targetGo.transform.localPosition.y, z = targetGo.transform.localPosition.z },
@@ -682,8 +711,12 @@ namespace MCPForUnity.Editor.Tools.Prefabs
             }
             finally
             {
-                // Always unload prefab contents to free memory
-                PrefabUtility.UnloadPrefabContents(prefabContents);
+                // Only unload contents we loaded ourselves. The open stage's root belongs to the
+                // stage; unloading it would tear down the editor's live prefab stage.
+                if (!editingOpenStage)
+                {
+                    PrefabUtility.UnloadPrefabContents(prefabContents);
+                }
             }
         }
 
@@ -1324,14 +1357,23 @@ namespace MCPForUnity.Editor.Tools.Prefabs
                     return new ErrorResponse($"Failed to open prefab stage for '{sanitizedPath}'. PrefabStageUtility.OpenPrefab did not enter the requested prefab stage.");
                 }
 
+                // An already-open stage is NOT re-read from disk by OpenPrefab. If it carries
+                // unsaved edits, its in-memory copy differs from the file and will overwrite the
+                // file on the next save or close. Surface that instead of letting the caller
+                // assume it is looking at what is on disk (issue #77).
+                bool isDirty = prefabStage.scene.isDirty;
+
                 return new SuccessResponse(
-                    $"Opened prefab stage for '{sanitizedPath}'.",
+                    isDirty
+                        ? $"Opened prefab stage for '{sanitizedPath}'. The stage has unsaved in-memory changes that will overwrite the file when saved or closed."
+                        : $"Opened prefab stage for '{sanitizedPath}'.",
                     new
                     {
                         prefabPath = sanitizedPath,
                         openedPrefabPath = prefabStage.assetPath,
                         rootName = prefabStage.prefabContentsRoot.name,
-                        enteredPrefabStage = enteredStage
+                        enteredPrefabStage = enteredStage,
+                        isDirty
                     }
                 );
             }
@@ -1383,8 +1425,16 @@ namespace MCPForUnity.Editor.Tools.Prefabs
                 }
 
                 string prefabPath = prefabStage.assetPath;
+                // Report whether unsaved in-memory edits existed at close time. Without save_before_close
+                // those edits are discarded rather than written, and the caller has no other way to
+                // tell that from a clean close (issue #77).
+                bool wasDirty = prefabStage.scene.isDirty;
                 StageUtility.GoToMainStage();
-                return new SuccessResponse($"Exited prefab stage for '{prefabPath}'.", new { prefabPath });
+                return new SuccessResponse(
+                    wasDirty && !saveBeforeClose
+                        ? $"Exited prefab stage for '{prefabPath}'. Unsaved in-memory changes were discarded; pass save_before_close to keep them."
+                        : $"Exited prefab stage for '{prefabPath}'.",
+                    new { prefabPath, wasDirty, savedBeforeClose = saveBeforeClose });
             }
             catch (Exception e)
             {

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManagePrefabsStageCoherenceTests.cs
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManagePrefabsStageCoherenceTests.cs
@@ -1,0 +1,232 @@
+using System.IO;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using MCPForUnity.Editor.Tools.Prefabs;
+using static MCPForUnityTests.Editor.TestUtilities;
+
+namespace MCPForUnityTests.Editor.Tools
+{
+    /// <summary>
+    /// Regression tests for issue #77: modify_contents and the prefab stage held two
+    /// disconnected in-memory copies of the same asset with no cross-invalidation.
+    /// modify_contents called PrefabUtility.LoadPrefabContents (its own isolated copy) and
+    /// saved it; the stage's separate copy was then written over the file by the next
+    /// save_prefab_stage or close_prefab_stage, silently destroying the modify_contents work.
+    /// Both writes succeeded, so there was no error path to notice.
+    /// </summary>
+    public class ManagePrefabsStageCoherenceTests
+    {
+        private const string TempDirectory = "Assets/Temp/ManagePrefabsStageCoherenceTests";
+
+        [SetUp]
+        public void SetUp()
+        {
+            StageUtility.GoToMainStage();
+            EnsureFolder(TempDirectory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            StageUtility.GoToMainStage();
+
+            if (AssetDatabase.IsValidFolder(TempDirectory))
+            {
+                AssetDatabase.DeleteAsset(TempDirectory);
+            }
+
+            CleanupEmptyParentFolders(TempDirectory);
+        }
+
+        private static string CreatePrefab(string name)
+        {
+            string prefabPath = Path.Combine(TempDirectory, name + ".prefab").Replace('\\', '/');
+            var source = new GameObject(name);
+            try
+            {
+                PrefabUtility.SaveAsPrefabAsset(source, prefabPath);
+            }
+            finally
+            {
+                Object.DestroyImmediate(source);
+            }
+            AssetDatabase.Refresh();
+            return prefabPath;
+        }
+
+        private static Vector3 ReadPositionFromDisk(string prefabPath)
+        {
+            // Load the asset fresh so the assertion reads the file, not a cached editing copy.
+            AssetDatabase.Refresh();
+            var asset = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.IsNotNull(asset, $"Prefab asset missing at '{prefabPath}'.");
+            return asset.transform.localPosition;
+        }
+
+        /// <summary>
+        /// The reported data loss: with a stage open on the same asset, a modify_contents write
+        /// followed by save_prefab_stage left the file holding the STAGE's untouched copy.
+        /// </summary>
+        [Test]
+        public void ModifyContents_WithStageOpenOnSameAsset_SurvivesSavePrefabStage()
+        {
+            string prefabPath = CreatePrefab("StageCoherence_Save");
+
+            var opened = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "open_prefab_stage",
+                ["prefabPath"] = prefabPath
+            }));
+            Assert.IsTrue(opened.Value<bool>("success"), opened.Value<string>("message"));
+
+            var modified = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "modify_contents",
+                ["prefabPath"] = prefabPath,
+                ["position"] = new JArray { 1f, 2f, 3f }
+            }));
+            Assert.IsTrue(modified.Value<bool>("success"), modified.Value<string>("message"));
+            Assert.IsTrue(
+                modified["data"].Value<bool>("editedOpenPrefabStage"),
+                "modify_contents must edit the open stage's copy, not load a second one.");
+
+            var saved = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "save_prefab_stage"
+            }));
+            Assert.IsTrue(saved.Value<bool>("success"), saved.Value<string>("message"));
+
+            ManagePrefabs.HandleCommand(new JObject { ["action"] = "close_prefab_stage" });
+
+            Assert.AreEqual(
+                new Vector3(1f, 2f, 3f),
+                ReadPositionFromDisk(prefabPath),
+                "save_prefab_stage overwrote the modify_contents work with the stage's stale copy.");
+        }
+
+        /// <summary>
+        /// The second reported shape: closing the stage without an explicit save wiped the
+        /// modify_contents write, because the stage's copy was written over the file on the way out.
+        /// </summary>
+        [Test]
+        public void ModifyContents_WithStageOpenOnSameAsset_SurvivesCloseWithoutSave()
+        {
+            string prefabPath = CreatePrefab("StageCoherence_Close");
+
+            ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "open_prefab_stage",
+                ["prefabPath"] = prefabPath
+            });
+
+            var modified = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "modify_contents",
+                ["prefabPath"] = prefabPath,
+                ["position"] = new JArray { 4f, 5f, 6f }
+            }));
+            Assert.IsTrue(modified.Value<bool>("success"), modified.Value<string>("message"));
+
+            var closed = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "close_prefab_stage"
+            }));
+            Assert.IsTrue(closed.Value<bool>("success"), closed.Value<string>("message"));
+
+            Assert.AreEqual(
+                new Vector3(4f, 5f, 6f),
+                ReadPositionFromDisk(prefabPath),
+                "Closing the stage discarded the modify_contents write.");
+        }
+
+        /// <summary>
+        /// A stage open on a DIFFERENT asset must not divert the write — modify_contents still
+        /// edits its own isolated copy of the requested path.
+        /// </summary>
+        [Test]
+        public void ModifyContents_WithStageOpenOnDifferentAsset_EditsRequestedPrefab()
+        {
+            string stagePath = CreatePrefab("StageCoherence_Other");
+            string targetPath = CreatePrefab("StageCoherence_Target");
+
+            ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "open_prefab_stage",
+                ["prefabPath"] = stagePath
+            });
+
+            var modified = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "modify_contents",
+                ["prefabPath"] = targetPath,
+                ["position"] = new JArray { 7f, 8f, 9f }
+            }));
+            Assert.IsTrue(modified.Value<bool>("success"), modified.Value<string>("message"));
+            Assert.IsFalse(
+                modified["data"].Value<bool>("editedOpenPrefabStage"),
+                "A stage on a different asset must not be treated as the target's editing copy.");
+
+            ManagePrefabs.HandleCommand(new JObject { ["action"] = "close_prefab_stage" });
+
+            Assert.AreEqual(new Vector3(7f, 8f, 9f), ReadPositionFromDisk(targetPath));
+            Assert.AreEqual(Vector3.zero, ReadPositionFromDisk(stagePath),
+                "The staged prefab must be untouched by a write aimed at another path.");
+        }
+
+        /// <summary>
+        /// No stage open at all: the original headless path must keep working unchanged.
+        /// </summary>
+        [Test]
+        public void ModifyContents_WithNoStageOpen_StillEditsHeadlessly()
+        {
+            string prefabPath = CreatePrefab("StageCoherence_Headless");
+
+            var modified = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "modify_contents",
+                ["prefabPath"] = prefabPath,
+                ["position"] = new JArray { 10f, 11f, 12f }
+            }));
+
+            Assert.IsTrue(modified.Value<bool>("success"), modified.Value<string>("message"));
+            Assert.IsFalse(modified["data"].Value<bool>("editedOpenPrefabStage"));
+            Assert.AreEqual(new Vector3(10f, 11f, 12f), ReadPositionFromDisk(prefabPath));
+        }
+
+        /// <summary>
+        /// Pins the reporting contract: a close that discards unsaved stage edits must say so.
+        /// A silent clean-looking close is exactly how the original data loss went unnoticed.
+        /// </summary>
+        [Test]
+        public void ClosePrefabStage_ReportsWhetherUnsavedChangesExisted()
+        {
+            string prefabPath = CreatePrefab("StageCoherence_DirtyReport");
+
+            ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "open_prefab_stage",
+                ["prefabPath"] = prefabPath
+            });
+
+            var stage = PrefabStageUtility.GetCurrentPrefabStage();
+            Assert.IsNotNull(stage);
+            var child = new GameObject("UnsavedChild");
+            child.transform.SetParent(stage.prefabContentsRoot.transform, false);
+            EditorSceneManager.MarkSceneDirty(stage.scene);
+
+            var closed = ToJObject(ManagePrefabs.HandleCommand(new JObject
+            {
+                ["action"] = "close_prefab_stage"
+            }));
+
+            Assert.IsTrue(closed.Value<bool>("success"), closed.Value<string>("message"));
+            Assert.IsTrue(
+                closed["data"].Value<bool>("wasDirty"),
+                "close_prefab_stage must report that unsaved in-memory changes existed.");
+            Assert.IsFalse(closed["data"].Value<bool>("savedBeforeClose"));
+        }
+    }
+}

--- a/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManagePrefabsStageCoherenceTests.cs.meta
+++ b/TestProjects/UnityMCPTests/Assets/Tests/EditMode/Tools/ManagePrefabsStageCoherenceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d0c94b3be2954659b3fea6aad8f8fd76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #77

## Root cause — not a cache, two copies

The issue frames this as a "cached snapshot". There is no server-side cache. There are two disconnected in-memory copies of the same asset with no cross-invalidation, all in `MCPForUnity/Editor/Tools/Prefabs/ManagePrefabs.cs`:

- `ModifyContents` called `PrefabUtility.LoadPrefabContents(path)` — its **own** isolated copy read straight from disk — mutated it, saved it with `SaveAsPrefabAsset`, and unloaded it.
- `OpenPrefabStage`'s `prefabStage.prefabContentsRoot` is a **separate** copy, materialised when the stage opened.
- `TrySavePrefabStage` unconditionally writes that stage copy over whatever is on disk.

The decisive absence: `PrefabStageUtility.GetCurrentPrefabStage()` appeared exactly three times in the file — `FindSceneObjectByName`, `SavePrefabStage`, `ClosePrefabStage`. `ModifyContents` never called it, so it could not detect a stage open on the same asset. The stage's later save then wrote its stale copy over the modify_contents work. Both `SaveAsPrefabAsset` calls succeed, so there is no error path — the loss is silent and unrecoverable.

The issue's own fix sketch points at `Server/` prefab-stage state and an mtime cache. That location is wrong; the defect is entirely editor-side C#, and this PR fixes it there.

## The fix

Took the sketch's **preferred** option rather than the hard-error fallback: when a stage is open on the same asset, `ModifyContents` operates on `openStage.prefabContentsRoot` instead of loading a second copy, and saves through `TrySavePrefabStage` so the stage's dirty flag is cleared in the same operation. Exactly one in-memory copy of an asset is ever authoritative, and there is nothing left to overwrite it.

- A stage open on a **different** asset is left alone — the headless path runs unchanged.
- The `finally` only unloads contents it loaded itself; unloading the stage's root would tear down the live stage.
- The response gains `editedOpenPrefabStage` so a caller can tell which copy answered.
- `open_prefab_stage` reports `isDirty`, and `close_prefab_stage` reports `wasDirty` + `savedBeforeClose`, with a message saying outright when a close discarded unsaved edits. A discarding close was previously indistinguishable from a clean one — which is how the original loss went unnoticed.

I did **not** change close semantics (e.g. auto-saving a dirty stage). The sketch flags that as needing live-editor confirmation of what `StageUtility.GoToMainStage()` actually does with a dirty stage; I could not confirm it, so I surfaced the state rather than guessing at behaviour.

## Tests

New EditMode test `ManagePrefabsStageCoherenceTests` covering the reported cycle and its neighbours:

- **The repro:** open stage -> modify_contents(position) -> save_prefab_stage -> close; asserts the on-disk prefab holds the modify_contents value. Red before this change (the stage's untouched copy won).
- **The no-explicit-save shape:** open stage -> modify_contents -> close without saving; the write must survive.
- **Different asset staged:** the write must still land on the requested path, `editedOpenPrefabStage` false, and the staged prefab untouched.
- **No stage open:** the headless path is unregressed.
- **Reporting contract pinned:** a close with genuinely unsaved stage edits must report `wasDirty: true`.

## Verification status — read this before merging

**These tests did not run in CI, and I want to be explicit about that rather than let a green badge imply otherwise.** `unity-tests` reports a passing `Test in editmode on Unity 6000.0.75f1` in about 8 seconds. The log shows why:

```
UNITY_LICENSE:
Unity license secrets missing; skipping Unity tests.
```

The job exits clean so the status check still appears. Every Unity EditMode check on this repo is currently a no-op — a green that would look identical if the whole suite were failing.

What I could verify without an editor: all changed C# parses clean under Roslyn (`csc` from the dotnet SDK, files compiled standalone) — zero `CS1xxx` syntax diagnostics; the only errors are `CS0246`/`CS0518` missing-Unity-assembly errors, as expected. That proves the syntax, not the behaviour.

A maintainer with a licensed editor should run `ManagePrefabsStageCoherenceTests` before trusting this. The separate license gap is worth its own issue.

Base is `beta`, not `main`: `origin/HEAD -> origin/beta`, and `main` is 736 commits behind with 0 unique commits.