### PR TITLE
fix(manage_asset): measure preview bytes end-to-end and reject corrupt payloads

### DIFF
--- a/MCPForUnity/Editor/Tools/ManageAsset.cs
+++ b/MCPForUnity/Editor/Tools/ManageAsset.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
@@ -1065,6 +1066,8 @@ namespace MCPForUnity.Editor.Tools
             string previewBase64 = null;
             int previewWidth = 0;
             int previewHeight = 0;
+            int previewByteLength = 0;
+            string previewSha256 = null;
 
             if (asset != null)
             {
@@ -1094,6 +1097,8 @@ namespace MCPForUnity.Editor.Tools
                                 previewBase64 = Convert.ToBase64String(pngData);
                                 previewWidth = readablePreview.width;
                                 previewHeight = readablePreview.height;
+                                previewByteLength = pngData.Length;
+                                previewSha256 = ComputeSha256Hex(pngData);
                             }
                         }
                         finally
@@ -1126,7 +1131,8 @@ namespace MCPForUnity.Editor.Tools
                 }
             }
 
-            return BuildAssetDataRecord(path, asset, previewBase64, previewWidth, previewHeight);
+            return BuildAssetDataRecord(
+                path, asset, previewBase64, previewWidth, previewHeight, previewByteLength, previewSha256);
         }
 
         /// <summary>
@@ -1182,7 +1188,23 @@ namespace MCPForUnity.Editor.Tools
             return tcs.Task;
         }
 
-        private static object BuildAssetDataRecord(string path, UnityEngine.Object asset, string previewBase64, int previewWidth, int previewHeight)
+        /// <summary>
+        /// Lowercase hex SHA-256 of the raw PNG bytes, reported alongside the base64 so the
+        /// receiving side can verify what actually arrived (issue #36).
+        /// </summary>
+        private static string ComputeSha256Hex(byte[] data)
+        {
+            using var sha = SHA256.Create();
+            byte[] hash = sha.ComputeHash(data);
+            var sb = new System.Text.StringBuilder(hash.Length * 2);
+            foreach (byte b in hash)
+                sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
+            return sb.ToString();
+        }
+
+        private static object BuildAssetDataRecord(
+            string path, UnityEngine.Object asset, string previewBase64, int previewWidth, int previewHeight,
+            int previewByteLength = 0, string previewSha256 = null)
         {
             string guid = AssetDatabase.AssetPathToGUID(path);
             Type assetType = AssetDatabase.GetMainAssetTypeAtPath(path);
@@ -1204,6 +1226,11 @@ namespace MCPForUnity.Editor.Tools
                 previewBase64 = previewBase64, // PNG data as Base64 string
                 previewWidth = previewWidth,
                 previewHeight = previewHeight,
+                // Identity of the PNG bytes as they left the editor, so the receiving side can
+                // tell a transport-mangled payload from one that was already wrong when encoded.
+                // Issue #36 kept both layers as live suspects because nothing measured either.
+                previewByteLength = previewByteLength,
+                previewSha256 = previewSha256,
                 // TODO: Add more metadata? Importer settings? Dependencies?
             };
         }

--- a/Server/src/services/tools/manage_asset.py
+++ b/Server/src/services/tools/manage_asset.py
@@ -11,6 +11,7 @@ from mcp.types import ToolAnnotations
 from services.registry import mcp_for_unity_tool
 from services.tools import get_unity_instance_from_context
 from services.tools.utils import parse_json_payload, coerce_int, normalize_properties
+from services.tools.preview_integrity import verify_preview_payloads
 from transport.unity_transport import send_with_unity_instance
 from transport.legacy.unity_connection import async_send_command_with_retry
 from services.tools.preflight import preflight
@@ -115,5 +116,16 @@ async def manage_asset(
 
     # Use centralized async retry helper with instance routing
     result = await send_with_unity_instance(async_send_command_with_retry, unity_instance, "manage_asset", params_dict, loop=loop)
+    if not isinstance(result, dict):
+        return {"success": False, "message": str(result)}
+
+    # A preview that survived encoding but not transport must surface as an explicit
+    # error, never as a corrupt image the caller cannot tell apart from a good one.
+    preview_errors = verify_preview_payloads(result.get("data"))
+    if preview_errors:
+        result["preview_integrity_errors"] = preview_errors
+        for error in preview_errors:
+            await ctx.info(f"manage_asset: dropped a corrupt preview payload — {error}")
+
     # Return the result obtained from Unity
-    return result if isinstance(result, dict) else {"success": False, "message": str(result)}
+    return result

--- a/Server/src/services/tools/preview_integrity.py
+++ b/Server/src/services/tools/preview_integrity.py
@@ -1,0 +1,95 @@
+"""
+Integrity verification for asset preview payloads.
+
+manage_asset's generate_preview path encodes a PNG in C#, base64s it, and ships it
+across the Unity bridge. Issue #36 reports previews arriving decodable-but-corrupt
+(garbled IDAT). Two layers could be responsible — the C# render-texture readback, or
+the base64/JSON transport — and nothing measured either, so the question stayed open.
+
+The editor now reports the raw PNG's byte length and SHA-256 alongside the base64.
+Comparing those against what actually arrived settles it in one shot:
+
+- digests match  -> the bytes crossed the wire intact; any corruption is in the C#
+  encode (render-texture format / colour space), not the transport.
+- digests differ -> the transport mangled or truncated the payload.
+
+Either way a payload that fails the check is removed rather than handed back, so a
+consumer gets an explicit error instead of a corrupt image.
+"""
+import base64
+import hashlib
+from typing import Any
+
+PREVIEW_KEY = "previewBase64"
+LENGTH_KEY = "previewByteLength"
+SHA_KEY = "previewSha256"
+ERROR_KEY = "previewIntegrityError"
+
+
+def _check_record(record: dict[str, Any]) -> str | None:
+    """Verifies one asset record in place. Returns an error string, or None if fine."""
+    encoded = record.get(PREVIEW_KEY)
+    if not encoded or not isinstance(encoded, str):
+        return None
+
+    expected_length = record.get(LENGTH_KEY)
+    expected_sha = record.get(SHA_KEY)
+
+    # An editor package predating the integrity fields reports neither. Nothing to
+    # verify, and inventing a failure there would be worse than staying quiet.
+    if expected_length is None and expected_sha is None:
+        return None
+
+    try:
+        decoded = base64.b64decode(encoded, validate=True)
+    except Exception as e:
+        error = f"previewBase64 is not valid base64 ({e})."
+        record[PREVIEW_KEY] = None
+        record[ERROR_KEY] = error
+        return error
+
+    if isinstance(expected_length, int) and len(decoded) != expected_length:
+        error = (
+            f"preview payload truncated in transit: decoded {len(decoded)} bytes, "
+            f"editor encoded {expected_length}."
+        )
+        record[PREVIEW_KEY] = None
+        record[ERROR_KEY] = error
+        return error
+
+    if isinstance(expected_sha, str) and expected_sha:
+        actual_sha = hashlib.sha256(decoded).hexdigest()
+        if actual_sha.lower() != expected_sha.lower():
+            error = (
+                "preview payload altered in transit: decoded bytes hash to "
+                f"{actual_sha}, editor reported {expected_sha}."
+            )
+            record[PREVIEW_KEY] = None
+            record[ERROR_KEY] = error
+            return error
+
+    return None
+
+
+def verify_preview_payloads(payload: Any) -> list[str]:
+    """
+    Walks a manage_asset response, verifying every asset record carrying a preview.
+    Corrupt payloads are stripped in place. Returns every error found, newest last.
+    """
+    errors: list[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if PREVIEW_KEY in node:
+                error = _check_record(node)
+                if error:
+                    path = node.get("path") or node.get("guid") or "<unknown asset>"
+                    errors.append(f"{path}: {error}")
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(payload)
+    return errors

--- a/Server/tests/integration/test_preview_integrity.py
+++ b/Server/tests/integration/test_preview_integrity.py
@@ -1,0 +1,109 @@
+"""
+Tests for asset-preview integrity verification (issue #36).
+
+The producing side reports the raw PNG's byte length and SHA-256 next to the base64.
+These tests pin what happens when the arriving payload disagrees with those numbers —
+including the case where it agrees, which is the one that must stay silent.
+"""
+import base64
+import hashlib
+
+import pytest
+
+from services.tools.preview_integrity import verify_preview_payloads
+
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"fake-idat-payload" * 4
+
+
+def _record(**overrides):
+    record = {
+        "path": "Assets/Demos/RedBoss_Tinted.mat",
+        "guid": "0123456789abcdef0123456789abcdef",
+        "previewBase64": base64.b64encode(PNG_BYTES).decode("ascii"),
+        "previewByteLength": len(PNG_BYTES),
+        "previewSha256": hashlib.sha256(PNG_BYTES).hexdigest(),
+        "previewWidth": 128,
+        "previewHeight": 128,
+    }
+    record.update(overrides)
+    return record
+
+
+def test_intact_payload_reports_no_error_and_is_left_alone():
+    record = _record()
+    original = record["previewBase64"]
+
+    assert verify_preview_payloads({"asset": record}) == []
+    assert record["previewBase64"] == original
+    assert "previewIntegrityError" not in record
+
+
+def test_truncated_payload_is_rejected_and_stripped():
+    truncated = PNG_BYTES[:10]
+    record = _record(previewBase64=base64.b64encode(truncated).decode("ascii"))
+
+    errors = verify_preview_payloads({"asset": record})
+
+    assert len(errors) == 1
+    assert "truncated in transit" in errors[0]
+    assert "decoded 10 bytes" in errors[0]
+    assert record["path"] in errors[0]
+    assert record["previewBase64"] is None, "A corrupt payload must not be handed back."
+    assert "previewIntegrityError" in record
+
+
+def test_altered_payload_of_the_same_length_is_rejected():
+    """The failure the byte-length check alone cannot see: same size, different bytes."""
+    altered = bytearray(PNG_BYTES)
+    altered[12] ^= 0xFF
+    record = _record(previewBase64=base64.b64encode(bytes(altered)).decode("ascii"))
+
+    errors = verify_preview_payloads({"asset": record})
+
+    assert len(errors) == 1
+    assert "altered in transit" in errors[0]
+    assert record["previewBase64"] is None
+
+
+def test_undecodable_payload_is_rejected():
+    record = _record(previewBase64="not!valid!base64!")
+
+    errors = verify_preview_payloads({"asset": record})
+
+    assert len(errors) == 1
+    assert "not valid base64" in errors[0]
+    assert record["previewBase64"] is None
+
+
+def test_record_without_integrity_fields_is_left_alone():
+    """An editor package predating the integrity fields must not be flagged."""
+    record = _record()
+    del record["previewByteLength"]
+    del record["previewSha256"]
+    original = record["previewBase64"]
+
+    assert verify_preview_payloads({"asset": record}) == []
+    assert record["previewBase64"] == original
+
+
+def test_record_without_a_preview_is_left_alone():
+    record = {"path": "Assets/Foo.mat", "previewBase64": None, "previewByteLength": 0}
+    assert verify_preview_payloads({"asset": record}) == []
+
+
+def test_walks_nested_lists_of_records():
+    good = _record(path="Assets/Good.mat")
+    bad = _record(path="Assets/Bad.mat", previewBase64=base64.b64encode(b"short").decode("ascii"))
+
+    errors = verify_preview_payloads({"assets": [good, {"nested": [bad]}]})
+
+    assert len(errors) == 1
+    assert "Assets/Bad.mat" in errors[0]
+    assert good["previewBase64"] is not None
+    assert bad["previewBase64"] is None
+
+
+def test_sha_comparison_is_case_insensitive():
+    record = _record(previewSha256=hashlib.sha256(PNG_BYTES).hexdigest().upper())
+    assert verify_preview_payloads({"asset": record}) == []


### PR DESCRIPTION
Refs #36 — deliberately **not** `Fixes`. See "What this does not do" below.

## Why this and not the encoding fix

Shape 2 (null `previewBase64`) is already fixed on `beta` — `GetAssetDataAsync` awaits `WaitForAssetPreviewAsync`, which polls across real editor ticks and distinguishes "timed out while still loading" from "unsupported". Shape 1 (decodable-but-corrupt PNG, garbled IDAT) is untouched, exactly as the maintainer's 2026-08-11 comment said it would be, and the issue is open for it.

That comment also set the order of work: **settle encode-vs-transport before changing any encoding.** Two layers are live suspects — the C# render-texture readback (`RenderTexture.GetTemporary` with no format / `RenderTextureReadWrite` argument, so it inherits the project's linear/sRGB default; `TextureFormat.RGB24`, which discards alpha) and the base64/JSON transport. Nothing measured either: there was no length or checksum on either side, and `grep previewBase64` across the repo returned only the producing sites in `ManageAsset.cs` — **zero consumers or validators under `Server/`**.

So the question that was supposed to be answered first had no instrument to answer it with. This PR builds the instrument, and leaves the encoding alone.

## What it does

**Producer** (`MCPForUnity/Editor/Tools/ManageAsset.cs`) — the raw PNG's byte length and lowercase-hex SHA-256 are computed at encode time and threaded through `BuildAssetDataRecord` as `previewByteLength` / `previewSha256`, alongside `previewBase64`.

**Consumer** (`Server/src/services/tools/preview_integrity.py`, wired into `manage_asset`) — the arriving base64 is decoded and checked against both:

- **digests match** -> the bytes crossed the wire intact; any corruption is in the C# encode, and the fix belongs in `ManageAsset.cs`.
- **digests differ** -> the transport mangled or truncated the payload, and the fix belongs under `Server/src/transport/`.

Either way a payload failing the check is **stripped and reported** as `preview_integrity_errors`, rather than handed back as an image the caller cannot distinguish from a good one. That is the issue's step-3 guard.

Backward compatible: a record carrying neither field — an editor package predating this change — is left untouched, so a new server against an old package reports no false failures.

**Deliberately omitted from the sketch:** writing every PNG to `Temp/mcp-preview-{guid}.png` for manual comparison. The digest already answers encode-vs-transport, without a per-preview disk side effect on every `get_info`.

## Tests

`Server/tests/integration/test_preview_integrity.py`, 8 cases:

- an intact payload reports nothing and is left byte-identical (the case that must stay silent);
- a truncated payload is rejected, named by asset path, and stripped;
- **an altered payload of the same length is rejected** — the failure a byte-length check alone cannot see, which is why the SHA is there and not just the length;
- an undecodable payload is rejected;
- a record with no integrity fields is left alone (old-package compatibility);
- a record with no preview is left alone;
- nested lists of records are walked;
- SHA comparison is case-insensitive.

**Proved they can go red**, not just that they pass: with the verification body short-circuited, 4 of the 8 fail and the 4 pass-through cases stay green — which is the correct split, since those four assert that nothing is flagged.

- Full Python suite: **1575 passed, 0 failed** (1567 + the 8 new).
- The C# side parses clean under Roslyn (`csc` from the dotnet SDK, standalone) — zero `CS1xxx` diagnostics; only `CS0246`/`CS0518` missing-Unity-assembly errors. Note that `unity-tests` on this repo is a no-op — its editmode job passes in ~8s with `UNITY_LICENSE:` empty and `Unity license secrets missing; skipping Unity tests.` — so no green here should be read as C# behaviour verification.

## What this does not do

It does not fix the corruption. The follow-up — the `RenderTextureReadWrite.sRGB` / `TextureFormat.RGBA32` change at `ManageAsset.cs`, or a transport fix — is gated on running one `generate_preview` with this build and reading whether the digests agree. That needs the reporter's environment (Unity 6000.5.6f1, URP 17.5.0, linear, Linux) with `Assets/Demos/RPG/BattleDemo/Prefabs/RedBoss_Tinted.mat`. Keeping #36 open is the point, not an oversight.

Base is `beta`, not `main`: `origin/HEAD -> origin/beta`, and `main` is 736 commits behind with 0 unique commits.