### PR TITLE
fix(stdio): stop logging every client connect/exit at default verbosity

### DIFF
--- a/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
+++ b/MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs
@@ -537,7 +537,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     try
                     {
                         var ep = client.Client?.RemoteEndPoint?.ToString() ?? "unknown";
-                        McpLog.Info($"Client connected {ep} (active clients: {clientCount})");
+                        McpLog.Info($"Client connected {ep} (active clients: {clientCount})", always: false);
                     }
                     catch { }
                     try
@@ -737,7 +737,7 @@ namespace MCPForUnity.Editor.Services.Transport.Transports
                     }
                     int remaining;
                     lock (clientsLock) { remaining = activeClients.Count; }
-                    McpLog.Info($"Client handler exited (remaining clients: {remaining})");
+                    McpLog.Info($"Client handler exited (remaining clients: {remaining})", always: false);
                 }
             }
         }


### PR DESCRIPTION
## Description

Stop logging every MCP client connect/exit at default verbosity. Two per-connection lines currently fire on every client attach and detach:

- `McpLog.Info($"Client connected {ep} (active clients: {clientCount})")`
- `McpLog.Info($"Client handler exited (remaining clients: {remaining})")`

With several Claude Code sessions sharing one Editor these two lines dominate the console. Both calls gain `, always: false`, so they only print when verbose/debug logging is enabled. Errors and eviction warnings are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Changes Made

- `MCPForUnity/Editor/Services/Transport/Transports/StdioBridgeHost.cs`
  - Line ~540: `McpLog.Info($"Client connected {ep} (active clients: {clientCount})", always: false)`
  - Line ~740: `McpLog.Info($"Client handler exited (remaining clients: {remaining})", always: false)`

The `always` parameter is `public static void Info(string message, bool always = true)` at `MCPForUnity/Editor/Helpers/McpLog.cs:37` — when `always: false`, the call is gated behind `IsDebugEnabled()`. Verified by reading that signature only; no Unity run was performed.

## Compatibility / Package Source

- Unity version(s) tested: not run (editor C# log-only change, verified by reading the `McpLog.Info` signature)
- Package source used (`#beta`, `#main`, tag, branch, or `file:`): `#beta`
- Resolved commit hash from `Packages/packages-lock.json`: not applicable

## Testing/Screenshots/Recordings

- [ ] Python tests (`cd Server && uv run pytest tests/ -v`)
- [ ] Unity EditMode tests
- [ ] Unity PlayMode tests
- [ ] Package import/compile check
- [x] Not applicable (explain why in Additional Notes)

## Documentation Updates

- [ ] I have added/removed/modified tools or resources
- [ ] If yes, I have updated all documentation files

## Related Issues

None.

## Additional Notes

No Unity Editor run was performed for this change. Verification was limited to reading the `McpLog.Info` signature (`MCPForUnity/Editor/Helpers/McpLog.cs:37`, `public static void Info(string message, bool always = true)`), which confirms that `always: false` suppresses the message unless debug logging is enabled. The change is a pure logging-verbosity adjustment on the transport path; no runtime behavior is altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01ELtARjLbBr416F2kcy3ixH
