### PR TITLE
docs(reference): regenerate stale tool reference

### DIFF
--- a/website/docs/reference/tools/core/index.md
+++ b/website/docs/reference/tools/core/index.md
@@ -18,23 +18,50 @@ Essential scene, script, asset & editor tools (always on by default)
 - **[`find_gameobjects`](./find_gameobjects.md)** — Search for GameObjects in the scene by name, tag, layer, component type, or path.
 - **[`find_in_file`](./find_in_file.md)** — Searches a file with a regex pattern and returns line numbers and excerpts.
 - **[`get_sha`](./get_sha.md)** — Get SHA256 and basic metadata for a Unity C# script without returning file contents.
+- **[`manage_addressables`](./manage_addressables.md)** — Unity Addressables asset system operations.
 - **[`manage_asset`](./manage_asset.md)** — Performs asset operations (import, create, modify, delete, etc.) in Unity.
+- **[`manage_asset_hunter`](./manage_asset_hunter.md)** — Interact with Asset Hunter Pro to analyze project assets.
+- **[`manage_audio`](./manage_audio.md)** — Unity audio system management.
+- **[`manage_behavior`](./manage_behavior.md)** — Unity Behavior (AI) operations.
 - **[`manage_build`](./manage_build.md)** — Manage Unity player builds — trigger builds, switch platforms, configure settings, manage build scenes and profiles, run batch builds across platforms.
 - **[`manage_camera`](./manage_camera.md)** — Manage cameras (Unity Camera + Cinemachine).
+- **[`manage_cinemachine`](./manage_cinemachine.md)** — Unity Cinemachine virtual camera management.
 - **[`manage_components`](./manage_components.md)** — Add, remove, or set properties on components attached to GameObjects.
+- **[`manage_dots`](./manage_dots.md)** — Debug and monitor Unity DOTS ECS at runtime.
+- **[`manage_dots_graphics`](./manage_dots_graphics.md)** — Debug Unity DOTS Entities Graphics rendering at runtime.
+- **[`manage_dots_physics`](./manage_dots_physics.md)** — Debug Unity DOTS Physics at runtime.
+- **[`manage_dots_subscene`](./manage_dots_subscene.md)** — Manage Unity DOTS SubScenes at runtime.
 - **[`manage_editor`](./manage_editor.md)** — Controls and queries the Unity editor's state and settings.
 - **[`manage_gameobject`](./manage_gameobject.md)** — Performs CRUD operations on GameObjects.
 - **[`manage_graphics`](./manage_graphics.md)** — Manage rendering graphics: volumes, post-processing, light baking, rendering stats, pipeline settings, and URP renderer features.
+- **[`manage_input_system`](./manage_input_system.md)** — Unity Input System inspection.
+- **[`manage_lighting`](./manage_lighting.md)** — Unity lighting system management.
+- **[`manage_localization`](./manage_localization.md)** — Unity Localization operations.
 - **[`manage_material`](./manage_material.md)** — Manages Unity materials (set properties, colors, shaders, etc).
+- **[`manage_mesh`](./manage_mesh.md)** — Inspect and modify Unity Mesh data on GameObjects.
+- **[`manage_navigation`](./manage_navigation.md)** — Unity AI Navigation management.
+- **[`manage_netcode`](./manage_netcode.md)** — Unity Netcode for GameObjects operations.
 - **[`manage_packages`](./manage_packages.md)** — Manage Unity packages: query, install, remove, embed, and configure registries.
 - **[`manage_physics`](./manage_physics.md)** — Manage physics settings, collision matrix, materials, joints, queries, and validation.
+- **[`manage_physics2d`](./manage_physics2d.md)** — Unity 2D physics operations.
 - **[`manage_prefabs`](./manage_prefabs.md)** — Manages Unity Prefab assets.
+- **[`manage_render_pipeline`](./manage_render_pipeline.md)** — Unity render pipeline management (URP/HDRP).
 - **[`manage_scene`](./manage_scene.md)** — Performs CRUD operations on Unity scenes.
 - **[`manage_script`](./manage_script.md)** — Compatibility router for legacy script operations.
 - **[`manage_script_capabilities`](./manage_script_capabilities.md)** — Get manage_script capabilities (supported ops, limits, and guards).
+- **[`manage_shader_tool`](./manage_shader_tool.md)** — Inspect and manage Unity shaders at runtime.
+- **[`manage_splines`](./manage_splines.md)** — Unity Splines operations.
+- **[`manage_terrain`](./manage_terrain.md)** — Inspect and modify Unity Terrain at runtime or in Edit mode.
+- **[`manage_tilemap`](./manage_tilemap.md)** — Unity 2D Tilemap operations.
+- **[`manage_timeline`](./manage_timeline.md)** — Unity Timeline management.
 - **[`manage_tools`](./manage_tools.md)** — Manage which tool groups are visible in this session.
+- **[`manage_ui_toolkit`](./manage_ui_toolkit.md)** — Unity UI Toolkit (UIElements) operations.
+- **[`manage_video`](./manage_video.md)** — Unity VideoPlayer operations.
 - **[`read_console`](./read_console.md)** — Gets messages from or clears the Unity Editor console.
 - **[`refresh_unity`](./refresh_unity.md)** — Request a Unity asset database refresh and optionally a script compilation.
+- **[`reimport_assets`](./reimport_assets.md)** — Reimport specific Unity assets by path.
+- **[`rendering_stats`](./rendering_stats.md)** — Read Unity rendering and performance statistics.
 - **[`script_apply_edits`](./script_apply_edits.md)** — Structured C# edits (methods/classes) with safer boundaries - prefer this over raw text.
 - **[`set_active_instance`](./set_active_instance.md)** — Set the active Unity instance for this client/session.
 - **[`validate_script`](./validate_script.md)** — Validate a C# script and return diagnostics.
+- **[`validation_snapshot`](./validation_snapshot.md)** — Capture a full runtime validation snapshot in ONE call — entity counts (total/alive/dead/by-team), health distribution (min/max/mean), position samples, NaN bounds check, rendering stats (FPS/draw calls/batches), battle state, console er…

--- a/website/docs/reference/tools/core/manage_addressables.md
+++ b/website/docs/reference/tools/core/manage_addressables.md
@@ -1,0 +1,38 @@
+---
+title: manage_addressables
+sidebar_label: manage_addressables
+description: "Unity Addressables asset system operations."
+---
+
+# `manage_addressables`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_addressables`
+
+## Description
+
+Unity Addressables asset system operations. Actions: list_groups (all Addressable groups), get_group (entries, schemas, build/load paths), list_entries (entries in group with addresses and labels), get_entry (entry detail — GUID, address, labels), list_labels (all labels in settings), build (build Addressable content), analyze (run analyze rules for duplicates/issues). Requires com.unity.addressables package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_groups', 'get_group', 'list_entries', 'get_entry', 'list_labels', 'build', 'analyze']` | yes | Action to perform on Unity Addressables. |
+| `group_name` | `str \| None` | — | Addressable group name |
+| `address` | `str \| None` | — | Addressable entry address |
+| `guid` | `str \| None` | — | Addressable entry GUID |
+| `clean` | `bool \| None` | — | Clean build (for build action) |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_asset_hunter.md
+++ b/website/docs/reference/tools/core/manage_asset_hunter.md
@@ -1,0 +1,37 @@
+---
+title: manage_asset_hunter
+sidebar_label: manage_asset_hunter
+description: "Interact with Asset Hunter Pro to analyze project assets."
+---
+
+# `manage_asset_hunter`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_asset_hunter`
+
+## Description
+
+Interact with Asset Hunter Pro to analyze project assets. Actions: 'scan_unused' (find unused assets from latest build report), 'get_duplicates' (find duplicate assets by content hash), 'get_dependencies' (query asset references or reverse references), 'get_build_report' (summary of latest build report), 'get_settings' (current exclusion/ignore settings). Requires HeurekaGames Asset Hunter PRO package. Build report actions require a prior Unity build with AHP enabled.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['scan_unused', 'get_duplicates', 'get_dependencies', 'get_build_report', 'get_settings']` | yes | Action to perform. |
+| `asset_path` | `str \| None` | — | Asset path for 'get_dependencies' (e.g. 'Assets/Sprites/icon.png'). |
+| `direction` | `Literal['references', 'referenced_by'] \| None` | — | For 'get_dependencies': 'references' = what this asset uses, 'referenced_by' = what uses this asset. Default: 'references'. |
+| `filter_type` | `str \| None` | — | For 'scan_unused': filter by asset type name (e.g. 'Texture2D', 'Material'). |
+| `page_size` | `int \| str \| None` | — | Items per page (default 50, max 500). |
+| `cursor` | `int \| str \| None` | — | Paging cursor (0-based offset). Use nextCursor from previous response. |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_audio.md
+++ b/website/docs/reference/tools/core/manage_audio.md
@@ -1,0 +1,39 @@
+---
+title: manage_audio
+sidebar_label: manage_audio
+description: "Unity audio system management."
+---
+
+# `manage_audio`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_audio`
+
+## Description
+
+Unity audio system management. Actions: list_sources (all AudioSource components), get_source (full AudioSource detail), set_source (modify volume, pitch, spatial blend), play/stop/pause (control playback — Play mode only), list_clips (AudioClip assets in project), get_clip_info (clip length, frequency, channels, load type), list_mixers (AudioMixer assets), get_mixer (mixer groups, exposed params, current values), set_mixer_param (set exposed mixer float). Uses built-in UnityEngine.Audio — no package dependency.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_sources', 'get_source', 'set_source', 'play', 'stop', 'pause', 'list_clips', 'get_clip_info', 'list_mixers', 'get_mixer', 'set_mixer_param']` | yes | Action to perform on Unity audio. |
+| `target` | `str \| None` | — | GameObject name/ID (for source actions) or asset path/name (for clip/mixer) |
+| `properties` | `str \| None` | — | JSON object of properties to set |
+| `param_name` | `str \| None` | — | Exposed mixer parameter name (for set_mixer_param) |
+| `value` | `float \| None` | — | Value to set (for set_mixer_param) |
+| `filter` | `str \| None` | — | Name filter for list operations |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_behavior.md
+++ b/website/docs/reference/tools/core/manage_behavior.md
@@ -1,0 +1,37 @@
+---
+title: manage_behavior
+sidebar_label: manage_behavior
+description: "Unity Behavior (AI) operations."
+---
+
+# `manage_behavior`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_behavior`
+
+## Description
+
+Unity Behavior (AI) operations. Actions: list_agents (all BehaviorGraphAgent components), get_agent (graph name, running state, current node), list_variables (blackboard variables on agent), get_variable (variable name, type, value), set_variable (set blackboard variable value). Requires com.unity.behavior package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_agents', 'get_agent', 'list_variables', 'get_variable', 'set_variable']` | yes | Action to perform on Unity Behavior. |
+| `target` | `str \| None` | — | GameObject name or instance ID with BehaviorGraphAgent |
+| `variable_name` | `str \| None` | — | Blackboard variable name |
+| `value` | `str \| None` | — | Variable value to set (as string) |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_camera.md
+++ b/website/docs/reference/tools/core/manage_camera.md
@@ -41,7 +41,7 @@ CAMERA CONTROL:
 - list_cameras: List all cameras with status
 
 CAPTURE:
-- screenshot: Capture a screenshot. By default (no camera specified) uses ScreenCapture API, which captures all render layers including Screen Space - Overlay UI canvases. Specifying a camera uses direct camera rendering, which EXCLUDES Screen Space - Overlay canvases (use only when you need a specific viewpoint without UI). Supports include_image=true for inline base64 PNG, batch='surround' for 6-angle contact sheet, batch='orbit' for configurable grid, view_target/view_position for positioned capture, and capture_source='scene_view' to capture the active Unity Scene View viewport.
+- screenshot: Capture a screenshot. By default (no camera specified) uses ScreenCapture API, which captures all render layers including Screen Space - Overlay UI canvases. Specifying a camera uses direct camera rendering, which EXCLUDES Screen Space - Overlay canvases (use only when you need a specific viewpoint without UI). Supports include_image=true for inline base64 PNG, batch='surround' for 6-angle contact sheet, batch='orbit' for configurable grid, view_target/view_position for positioned capture, capture_source='scene_view' to capture the active Unity Scene View viewport, and capture_source='screen' to capture the full Game View including OnGUI/IMGUI overlays.
 - screenshot_multiview: Shorthand for screenshot with batch='surround' and include_image=true.
 
 ## Parameters
@@ -57,7 +57,7 @@ CAPTURE:
 | `camera` | `str \| None` | — | Camera to capture from (name, path, or instance ID). Omit to use ScreenCapture API (captures all layers including Screen Space Overlay UI). Specify only when you need a particular camera viewpoint; note that Screen Space - Overlay canvases will NOT appear in camera-rendered captures. |
 | `include_image` | `bool \| str \| None` | — | If true, return screenshot as inline base64 PNG. Default false. |
 | `max_resolution` | `int \| str \| None` | — | Max resolution (longest edge px) for inline image. Default 640. |
-| `capture_source` | `Literal['game_view', 'scene_view'] \| None` | — | Screenshot source. 'game_view' (default) captures the game/camera path; 'scene_view' captures the active Unity Scene View viewport. |
+| `capture_source` | `Literal['game_view', 'scene_view', 'screen'] \| None` | — | Screenshot source. 'game_view' (default) captures the game/camera path; 'scene_view' captures the active Unity Scene View viewport; 'screen' captures the full Game View including OnGUI/IMGUI overlays (requires Screen Capture module). |
 | `batch` | `str \| None` | — | Batch capture mode: 'surround' (6 angles) or 'orbit' (configurable grid). |
 | `view_target` | `str \| int \| list[float] \| None` | — | Target to focus on. GameObject name/path/ID or [x,y,z]. For game_view: aims camera at target. For scene_view: frames the Scene View on the target. |
 | `view_position` | `list[float] \| str \| None` | — | World position [x,y,z] to place camera for positioned capture. |

--- a/website/docs/reference/tools/core/manage_cinemachine.md
+++ b/website/docs/reference/tools/core/manage_cinemachine.md
@@ -1,0 +1,37 @@
+---
+title: manage_cinemachine
+sidebar_label: manage_cinemachine
+description: "Unity Cinemachine virtual camera management."
+---
+
+# `manage_cinemachine`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_cinemachine`
+
+## Description
+
+Unity Cinemachine virtual camera management. Actions: list_vcams (all CinemachineCamera components), get_vcam (priority, follow/look-at, body/aim settings), set_vcam (modify priority, follow target), get_brain (active camera, blend state, default blend), set_priority (change camera priority), list_blends (custom blend definitions). Requires com.unity.cinemachine package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_vcams', 'get_vcam', 'set_vcam', 'get_brain', 'set_priority', 'list_blends']` | yes | Action to perform on Unity Cinemachine. |
+| `target` | `str \| None` | — | GameObject name or instance ID |
+| `properties` | `str \| None` | — | JSON object of properties to set |
+| `priority` | `int \| None` | — | Camera priority value |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_dots.md
+++ b/website/docs/reference/tools/core/manage_dots.md
@@ -1,0 +1,46 @@
+---
+title: manage_dots
+sidebar_label: manage_dots
+description: "Debug and monitor Unity DOTS ECS at runtime."
+---
+
+# `manage_dots`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_dots`
+
+## Description
+
+Debug and monitor Unity DOTS ECS at runtime. Actions: list_worlds (show all ECS Worlds), query_entities (find entities by component types), get_entity (inspect entity components — use component_types to filter specific components), list_systems (list systems with enabled status), get_system (system details, queries, ordering), performance_snapshot (chunk utilization, archetype stats, entity counts), toggle_system (enable/disable a system for debugging), list_component_types (discover all registered ECS types with optional filter), create_entity (create debug entity with components), destroy_entity (destroy entity by index/version), set_component (modify a component field value at runtime), add_component (add a component to an existing entity), remove_component (remove a component from an entity), query_count (fast entity count without fetching data), inspect_bdp_tree (show BDP behavior tree state — active branch, running task, task statuses). Requires com.unity.entities package. Most actions work in Edit mode; performance_snapshot and inspect_bdp_tree are most useful during Play mode.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_worlds', 'query_entities', 'get_entity', 'list_systems', 'get_system', 'performance_snapshot', 'toggle_system', 'list_component_types', 'create_entity', 'destroy_entity', 'set_component', 'add_component', 'remove_component', 'query_count', 'inspect_bdp_tree']` | yes | Action to perform on DOTS ECS data. |
+| `component_types` | `str \| None` | — | Comma-separated component type names for query_entities/create_entity/get_entity filter (e.g. 'Health,NavigationTarget') |
+| `entity_index` | `int \| None` | — | Entity index for get_entity/destroy_entity |
+| `entity_version` | `int \| None` | — | Entity version for get_entity/destroy_entity (default 1) |
+| `system_name` | `str \| None` | — | System name (short or full) for get_system/toggle_system |
+| `enabled` | `bool \| str \| None` | — | Enable/disable for toggle_system (true/false) |
+| `component_name` | `str \| None` | — | Component type name for set_component/add_component/remove_component |
+| `field_name` | `str \| None` | — | Field name to modify (for set_component) |
+| `field_value` | `str \| None` | — | New field value as string (for set_component) |
+| `world` | `str \| None` | — | Target world name (defaults to DefaultGameObjectInjectionWorld) |
+| `group` | `str \| None` | — | Filter systems by group name (for list_systems) |
+| `filter` | `str \| None` | — | Name filter for list_component_types |
+| `category` | `str \| None` | — | Category filter for list_component_types (e.g. 'BufferData', 'ComponentData') |
+| `page_size` | `int \| None` | — | Max entities/types to return (default 20, max 200) |
+| `limit` | `int \| None` | — | Max archetypes in performance_snapshot (default 20) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_dots_graphics.md
+++ b/website/docs/reference/tools/core/manage_dots_graphics.md
@@ -1,0 +1,35 @@
+---
+title: manage_dots_graphics
+sidebar_label: manage_dots_graphics
+description: "Debug Unity DOTS Entities Graphics rendering at runtime."
+---
+
+# `manage_dots_graphics`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_dots_graphics`
+
+## Description
+
+Debug Unity DOTS Entities Graphics rendering at runtime. Actions: get_render_stats (count rendered entities, LOD groups), list_rendered_entities (list entities with MaterialMeshInfo), get_entity_rendering (inspect render bounds, material, mesh, filter settings), list_registered_materials (unique materials from RenderMeshArrays), list_registered_meshes (unique meshes with vertex counts). Requires com.unity.entities.graphics package. Works best during Play mode.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['get_render_stats', 'list_rendered_entities', 'get_entity_rendering', 'list_registered_materials', 'list_registered_meshes']` | yes | Action to perform on DOTS Graphics data. |
+| `entity_index` | `int \| None` | — | Entity index (for get_entity_rendering) |
+| `world` | `str \| None` | — | Target world name |
+| `page_size` | `int \| None` | — | Max results to return (default 20) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_dots_physics.md
+++ b/website/docs/reference/tools/core/manage_dots_physics.md
@@ -1,0 +1,40 @@
+---
+title: manage_dots_physics
+sidebar_label: manage_dots_physics
+description: "Debug Unity DOTS Physics at runtime."
+---
+
+# `manage_dots_physics`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_dots_physics`
+
+## Description
+
+Debug Unity DOTS Physics at runtime. Actions: get_physics_world (body/joint counts), raycast (cast ray, get hit entities with position/normal), overlap_aabb (find bodies in axis-aligned bounding box), list_colliders (list entities with PhysicsCollider), get_body (inspect physics body — position, velocity, collider type). Requires com.unity.physics package. Works best during Play mode.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['get_physics_world', 'raycast', 'overlap_aabb', 'list_colliders', 'get_body']` | yes | Action to perform on DOTS Physics data. |
+| `origin` | `str \| None` | — | Ray origin as 'x,y,z' (for raycast) |
+| `direction` | `str \| None` | — | Ray direction as 'x,y,z' (for raycast) |
+| `max_distance` | `float \| None` | — | Max ray distance (default 100) |
+| `min` | `str \| None` | — | AABB min corner as 'x,y,z' (for overlap_aabb) |
+| `max` | `str \| None` | — | AABB max corner as 'x,y,z' (for overlap_aabb) |
+| `body_index` | `int \| None` | — | Physics body index (for get_body) |
+| `world` | `str \| None` | — | Target world name |
+| `page_size` | `int \| None` | — | Max results to return (default 20) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_dots_subscene.md
+++ b/website/docs/reference/tools/core/manage_dots_subscene.md
@@ -1,0 +1,33 @@
+---
+title: manage_dots_subscene
+sidebar_label: manage_dots_subscene
+description: "Manage Unity DOTS SubScenes at runtime."
+---
+
+# `manage_dots_subscene`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_dots_subscene`
+
+## Description
+
+Manage Unity DOTS SubScenes at runtime. Actions: list_subscenes (find all SubScene components in hierarchy), load_subscene (request async scene loading), unload_subscene (unload scene and destroy meta entities), get_subscene_status (streaming state, section counts, asset path), list_sections (inspect individual scene sections and their load state). Requires com.unity.entities package. Works best during Play mode.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_subscenes', 'load_subscene', 'unload_subscene', 'get_subscene_status', 'list_sections']` | yes | Action to perform on DOTS SubScenes. |
+| `scene_name` | `str \| None` | — | SubScene name or GameObject name (for load/unload/status/sections) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_input_system.md
+++ b/website/docs/reference/tools/core/manage_input_system.md
@@ -1,0 +1,38 @@
+---
+title: manage_input_system
+sidebar_label: manage_input_system
+description: "Unity Input System inspection."
+---
+
+# `manage_input_system`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_input_system`
+
+## Description
+
+Unity Input System inspection. Actions: list_action_assets (find InputActionAsset in project), get_action_map (actions in a map with bindings), get_action (bindings, interactions, processors), list_devices (connected input devices), get_device (device layout, controls), list_player_inputs (find PlayerInput components). Requires com.unity.inputsystem package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_action_assets', 'get_action_map', 'get_action', 'list_devices', 'get_device', 'list_player_inputs']` | yes | Action to perform on Unity Input System. |
+| `asset` | `str \| None` | — | InputActionAsset name or path |
+| `map_name` | `str \| None` | — | Action map name |
+| `action_name` | `str \| None` | — | Input action name |
+| `device_name` | `str \| None` | — | Device name or layout |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_lighting.md
+++ b/website/docs/reference/tools/core/manage_lighting.md
@@ -1,0 +1,37 @@
+---
+title: manage_lighting
+sidebar_label: manage_lighting
+description: "Unity lighting system management."
+---
+
+# `manage_lighting`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_lighting`
+
+## Description
+
+Unity lighting system management. Actions: list_lights (all Light components, optional type filter), get_light (full light properties), set_light (modify color, intensity, range, shadows), bake (trigger lightmap bake — async), cancel_bake (cancel in-progress bake), get_bake_status (is baking? progress?), list_probes (light probes + reflection probes), get_probe (probe detail — type, bounds, mode), get_environment (RenderSettings — ambient, fog, skybox, sun), set_environment (modify RenderSettings), get_lightmap_settings (lightmapper config). Uses built-in Unity lighting APIs — no package dependency.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_lights', 'get_light', 'set_light', 'bake', 'cancel_bake', 'get_bake_status', 'list_probes', 'get_probe', 'get_environment', 'set_environment', 'get_lightmap_settings']` | yes | Action to perform on Unity lighting. |
+| `target` | `str \| None` | — | GameObject name or instance ID |
+| `properties` | `str \| None` | — | JSON object of properties to set |
+| `type_filter` | `str \| None` | — | Light type filter: Directional, Point, Spot, Area |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_localization.md
+++ b/website/docs/reference/tools/core/manage_localization.md
@@ -1,0 +1,38 @@
+---
+title: manage_localization
+sidebar_label: manage_localization
+description: "Unity Localization operations."
+---
+
+# `manage_localization`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_localization`
+
+## Description
+
+Unity Localization operations. Actions: list_locales (available locales), get_active_locale (current active locale), set_active_locale (switch active locale), list_tables (string/asset table collections), get_entry (get localized string for key+locale), set_entry (set localized string). Requires com.unity.localization package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_locales', 'get_active_locale', 'set_active_locale', 'list_tables', 'get_entry', 'set_entry']` | yes | Action to perform on Unity Localization. |
+| `locale_code` | `str \| None` | — | Locale code (e.g. 'en', 'ja', 'fr') |
+| `table` | `str \| None` | — | String table collection name |
+| `key` | `str \| None` | — | Localization key/entry name |
+| `locale` | `str \| None` | — | Target locale for get/set entry |
+| `value` | `str \| None` | — | Localized string value (for set_entry) |
+| `type` | `str \| None` | — | Table type: 'string' or 'asset' (for list_tables) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_mesh.md
+++ b/website/docs/reference/tools/core/manage_mesh.md
@@ -1,0 +1,37 @@
+---
+title: manage_mesh
+sidebar_label: manage_mesh
+description: "Inspect and modify Unity Mesh data on GameObjects."
+---
+
+# `manage_mesh`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_mesh`
+
+## Description
+
+Inspect and modify Unity Mesh data on GameObjects. Actions: inspect (all-in-one: info + attributes + color samples — use this first), get_info (vertex/triangle count, bounds, index format, submesh count, isReadable), get_attributes (list VertexAttributeDescriptor for each attribute: format, dimension, stream), has_attribute (check if mesh has a specific attribute: Position/Normal/Color/TexCoord0/Tangent/etc), sample_colors (sample vertex colors evenly spaced across the mesh), sample_vertices (sample vertex positions evenly spaced across the mesh), set_colors (set all vertex colors to a solid RGBA color), force_upload (call mesh.UploadMeshData(false) to upload pending changes). Target is a GameObject name or instance ID; mesh is read from its MeshFilter.sharedMesh.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['inspect', 'get_info', 'get_attributes', 'has_attribute', 'sample_colors', 'sample_vertices', 'set_colors', 'force_upload']` | yes | Action to perform on the mesh. |
+| `target` | `str` | yes | GameObject name or instance ID whose MeshFilter.sharedMesh will be used. |
+| `attribute` | `str \| None` | — | Vertex attribute name for has_attribute (e.g. Position, Normal, Color, TexCoord0, Tangent). |
+| `color` | `str \| None` | — | RGBA color as 'r,g,b,a' floats 0-1 for set_colors (e.g. '1,0,0,1' for red). |
+| `count` | `int \| None` | — | Number of samples to return for sample_* and inspect actions (default 10). |
+| `offset` | `int \| None` | — | Start offset index for sampling (default 0). |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_navigation.md
+++ b/website/docs/reference/tools/core/manage_navigation.md
@@ -1,0 +1,40 @@
+---
+title: manage_navigation
+sidebar_label: manage_navigation
+description: "Unity AI Navigation management."
+---
+
+# `manage_navigation`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_navigation`
+
+## Description
+
+Unity AI Navigation management. Actions: list_surfaces (all NavMeshSurface components), bake (bake NavMesh for a surface), clear (clear baked NavMesh), list_agents (all NavMeshAgent components), get_agent (speed, radius, destination, path status), set_agent_destination (set agent destination — Play mode), list_obstacles (all NavMeshObstacle components), sample_position (nearest point on NavMesh), calculate_path (path between two points). Requires com.unity.ai.navigation package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_surfaces', 'bake', 'clear', 'list_agents', 'get_agent', 'set_agent_destination', 'list_obstacles', 'sample_position', 'calculate_path']` | yes | Action to perform on Unity AI Navigation. |
+| `target` | `str \| None` | — | GameObject name or instance ID |
+| `position` | `str \| None` | — | Position as 'x,y,z' |
+| `start` | `str \| None` | — | Start position as 'x,y,z' (for calculate_path) |
+| `end` | `str \| None` | — | End position as 'x,y,z' (for calculate_path) |
+| `max_distance` | `float \| None` | — | Max sample distance (for sample_position) |
+| `area_mask` | `int \| None` | — | NavMesh area mask (default -1 = all) |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_netcode.md
+++ b/website/docs/reference/tools/core/manage_netcode.md
@@ -1,0 +1,35 @@
+---
+title: manage_netcode
+sidebar_label: manage_netcode
+description: "Unity Netcode for GameObjects operations."
+---
+
+# `manage_netcode`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_netcode`
+
+## Description
+
+Unity Netcode for GameObjects operations. Actions: get_network_manager (transport, connection state, clients), list_network_objects (all NetworkObject components), get_network_object (ownership, network ID, spawn state), start_host (start as host), start_server (start as server), start_client (start as client), shutdown (stop networking). Requires com.unity.netcode.gameobjects package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['get_network_manager', 'list_network_objects', 'get_network_object', 'start_host', 'start_server', 'start_client', 'shutdown']` | yes | Action to perform on Unity Netcode. |
+| `target` | `str \| None` | — | GameObject name or instance ID with NetworkObject |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_physics2d.md
+++ b/website/docs/reference/tools/core/manage_physics2d.md
@@ -1,0 +1,43 @@
+---
+title: manage_physics2d
+sidebar_label: manage_physics2d
+description: "Unity 2D physics operations."
+---
+
+# `manage_physics2d`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_physics2d`
+
+## Description
+
+Unity 2D physics operations. Actions: raycast (2D raycast), raycast_all (all 2D hits), overlap_circle (entities in circle), overlap_box (entities in box), list_rigidbodies (all Rigidbody2D), get_rigidbody (body type, mass, velocity, gravity scale), list_colliders (all Collider2D), get_physics2d_settings (gravity, collision matrix). Uses built-in UnityEngine.Physics2D — no package dependency.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['raycast', 'raycast_all', 'overlap_circle', 'overlap_box', 'list_rigidbodies', 'get_rigidbody', 'list_colliders', 'get_physics2d_settings']` | yes | Action to perform on Unity 2D physics. |
+| `origin` | `str \| None` | — | Ray origin as 'x,y' |
+| `direction` | `str \| None` | — | Ray direction as 'x,y' |
+| `max_distance` | `float \| None` | — | Max ray distance (default 100) |
+| `layer_mask` | `int \| None` | — | Layer mask for filtering (default -1 = all) |
+| `center` | `str \| None` | — | Overlap center as 'x,y' |
+| `radius` | `float \| None` | — | Circle radius (for overlap_circle) |
+| `size` | `str \| None` | — | Box size as 'x,y' (for overlap_box) |
+| `angle` | `float \| None` | — | Box rotation angle (for overlap_box) |
+| `target` | `str \| None` | — | GameObject name or instance ID |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_render_pipeline.md
+++ b/website/docs/reference/tools/core/manage_render_pipeline.md
@@ -1,0 +1,39 @@
+---
+title: manage_render_pipeline
+sidebar_label: manage_render_pipeline
+description: "Unity render pipeline management (URP/HDRP)."
+---
+
+# `manage_render_pipeline`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_render_pipeline`
+
+## Description
+
+Unity render pipeline management (URP/HDRP). Actions: get_pipeline_info (active render pipeline type, asset name), list_volumes (all Volume components — global/local), get_volume (volume profile overrides and values), set_volume_override (modify a volume override value), list_renderer_features (URP renderer features), get_render_pipeline_asset (active pipeline asset settings), list_post_processing (active post-processing effects summary), toggle_volume_override (enable/disable a specific override). Uses built-in GraphicsSettings — no package dependency.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['get_pipeline_info', 'list_volumes', 'get_volume', 'set_volume_override', 'list_renderer_features', 'get_render_pipeline_asset', 'list_post_processing', 'toggle_volume_override']` | yes | Action to perform on Unity render pipeline. |
+| `target` | `str \| None` | — | Volume GameObject name or instance ID |
+| `override_type` | `str \| None` | — | Volume override type name (e.g. Bloom, ColorAdjustments) |
+| `property` | `str \| None` | — | Override property name to set |
+| `value` | `str \| None` | — | Value to set (string representation) |
+| `enabled` | `bool \| None` | — | Enable/disable override (for toggle_volume_override) |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_shader_tool.md
+++ b/website/docs/reference/tools/core/manage_shader_tool.md
@@ -1,0 +1,34 @@
+---
+title: manage_shader_tool
+sidebar_label: manage_shader_tool
+description: "Inspect and manage Unity shaders at runtime."
+---
+
+# `manage_shader_tool`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_shader_tool`
+
+## Description
+
+Inspect and manage Unity shaders at runtime. Actions: reimport (force reimport a shader asset by path), get_errors (list compiler errors/warnings with file and line info), get_info (shader name, isSupported, pass count, subshader count, render queue), get_passes (list all passes with names and enabled state per subshader), find (locate shader by name, returns asset path and info), is_compiling (check if any shaders are currently compiling). Use 'path' param for asset-path-based lookup (e.g. 'Packages/com.foo/Shaders/MyShader.shader'), or 'name' for shader declaration name (e.g. 'Universal Render Pipeline/Lit').
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['reimport', 'get_errors', 'get_info', 'get_passes', 'find', 'is_compiling']` | yes | Action to perform on shaders. |
+| `path` | `str \| None` | — | Asset path to the shader (e.g. 'Assets/Shaders/MyShader.shader' or 'Packages/com.foo/MyShader.shader'). Used by: reimport, get_errors, get_info, get_passes. |
+| `name` | `str \| None` | — | Shader declaration name as used in Shader.Find() (e.g. 'Universal Render Pipeline/Lit'). Used by: find, get_errors, get_info, get_passes. |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_splines.md
+++ b/website/docs/reference/tools/core/manage_splines.md
@@ -1,0 +1,40 @@
+---
+title: manage_splines
+sidebar_label: manage_splines
+description: "Unity Splines operations."
+---
+
+# `manage_splines`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_splines`
+
+## Description
+
+Unity Splines operations. Actions: list_splines (all SplineContainer components), get_spline (knot count, length, closed state), get_knot (knot position, rotation, tangents), add_knot (add knot at position), remove_knot (remove knot by index), set_knot (modify knot position/tangents), evaluate (position/tangent/up at t 0-1). Requires com.unity.splines package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_splines', 'get_spline', 'get_knot', 'add_knot', 'remove_knot', 'set_knot', 'evaluate']` | yes | Action to perform on Unity Splines. |
+| `target` | `str \| None` | — | GameObject name or instance ID with SplineContainer |
+| `spline_index` | `int \| None` | — | Index of spline in container (default 0) |
+| `knot_index` | `int \| None` | — | Knot index within spline |
+| `position` | `str \| None` | — | Knot position as 'x,y,z' |
+| `rotation` | `str \| None` | — | Knot rotation as 'x,y,z,w' quaternion |
+| `t` | `float \| None` | — | Normalized position along spline (0-1) for evaluate |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_terrain.md
+++ b/website/docs/reference/tools/core/manage_terrain.md
@@ -1,0 +1,41 @@
+---
+title: manage_terrain
+sidebar_label: manage_terrain
+description: "Inspect and modify Unity Terrain at runtime or in Edit mode."
+---
+
+# `manage_terrain`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_terrain`
+
+## Description
+
+Inspect and modify Unity Terrain at runtime or in Edit mode. Actions: get_info (heightmap resolution, size, layer/tree counts), get_height (sample world-space height at x/z), set_heights (paint circular brush with set/raise/lower/smooth modes), flatten (set entire heightmap to uniform normalized height), get_splat_weights (texture layer weights at world position), paint_texture (paint terrain texture layer with circular brush), get_heightmap_sample (read NxN heightmap patch around world position). All actions accept an optional 'target' param (GameObject name or instance ID) to select a specific Terrain; defaults to the active terrain in the scene.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['get_info', 'get_height', 'set_heights', 'flatten', 'get_splat_weights', 'paint_texture', 'get_heightmap_sample']` | yes | Action to perform on the Terrain. |
+| `target` | `str \| None` | — | GameObject name or instance ID of the Terrain. Defaults to the active terrain. |
+| `x` | `float \| None` | — | World-space X coordinate (for get_height, set_heights, get_splat_weights, paint_texture, get_heightmap_sample) |
+| `z` | `float \| None` | — | World-space Z coordinate (for get_height, set_heights, get_splat_weights, paint_texture, get_heightmap_sample) |
+| `radius` | `float \| None` | — | Brush radius in world units (for set_heights, paint_texture) |
+| `height` | `float \| None` | — | Normalized height 0-1 (for set_heights, flatten) |
+| `mode` | `Literal['set', 'raise', 'lower', 'smooth'] \| None` | — | Brush mode for set_heights (default: set) |
+| `layer_index` | `int \| None` | — | Terrain layer index to paint (for paint_texture) |
+| `strength` | `float \| None` | — | Paint strength 0-1 (for paint_texture) |
+| `size` | `int \| None` | — | Patch size NxN in heightmap pixels, clamped to 64 (for get_heightmap_sample) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_tilemap.md
+++ b/website/docs/reference/tools/core/manage_tilemap.md
@@ -1,0 +1,39 @@
+---
+title: manage_tilemap
+sidebar_label: manage_tilemap
+description: "Unity 2D Tilemap operations."
+---
+
+# `manage_tilemap`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_tilemap`
+
+## Description
+
+Unity 2D Tilemap operations. Actions: list_tilemaps (all Tilemap components), get_info (size, cell layout, tile count), get_tile (tile at position), set_tile (place tile), clear_tile (remove tile), clear_all (clear entire tilemap), get_bounds (used tile bounds), fill_area (fill rectangle with tile). Requires com.unity.2d.tilemap package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_tilemaps', 'get_info', 'get_tile', 'set_tile', 'clear_tile', 'clear_all', 'get_bounds', 'fill_area']` | yes | Action to perform on Unity Tilemap. |
+| `target` | `str \| None` | — | GameObject name or instance ID with Tilemap component |
+| `position` | `str \| None` | — | Cell position as 'x,y,z' |
+| `tile_asset` | `str \| None` | — | Asset path to TileBase asset |
+| `min` | `str \| None` | — | Min cell position as 'x,y,z' (for fill_area) |
+| `max` | `str \| None` | — | Max cell position as 'x,y,z' (for fill_area) |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_timeline.md
+++ b/website/docs/reference/tools/core/manage_timeline.md
@@ -1,0 +1,36 @@
+---
+title: manage_timeline
+sidebar_label: manage_timeline
+description: "Unity Timeline management."
+---
+
+# `manage_timeline`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_timeline`
+
+## Description
+
+Unity Timeline management. Actions: list_directors (all PlayableDirector components), get_director (state, time, duration, wrap mode), play/pause/stop (control playback), set_time (seek to time), list_tracks (tracks in timeline asset), get_bindings (track-to-object bindings). Requires com.unity.timeline package.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_directors', 'get_director', 'play', 'pause', 'stop', 'set_time', 'list_tracks', 'get_bindings']` | yes | Action to perform on Unity Timeline. |
+| `target` | `str \| None` | — | GameObject name or instance ID |
+| `time` | `float \| None` | — | Time in seconds (for set_time) |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_ui_toolkit.md
+++ b/website/docs/reference/tools/core/manage_ui_toolkit.md
@@ -1,0 +1,39 @@
+---
+title: manage_ui_toolkit
+sidebar_label: manage_ui_toolkit
+description: "Unity UI Toolkit (UIElements) operations."
+---
+
+# `manage_ui_toolkit`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_ui_toolkit`
+
+## Description
+
+Unity UI Toolkit (UIElements) operations. Actions: list_documents (all UIDocument components), get_document (panel settings, source UXML, root element summary), query_elements (find elements by USS selector), get_element (element properties — style, class list, text, layout), set_style (modify inline style property), list_uxml_assets (find UXML assets in project). Uses built-in UIElements — no package dependency.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_documents', 'get_document', 'query_elements', 'get_element', 'set_style', 'list_uxml_assets']` | yes | Action to perform on Unity UI Toolkit. |
+| `target` | `str \| None` | — | GameObject name or instance ID with UIDocument |
+| `query` | `str \| None` | — | USS selector to find elements (e.g. '.my-class', '#my-id', 'Button') |
+| `property` | `str \| None` | — | Style property name (for set_style, e.g. 'background-color') |
+| `value` | `str \| None` | — | Style property value (for set_style) |
+| `filter` | `str \| None` | — | Filter string for asset search |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/manage_video.md
+++ b/website/docs/reference/tools/core/manage_video.md
@@ -1,0 +1,37 @@
+---
+title: manage_video
+sidebar_label: manage_video
+description: "Unity VideoPlayer operations."
+---
+
+# `manage_video`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.manage_video`
+
+## Description
+
+Unity VideoPlayer operations. Actions: list_players (all VideoPlayer components), get_player (URL/clip, playback state, time, length), set_player (modify source, playback speed, loop, audio output), play (play video), pause (pause video), stop (stop video), set_time (seek to time). Uses built-in UnityEngine.Video — no package dependency.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['list_players', 'get_player', 'set_player', 'play', 'pause', 'stop', 'set_time']` | yes | Action to perform on Unity VideoPlayer. |
+| `target` | `str \| None` | — | GameObject name or instance ID with VideoPlayer |
+| `properties` | `str \| None` | — | JSON object with properties to set (for set_player) |
+| `time` | `float \| None` | — | Time in seconds (for set_time) |
+| `page_size` | `int \| None` | — | Max results to return (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor (0-based offset) |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/refresh_unity.md
+++ b/website/docs/reference/tools/core/refresh_unity.md
@@ -22,6 +22,7 @@ Request a Unity asset database refresh and optionally a script compilation. Can 
 | `scope` | `Literal['assets', 'scripts', 'all']` | — | Refresh scope |
 | `compile` | `Literal['none', 'request']` | — | Whether to request compilation |
 | `wait_for_ready` | `bool` | — | If true, wait until editor_state.advice.ready_for_tools is true |
+| `allow_during_play` | `bool` | — | If false (default), refuse to refresh/compile while Play mode is active -- on a DOTS project that forces a domain reload that permanently disposes the ECS Default World for the rest of the Play session. Pass true only if you understand and accept that. |
 
 ## Returns
 

--- a/website/docs/reference/tools/core/reimport_assets.md
+++ b/website/docs/reference/tools/core/reimport_assets.md
@@ -1,0 +1,34 @@
+---
+title: reimport_assets
+sidebar_label: reimport_assets
+description: "Reimport specific Unity assets by path."
+---
+
+# `reimport_assets`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.reimport_assets`
+
+## Description
+
+Reimport specific Unity assets by path. Faster and more granular than 'Reimport All'. No confirmation dialog — works seamlessly in automated workflows. Supports individual files and recursive folder reimport.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `paths` | `list[str]` | yes | Asset paths to reimport (e.g. ['Assets/Prefabs/Unit.prefab', 'Assets/Shaders/']). |
+| `force` | `bool` | — | Use ForceUpdate import option. Default: true. |
+| `recursive` | `bool` | — | Recursively reimport all assets in folders. Default: true. |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/rendering_stats.md
+++ b/website/docs/reference/tools/core/rendering_stats.md
@@ -1,0 +1,37 @@
+---
+title: rendering_stats
+sidebar_label: rendering_stats
+description: "Read Unity rendering and performance statistics."
+---
+
+# `rendering_stats`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.rendering_stats`
+
+## Description
+
+Read Unity rendering and performance statistics. Actions: get_stats (single-frame snapshot: draw calls, batches, FPS, cpuMainMs), get_memory (allocated/reserved/mono/graphics memory), get_profiler (frame timing, time scale, system info), get_stats_aggregated (N-frame aggregated: min/max/avg/p50/p95 for FPS, CPU, draw calls — uses long-lived ProfilerRecorders, much more reliable than single snapshots. Param: frames=number of recent frames to aggregate, 0=all available), get_system_stats (per-DOTS-system CPU breakdown sorted by cost — shows which systems consume the most frame budget. Param: top_n=number of systems), get_session_report (full Play session report from start to stop — includes Markdown summary, JSON timeline, CSV. Params: include_timeline=bool, include_csv=bool), list_sessions (list saved session files from Logs/PerfSessions/ — works anytime), load_session (load a saved session JSON by filename), analyze_session (analyze a saved session: bottleneck detection, system ranking, issues. Param: filename=session JSON file). Aggregated/system/session actions require Play mode; list/load/analyze work anytime.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['get_stats', 'get_memory', 'get_profiler', 'get_stats_aggregated', 'get_system_stats', 'get_session_report', 'list_sessions', 'load_session', 'analyze_session']` | yes | Action to perform. get_stats=single snapshot, get_stats_aggregated=N-frame percentiles, get_system_stats=per-system CPU breakdown, get_session_report=full session timeline+summary, list_sessions=list saved sessions, load_session=load session JSON, analyze_session=bottleneck analysis. |
+| `frames` | `int \| None` | — | For get_stats_aggregated: number of recent frames (0=all). |
+| `top_n` | `int \| None` | — | For get_system_stats: number of top systems to return. |
+| `include_timeline` | `bool \| None` | — | For get_session_report: include JSON timeline. |
+| `include_csv` | `bool \| None` | — | For get_session_report: include CSV data. |
+| `filename` | `str \| None` | — | For load_session/analyze_session: session JSON filename. |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/core/validation_snapshot.md
+++ b/website/docs/reference/tools/core/validation_snapshot.md
@@ -1,0 +1,35 @@
+---
+title: validation_snapshot
+sidebar_label: validation_snapshot
+description: "Capture a full runtime validation snapshot in ONE call — entity counts (total/alive/dead/by-team), health distribution (min/max/mean), position samples, NaN bounds check, rendering stats (FPS/draw calls/batches), battle state, console er…"
+---
+
+# `validation_snapshot`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `core` &nbsp;·&nbsp; **Module:** `services.tools.validation_snapshot`
+
+## Description
+
+Capture a full runtime validation snapshot in ONE call — entity counts (total/alive/dead/by-team), health distribution (min/max/mean), position samples, NaN bounds check, rendering stats (FPS/draw calls/batches), battle state, console errors, editor state. Use 'compare' to diff two snapshots and detect movement, anomalies, deltas. Requires com.unity.entities + DOTSRPG components. Play mode required for entity data.
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['capture', 'compare']` | yes | Action: 'capture' collects all validation data, 'compare' diffs two snapshots. |
+| `sample_size` | `int \| None` | — | Number of entity positions to sample (default 20, max 100). For 'capture' only. |
+| `snapshot_a` | `dict[str, Any] \| str \| None` | — | Previous snapshot JSON (for 'compare' action). |
+| `snapshot_b` | `dict[str, Any] \| str \| None` | — | Current snapshot JSON (for 'compare' action). |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+

--- a/website/docs/reference/tools/index.md
+++ b/website/docs/reference/tools/index.md
@@ -16,7 +16,7 @@ Every tool MCP for Unity exposes, generated directly from the Python `@mcp_for_u
 Animator control & AnimationClip creation
 - **[`manage_animation`](./animation/manage_animation.md)** — Manage Unity animation: Animator control and AnimationClip creation.
 
-## `core` &nbsp; (30 tools)
+## `core` &nbsp; (57 tools)
 Essential scene, script, asset & editor tools (always on by default)
 - **[`apply_text_edits`](./core/apply_text_edits.md)** — Apply small text edits to a C# script identified by URI.
 - **[`batch_execute`](./core/batch_execute.md)** — Executes multiple MCP commands in a single batch for dramatically better performance.
@@ -28,26 +28,53 @@ Essential scene, script, asset & editor tools (always on by default)
 - **[`find_gameobjects`](./core/find_gameobjects.md)** — Search for GameObjects in the scene by name, tag, layer, component type, or path.
 - **[`find_in_file`](./core/find_in_file.md)** — Searches a file with a regex pattern and returns line numbers and excerpts.
 - **[`get_sha`](./core/get_sha.md)** — Get SHA256 and basic metadata for a Unity C# script without returning file contents.
+- **[`manage_addressables`](./core/manage_addressables.md)** — Unity Addressables asset system operations.
 - **[`manage_asset`](./core/manage_asset.md)** — Performs asset operations (import, create, modify, delete, etc.) in Unity.
+- **[`manage_asset_hunter`](./core/manage_asset_hunter.md)** — Interact with Asset Hunter Pro to analyze project assets.
+- **[`manage_audio`](./core/manage_audio.md)** — Unity audio system management.
+- **[`manage_behavior`](./core/manage_behavior.md)** — Unity Behavior (AI) operations.
 - **[`manage_build`](./core/manage_build.md)** — Manage Unity player builds — trigger builds, switch platforms, configure settings, manage build scenes and profiles, run batch builds across platforms.
 - **[`manage_camera`](./core/manage_camera.md)** — Manage cameras (Unity Camera + Cinemachine).
+- **[`manage_cinemachine`](./core/manage_cinemachine.md)** — Unity Cinemachine virtual camera management.
 - **[`manage_components`](./core/manage_components.md)** — Add, remove, or set properties on components attached to GameObjects.
+- **[`manage_dots`](./core/manage_dots.md)** — Debug and monitor Unity DOTS ECS at runtime.
+- **[`manage_dots_graphics`](./core/manage_dots_graphics.md)** — Debug Unity DOTS Entities Graphics rendering at runtime.
+- **[`manage_dots_physics`](./core/manage_dots_physics.md)** — Debug Unity DOTS Physics at runtime.
+- **[`manage_dots_subscene`](./core/manage_dots_subscene.md)** — Manage Unity DOTS SubScenes at runtime.
 - **[`manage_editor`](./core/manage_editor.md)** — Controls and queries the Unity editor's state and settings.
 - **[`manage_gameobject`](./core/manage_gameobject.md)** — Performs CRUD operations on GameObjects.
 - **[`manage_graphics`](./core/manage_graphics.md)** — Manage rendering graphics: volumes, post-processing, light baking, rendering stats, pipeline settings, and URP renderer features.
+- **[`manage_input_system`](./core/manage_input_system.md)** — Unity Input System inspection.
+- **[`manage_lighting`](./core/manage_lighting.md)** — Unity lighting system management.
+- **[`manage_localization`](./core/manage_localization.md)** — Unity Localization operations.
 - **[`manage_material`](./core/manage_material.md)** — Manages Unity materials (set properties, colors, shaders, etc).
+- **[`manage_mesh`](./core/manage_mesh.md)** — Inspect and modify Unity Mesh data on GameObjects.
+- **[`manage_navigation`](./core/manage_navigation.md)** — Unity AI Navigation management.
+- **[`manage_netcode`](./core/manage_netcode.md)** — Unity Netcode for GameObjects operations.
 - **[`manage_packages`](./core/manage_packages.md)** — Manage Unity packages: query, install, remove, embed, and configure registries.
 - **[`manage_physics`](./core/manage_physics.md)** — Manage physics settings, collision matrix, materials, joints, queries, and validation.
+- **[`manage_physics2d`](./core/manage_physics2d.md)** — Unity 2D physics operations.
 - **[`manage_prefabs`](./core/manage_prefabs.md)** — Manages Unity Prefab assets.
+- **[`manage_render_pipeline`](./core/manage_render_pipeline.md)** — Unity render pipeline management (URP/HDRP).
 - **[`manage_scene`](./core/manage_scene.md)** — Performs CRUD operations on Unity scenes.
 - **[`manage_script`](./core/manage_script.md)** — Compatibility router for legacy script operations.
 - **[`manage_script_capabilities`](./core/manage_script_capabilities.md)** — Get manage_script capabilities (supported ops, limits, and guards).
+- **[`manage_shader_tool`](./core/manage_shader_tool.md)** — Inspect and manage Unity shaders at runtime.
+- **[`manage_splines`](./core/manage_splines.md)** — Unity Splines operations.
+- **[`manage_terrain`](./core/manage_terrain.md)** — Inspect and modify Unity Terrain at runtime or in Edit mode.
+- **[`manage_tilemap`](./core/manage_tilemap.md)** — Unity 2D Tilemap operations.
+- **[`manage_timeline`](./core/manage_timeline.md)** — Unity Timeline management.
 - **[`manage_tools`](./core/manage_tools.md)** — Manage which tool groups are visible in this session.
+- **[`manage_ui_toolkit`](./core/manage_ui_toolkit.md)** — Unity UI Toolkit (UIElements) operations.
+- **[`manage_video`](./core/manage_video.md)** — Unity VideoPlayer operations.
 - **[`read_console`](./core/read_console.md)** — Gets messages from or clears the Unity Editor console.
 - **[`refresh_unity`](./core/refresh_unity.md)** — Request a Unity asset database refresh and optionally a script compilation.
+- **[`reimport_assets`](./core/reimport_assets.md)** — Reimport specific Unity assets by path.
+- **[`rendering_stats`](./core/rendering_stats.md)** — Read Unity rendering and performance statistics.
 - **[`script_apply_edits`](./core/script_apply_edits.md)** — Structured C# edits (methods/classes) with safer boundaries - prefer this over raw text.
 - **[`set_active_instance`](./core/set_active_instance.md)** — Set the active Unity instance for this client/session.
 - **[`validate_script`](./core/validate_script.md)** — Validate a C# script and return diagnostics.
+- **[`validation_snapshot`](./core/validation_snapshot.md)** — Capture a full runtime validation snapshot in ONE call — entity counts (total/alive/dead/by-team), health distribution (min/max/mean), position samples, NaN bounds check, rendering stats (FPS/draw calls/batches), battle state, console er…
 
 ## `docs` &nbsp; (2 tools)
 Unity API reflection and documentation lookup
@@ -67,9 +94,10 @@ ScriptableObject management
 - **[`execute_code`](./scripting_ext/execute_code.md)** — Execute arbitrary C# code inside the Unity Editor.
 - **[`manage_scriptable_object`](./scripting_ext/manage_scriptable_object.md)** — Creates and modifies ScriptableObject assets using Unity SerializedObject property paths.
 
-## `testing` &nbsp; (2 tools)
+## `testing` &nbsp; (3 tools)
 Test runner & async test jobs
 - **[`get_test_job`](./testing/get_test_job.md)** — Polls an async Unity test job by job_id.
+- **[`manage_input_simulation`](./testing/manage_input_simulation.md)** — Play Mode input simulation.
 - **[`run_tests`](./testing/run_tests.md)** — Starts a Unity test run asynchronously and returns a job_id immediately.
 
 ## `ui` &nbsp; (1 tool)

--- a/website/docs/reference/tools/testing/index.md
+++ b/website/docs/reference/tools/testing/index.md
@@ -9,4 +9,5 @@ description: "MCP for Unity tools in the testing group."
 Test runner & async test jobs
 
 - **[`get_test_job`](./get_test_job.md)** — Polls an async Unity test job by job_id.
+- **[`manage_input_simulation`](./manage_input_simulation.md)** — Play Mode input simulation.
 - **[`run_tests`](./run_tests.md)** — Starts a Unity test run asynchronously and returns a job_id immediately.

--- a/website/docs/reference/tools/testing/manage_input_simulation.md
+++ b/website/docs/reference/tools/testing/manage_input_simulation.md
@@ -1,0 +1,53 @@
+---
+title: manage_input_simulation
+sidebar_label: manage_input_simulation
+description: "Play Mode input simulation."
+---
+
+# `manage_input_simulation`
+
+> **Auto-generated** from the Python tool registry. Do not hand-edit outside `<!-- examples:start --><!-- examples:end -->` blocks — the generator (`tools/generate_docs_reference.py`) will overwrite them.
+
+**Group:** `testing` &nbsp;·&nbsp; **Module:** `services.tools.manage_input_simulation`
+
+## Description
+
+Play Mode input simulation. Actions: discover (list interactive UI elements), get_element_bounds (bounding rect of a UI element), click (left/right/middle mouse click), double_click (double mouse click), mouse_move (move cursor to position), drag (click-hold-drag from one target to another), scroll (mouse wheel scroll), key_press (press/release/tap a key), key_combo (key with modifier keys, e.g. Ctrl+Z), text_input (type a string of text), touch_tap (single touch tap), touch_swipe (touch swipe gesture), touch_pinch (two-finger pinch gesture), sequence (execute multiple input steps in order), status (poll async sequence job by job_id).
+
+## Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `action` | `Literal['discover', 'get_element_bounds', 'click', 'double_click', 'mouse_move', 'drag', 'scroll', 'key_press', 'key_combo', 'text_input', 'touch_tap', 'touch_swipe', 'touch_pinch', 'sequence', 'status']` | yes | Action to perform |
+| `target` | `dict \| None` | — | Target: {mode:'coordinates'\|'gameobject'\|'ui_element'\|'anchor', ...} |
+| `from_target` | `dict \| None` | — | Source target for drag/swipe |
+| `to_target` | `dict \| None` | — | Destination target for drag/swipe |
+| `center_target` | `dict \| None` | — | Center target for pinch |
+| `button` | `str \| None` | — | Mouse button: left, right, middle |
+| `key` | `str \| None` | — | Key name (e.g. space, a, escape) |
+| `modifiers` | `list[str] \| None` | — | Modifier keys (ctrl, shift, alt) |
+| `mode` | `str \| None` | — | Key mode: press, release, tap |
+| `text` | `str \| None` | — | Text to type |
+| `delta_x` | `float \| None` | — | Scroll delta X |
+| `delta_y` | `float \| None` | — | Scroll delta Y |
+| `duration_ms` | `int \| None` | — | Duration in ms for drag/swipe/pinch |
+| `start_distance` | `float \| None` | — | Start distance for pinch (px) |
+| `end_distance` | `float \| None` | — | End distance for pinch (px) |
+| `steps` | `list[dict] \| None` | — | Sequence steps [{action, params, delay_ms}] |
+| `job_id` | `str \| None` | — | Job ID for status polling |
+| `flush` | `bool \| None` | — | Flush input immediately (default true) |
+| `capture_after` | `bool \| None` | — | Take screenshot after action (default false) |
+| `filter` | `str \| None` | — | Filter for discover (substring match) |
+| `page_size` | `int \| None` | — | Max results (default 50) |
+| `cursor` | `int \| None` | — | Pagination cursor |
+
+## Returns
+
+A `dict` containing the Unity response. The exact shape depends on the action.
+
+## Examples
+
+<!-- examples:start -->
+*No examples yet. Add usage examples here — they will be preserved across regenerations.*
+<!-- examples:end -->
+


### PR DESCRIPTION
The `Check docs reference is fresh` gate (`cd Server && uv run python ../tools/generate_docs_reference.py --check`) was failing **identically on clean `origin/beta`** — a base-staleness failure, not a PR fault. This PR regenerates the committed reference so the gate stays green for every future beta PR.

**Drift confirmed on clean `origin/beta` (before this PR):**
- 26 `core/*.md` tool pages existed in `Server/src/services/tools/*.py` since 2026-03-12 but were never committed (`generated-only`: manage_addressables, manage_asset_hunter, manage_audio, manage_behavior, manage_cinemachine, manage_dots, manage_dots_graphics, manage_dots_physics, manage_dots_subscene, manage_input_system, manage_lighting, manage_localization, manage_mesh, manage_navigation, manage_netcode, manage_physics2d, manage_render_pipeline, manage_shader_tool, manage_splines, manage_terrain, manage_tilemap, manage_timeline, manage_ui_toolkit, manage_video, reimport_assets, rendering_stats, validation_snapshot)
- 1 `testing/manage_input_simulation.md`
- 5 committed pages differed: `tools/index.md`, `tools/core/index.md`, `tools/core/manage_camera.md`, `tools/core/refresh_unity.md`, `tools/testing/index.md`

**This is generated output only** — produced verbatim by `tools/generate_docs_reference.py` (33 files: 28 new, 5 regenerated). No hand-edits, no generator changes, no source changes. `uv.lock`/harness setup was excluded.

Verified: `--check` now exits 0 on this branch, and the full Python suite passes (1575 passed, 0 failures).

Unblocks PR #87 plus every future beta PR.