### PR TITLE
fix(bridge): gate per-connection client lifecycle logs behind DebugLogs pref

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -537,7 +537,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     try
                     {
                         var ep = client.Client?.RemoteEndPoint?.ToString() ?? "unknown";
-                        McpLog.Info($"Client connected {ep} (active clients: {clientCount})");
+                        McpLog.Info($"Client connected {ep} (active clients: {clientCount})", always: false);
                     }
                     catch { }
                     try
@@ -737,7 +737,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     }
                     int remaining;
                     lock (clientsLock) { remaining = activeClients.Count; }
-                    McpLog.Info($"Client handler exited (remaining clients: {remaining})");
+                    McpLog.Info($"Client handler exited (remaining clients: {remaining})", always: false);
                 }
             }
         }


### PR DESCRIPTION
## Problem

`McpLog.Info(string message, bool always = true)` defaults `always` to `true`, so any call site that omits the second argument logs unconditionally and cannot be suppressed by the `EditorPrefKeys.DebugLogs` EditorPref (MCP window → "Debug Logs", default off).

Two per-connection call sites in `StdioBridgeHost.cs` omit it:

- `McpLog.Info($"Client connected {ep} (active clients: {clientCount})")`
- `McpLog.Info($"Client handler exited (remaining clients: {remaining})")`

Connection churn is normal operation (Claude Code sessions connect and disconnect constantly), so these do not belong at unconditional Info level.

## Measured impact (live editor, 2026-09-07 08:29 → 2026-09-08 19:07, 34h38m)

- 51,770 "Client connected" + 51,402 "Client handler exited" events (~25 connects/min, one per 2.4s, from 23 mcp-for-unity server processes across ~11 Claude Code sessions)
- 26,386 bytes of log per connect event, because ProjectSettings had ScriptOnly stack traces on LogType.Log, so every line ran StackTraceUtility.ExtractStackTrace
- Editor.log reached 1,366,016,130 bytes over 10,406,904 lines (~39 MB/hour)
- Editor Console retains every entry in memory; only 158 domain reloads occurred to flush it. Editor RSS reached 38.9 GB + 7.4 GB swap and was killed by earlyoom.
- Toggling the MCP "Debug Logs" pref off does not help, because `always` defaults to true. That is the bug.

## Fix

Add `always: false` to both call sites so they respect the existing DebugLogs pref:

```diff
- McpLog.Info($"Client connected {ep} (active clients: {clientCount})");
+ McpLog.Info($"Client connected {ep} (active clients: {clientCount})", always: false);
- McpLog.Info($"Client handler exited (remaining clients: {remaining})");
+ McpLog.Info($"Client handler exited (remaining clients: {remaining})", always: false);
```

Scope is deliberately minimal: exactly 2 changed lines. `McpLog.cs` is untouched, no other call sites changed, no reformatting.

## Follow-ups (NOT in this PR)

Scope-check sweep of remaining unconditional `McpLog.Info(` calls surfaced these candidates that may also fire in hot paths. Left unchanged here to keep the fix reviewable; worth gating separately:

- `StdioBridgeHost.cs:583` — `McpLog.Info($"Closing {staleClients.Length} stale client(s) after new connection from {newEp}")` — fires per connection when stale clients exist
- `StdioBridgeHost.cs:909` — `McpLog.Info($"Evicted {staleIds.Count} stale command(s) from queue")` — fires per command-queue eviction
- `TelemetryHelper.cs:210` — `McpLog.Info($"Telemetry: {telemetryData["event_type"]}")` — fires per telemetry event

The startup/lifecycle lines in `StdioBridgeHost.cs` (port switch, bridge started/stopped) and the editor-window UI actions are one-shot or user-triggered and are fine as unconditional Info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZkadZQiLGoymCZez58gTq
