### PR TITLE
fix(editor): route EntityIdToObject call sites through UnityObjectIdCompat (Unity 6000.0-6000.2 compile break)

### DIFF
--- a/MCPForUnity/Editor/Tools/InputSimulation/InputTargetResolver.cs
+++ b/MCPForUnity/Editor/Tools/InputSimulation/InputTargetResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 using UnityEngine.UI;
@@ -113,12 +114,11 @@ namespace MCPForUnity.Editor.Tools.InputSimulation
                 go = GameObject.Find(path);
             else if (!string.IsNullOrEmpty(instanceId) && int.TryParse(instanceId, out int id))
             {
-                // Unity 6 deprecated InstanceIDToObject(int) in favor of EntityIdToObject
-                // (CS0618 in 6.0-6.4, promoted to CS0619/error in 6000.5). EntityIdToObject
-                // accepts int via an implicit conversion, so no pragma is needed. Preserved
-                // here for the 'instance_id' JSON contract. See ManageTerrain.cs/ManageMesh.cs
-                // for the same idiom.
-                go = UnityEditor.EditorUtility.EntityIdToObject(id) as GameObject;
+                // EditorUtility.EntityIdToObject only exists on Unity 6000.3+ (CS0117 on
+                // 6000.0-6000.2), and InstanceIDToObject(int) is obsolete-as-error on 6000.5+.
+                // UnityObjectIdCompat.InstanceIDToObjectCompat version-gates all three cases.
+                // Preserved here for the 'instance_id' JSON contract.
+                go = UnityObjectIdCompat.InstanceIDToObjectCompat(id) as GameObject;
             }
             else if (!string.IsNullOrEmpty(name))
                 go = GameObject.Find(name);

--- a/MCPForUnity/Editor/Tools/ManageMesh.cs
+++ b/MCPForUnity/Editor/Tools/ManageMesh.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -229,7 +230,7 @@ namespace MCPForUnity.Editor.Tools
 
             GameObject go = null;
             if (int.TryParse(target, out int id))
-                go = EditorUtility.EntityIdToObject(id) as GameObject;
+                go = UnityObjectIdCompat.InstanceIDToObjectCompat(id) as GameObject;
             if (go == null)
                 go = GameObject.Find(target);
             if (go == null) return (null, $"GameObject not found: '{target}'");

--- a/MCPForUnity/Editor/Tools/ManageTerrain.cs
+++ b/MCPForUnity/Editor/Tools/ManageTerrain.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using MCPForUnity.Editor.Helpers;
+using MCPForUnity.Runtime.Helpers;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 
@@ -408,7 +409,7 @@ namespace MCPForUnity.Editor.Tools
             {
                 GameObject go = null;
                 if (int.TryParse(target, out int id))
-                    go = UnityEditor.EditorUtility.EntityIdToObject(id) as GameObject;
+                    go = UnityObjectIdCompat.InstanceIDToObjectCompat(id) as GameObject;
                 if (go == null)
                     go = GameObject.Find(target);
                 if (go != null)


### PR DESCRIPTION
## Problem

`MCPForUnity.Editor` fails to compile on Unity 6000.0–6000.2, so the bridge never starts and the MCP server reports "No Unity Editor instances found":

```
InputTargetResolver.cs(121,48): error CS0117: 'EditorUtility' does not contain a definition for 'EntityIdToObject'
ManageMesh.cs(232,36): error CS0117: 'EditorUtility' does not contain a definition for 'EntityIdToObject'
ManageTerrain.cs(411,52): error CS0117: 'EditorUtility' does not contain a definition for 'EntityIdToObject'
```

`EditorUtility.EntityIdToObject` only exists from Unity 6000.3. Commit 18f39d6 (#35) assumed it was available on 6.0+ and left these three call sites bare.

Verified against installed editors: `6000.2.10f1/Editor/Data/Managed/UnityEditor.dll` has no `EntityIdToObject` symbol; `6000.3.15f1` does.

## Fix

Route the three call sites through the existing `UnityObjectIdCompat.InstanceIDToObjectCompat` shim, which already version-gates:

- `< 6000.3` → `EditorUtility.InstanceIDToObject(int)`
- `6000.3–6000.5` → `EditorUtility.EntityIdToObject`
- `6000.6+` → reflection path

No behaviour change on 6000.3+.

## Test

Reproduced on TrickyPuzzle (Unity 6000.2.10f1) with the `beta` HEAD pin; after pinning this commit the package compiles and the bridge starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017c9eUVfibTkuwjwM6ff5Py
