### PR TITLE
docs: enrich Scene/Editor rows in MCP skill tool table

### DIFF
--- a/unity-mcp-skill/SKILL.md
+++ b/unity-mcp-skill/SKILL.md
@@ -178,11 +178,11 @@ uri="file:///full/path/to/file.cs"
 
 | Category | Key Tools | Use For |
 |----------|-----------|---------|
-| **Scene** | `manage_scene`, `find_gameobjects` | Scene operations, finding objects |
+| **Scene** | `manage_scene`, `find_gameobjects` | Scene operations, finding objects. Multi-scene editing (additive load, close, set active, move GO between scenes), scene templates (`3d_basic`, `2d_basic`, `empty`, `default`), scene validation with `auto_repair`. For build settings, use `manage_build(action="scenes")`. |
 | **Objects** | `manage_gameobject`, `manage_components` | Creating/modifying GameObjects |
 | **Scripts** | `create_script`, `script_apply_edits`, `validate_script` | C# code management (auto-refreshes on create/edit) |
 | **Assets** | `manage_asset`, `manage_prefabs` | Asset operations. **Prefab instantiation** is done via `manage_gameobject(action="create", prefab_path="...")`, not `manage_prefabs`. |
-| **Editor** | `manage_editor`, `execute_menu_item`, `read_console` | Editor control, package deployment (`deploy_package`/`restore_package` actions) |
+| **Editor** | `manage_editor`, `execute_menu_item`, `read_console` | Editor control, package deployment (`deploy_package`/`restore_package`), undo/redo (`undo`/`redo` actions) |
 | **Testing** | `run_tests`, `get_test_job` | Unity Test Framework |
 | **Batch** | `batch_execute` | Parallel/bulk operations |
 | **Camera** | `manage_camera` | Camera management (Unity Camera + Cinemachine). **Tier 1** (always available): create, target, lens, priority, list, screenshot. **Tier 2** (requires `com.unity.cinemachine`): brain, body/aim/noise pipeline, extensions, blending, force/release. 7 presets: follow, third_person, freelook, dolly, static, top_down, side_scroller. Resource: `mcpforunity://scene/cameras`. Use `ping` to check Cinemachine availability. See [tools-reference.md](references/tools-reference.md#camera-tools). |


### PR DESCRIPTION
## What

Enriches the `unity-mcp-skill/SKILL.md` tool table's **Scene** and **Editor** rows with capability details that are real, shipped server actions but missing from the documented table.

These two rows were cherry-picked from a preserved local copy at `$HOME/.claude/skills/unity-mcp-skill` (local edits dated 2026-08-24) that had diverged from the kit. That copy is backed up and read-only per the preservation task; only the two genuinely additive rows are proposed here.

- **Scene**: multi-scene editing (additive load, close / set active / move GO between scenes), scene templates (`3d_basic`/`2d_basic`/`empty`/`default`), scene validation with `auto_repair`, and build-settings routing to `manage_build(action="scenes")`.
- **Editor**: `undo`/`redo` actions alongside the existing package-deployment actions.

## Verification

Both capability sets verified against the server source:
- `Server/src/services/tools/manage_scene.py` — `additive` flag, `close_scene`, `set_active_scene`, `move_to_scene`, `validate` + `auto_repair`, scene templates, build-settings note
- `Server/src/services/tools/manage_editor.py` — `undo` / `redo` in the `Literal[...]` action list

## Not upstreamed (deliberately)

The remaining ~93 lines of local divergence are **stale snapshots** (an older `manage_camera`-based screenshot block superseded by current docs) or **path-transformer noise** (`probuilder-guide.md` → `tools-reference.md` link rewrites). They regress content and are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)